### PR TITLE
Fix installation issue by preparing for npm registry publication

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,39 @@
+# Source files (TypeScript)
+src/
+*.ts
+!*.d.ts
+
+# Development files
+.github/
+.husky/
+.vscode/
+.idea/
+.claude/
+docs/
+scripts/
+tmp/
+output/
+
+# Config files
+.gitignore
+.madgerc
+.tsprunerc
+biome.json
+tsconfig.json
+vitest.config.ts
+CLAUDE.md
+
+# Test files
+__tests__/
+*.test.js
+*.test.ts
+coverage/
+.vitest-cache/
+
+# Misc
+.DS_Store
+*.log
+.env*
+*.swp
+*.swo
+*~

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
 #### For Claude Code
 
 ```bash
-claude mcp add mcp-image --env GEMINI_API_KEY=your-api-key --env IMAGE_OUTPUT_DIR=/absolute/path/to/images -- npx -y https://github.com/shinpr/mcp-image
+claude mcp add mcp-image --env GEMINI_API_KEY=your-api-key --env IMAGE_OUTPUT_DIR=/absolute/path/to/images -- npx -y mcp-image
 ```
 
 #### For Cursor
@@ -44,7 +44,7 @@ Add to your Cursor settings (`~/.cursor/mcp.json`):
     "servers": {
       "mcp-image": {
         "command": "npx",
-        "args": ["-y", "https://github.com/shinpr/mcp-image"],
+        "args": ["-y", "mcp-image"],
         "env": {
           "GEMINI_API_KEY": "your_gemini_api_key_here",
           "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"


### PR DESCRIPTION
## Summary
  This PR addresses the installation issue reported in #2 by preparing
  the package for npm registry publication.

  ## Problem
  Users were unable to install the package via `npx -y
  https://github.com/shinpr/mcp-image` because:
  - The package is not published to npm registry
  - GitHub repository doesn't include built files (dist/ is in
  .gitignore)
  - Users had to manually clone, install, and build the project

  ## Solution
  - Add `.npmignore` to properly configure npm package contents
  - Update README.md with correct installation instructions using npm
  package name
  - Package will be published to npm registry after merge

  ## Changes
  - ✅ Add `.npmignore` to exclude unnecessary files from npm package
  - ✅ Update installation instructions in README to use `npx -y
  mcp-image`
  - ✅ Remove manual build steps from documentation

  ## Testing
  - Verified package contents with `npm pack --dry-run`
  - Confirmed local execution works with `npx mcp-image`
  - Tested that command fails in other directories (expected until npm
  publish)

  Fixes #2