### PR TITLE
fix: exclude vitest.config.mjs from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,6 +21,7 @@ output/
 biome.json
 tsconfig.json
 vitest.config.ts
+vitest.config.mjs
 CLAUDE.md
 
 # Test files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.16.0",
@@ -33,7 +33,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "20"
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-image",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for AI image generation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
- Add vitest.config.mjs to .npmignore
- Bump version to 0.1.1

🤖 Generated with [Claude Code](https://claude.ai/code)