### PR TITLE
fix: improve inputImagePath parameter description for better LLM unde…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.17.0",
@@ -3963,7 +3963,7 @@
       }
     },
     "node_modules/is-arrayish": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-image",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for AI image generation",
   "main": "dist/index.js",
   "bin": {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -102,7 +102,7 @@ export class MCPServerImpl {
               inputImagePath: {
                 type: 'string' as const,
                 description:
-                  'Optional absolute path to input image for image editing (must be an absolute path)',
+                  'Optional absolute path to source image for image-to-image generation. Use when generating variations, style transfers, or similar images based on an existing image (must be an absolute path)',
               },
               blendImages: {
                 type: 'boolean' as const,


### PR DESCRIPTION
…rstanding

- Change description from "image editing" to "image-to-image generation"
- Add specific use cases: variations, style transfers, similar images
- Use consistent "Use when..." pattern matching other parameters
- Bump version to 0.2.2

This change helps LLMs correctly identify when to use the inputImagePath parameter when users request generation based on existing images.

🤖 Generated with [Claude Code](https://claude.ai/code)