### PR TITLE
fix: increase maxTokens limit for better prompt generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-image",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for AI image generation",
   "main": "dist/index.js",
   "bin": {

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -99,7 +99,7 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
       // Generate structured prompt using Gemini 2.0 Flash via pure API call
       const config = {
         temperature: 0.7,
-        maxTokens: 500,
+        maxTokens: 2000,
         systemInstruction,
         ...(inputImageData && { inputImage: inputImageData }), // Only include if available
       }


### PR DESCRIPTION
- Increase maxTokens from 500 to 2000 for Gemini prompt generation
- Resolves issue with token size being too small for complex prompts
- Enables more detailed prompt enhancement for image generation
- Bump version to 0.2.1

🤖 Generated with [Claude Code](https://claude.ai/code)