### PR TITLE
feat: update to gemini-2.5-flash-image model and add aspect ratio   support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^1.17.0",
+        "@google/genai": "^1.22.0",
         "@modelcontextprotocol/sdk": "^1.0.0"
       },
       "bin": {
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.17.0.tgz",
-      "integrity": "sha512-r/OZWN9D8WvYrte3bcKPoLODrZ+2TjfxHm5OOyVHUbdFYIp1C4yJaXX4+sCS8I/+CbN9PxLjU5zm1cgmS7qz+A==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.22.0.tgz",
+      "integrity": "sha512-siETS3zTm3EGpTT4+BFc1z20xXBYfueD3gCYfxkOjuAKRk8lt8TJevDHi3zepn1oSI6NhG/LZvy0i+Q3qheObg==",
       "license": "Apache-2.0",
       "dependencies": {
         "google-auth-library": "^9.14.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:safe": "npm test && npm run cleanup:processes"
   },
   "dependencies": {
-    "@google/genai": "^1.17.0",
+    "@google/genai": "^1.22.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -98,7 +98,7 @@ describe('geminiClient', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.imageData).toBeInstanceOf(Buffer)
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
         expect(result.data.metadata.prompt).toBe('Generate a beautiful landscape')
         expect(result.data.metadata.mimeType).toBe('image/png')
       }
@@ -146,13 +146,13 @@ describe('geminiClient', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.imageData).toBeInstanceOf(Buffer)
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
         expect(result.data.metadata.prompt).toBe('Enhance this image')
         expect(result.data.metadata.mimeType).toBe('image/jpeg')
       }
 
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash-image-preview',
+        model: 'gemini-2.5-flash-image',
         contents: [
           {
             parts: [
@@ -482,14 +482,14 @@ describe('geminiClient', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data.imageData).toBeInstanceOf(Buffer)
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
         // Features are passed to the API but not stored in metadata
         expect(result.data.metadata.prompt).toBe('Generate character with blending')
       }
 
       // Verify API was called with original prompt (no enhancement at GeminiClient level)
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash-image-preview',
+        model: 'gemini-2.5-flash-image',
         contents: [
           {
             parts: [
@@ -542,12 +542,12 @@ describe('geminiClient', () => {
       if (result.success) {
         // Features are passed to the API but not stored in metadata
         expect(result.data.metadata.prompt).toBe('Generate factually accurate historical scene')
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
       }
 
       // Verify API was called with original prompt (no processing at GeminiClient level)
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash-image-preview',
+        model: 'gemini-2.5-flash-image',
         contents: [
           {
             parts: [
@@ -599,12 +599,12 @@ describe('geminiClient', () => {
       if (result.success) {
         // Features not specified - standard metadata only
         expect(result.data.metadata.prompt).toBe('Generate simple landscape')
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
       }
 
       // Verify API was called without generation config
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash-image-preview',
+        model: 'gemini-2.5-flash-image',
         contents: [
           {
             parts: [
@@ -663,12 +663,12 @@ describe('geminiClient', () => {
         expect(result.data.metadata.inputImageProvided).toBe(true)
         // Features are passed to the API but not stored in metadata
         expect(result.data.metadata.prompt).toBe('Blend this character with fantasy elements')
-        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image-preview')
+        expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
       }
 
       // Verify API was called with input image and original prompt (no processing at GeminiClient level)
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash-image-preview',
+        model: 'gemini-2.5-flash-image',
         contents: [
           {
             parts: [

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -702,4 +702,172 @@ describe('geminiClient', () => {
       })
     })
   })
+
+  describe('GeminiClient.generateImage with aspectRatio', () => {
+    it('should call API with imageConfig when aspectRatio is specified', async () => {
+      // Arrange
+      const mockResponse = {
+        response: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: 'base64-image-data-16-9',
+                      mimeType: 'image/png',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+
+      mockGeminiClientInstance.models.generateContent = vi.fn().mockResolvedValue(mockResponse)
+
+      const clientResult = createGeminiClient(testConfig)
+      expect(clientResult.success).toBe(true)
+
+      if (!clientResult.success) return
+      const client = clientResult.data
+
+      // Act
+      const result = await client.generateImage({
+        prompt: 'test prompt for aspect ratio',
+        aspectRatio: '16:9',
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+      expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
+        model: 'gemini-2.5-flash-image',
+        contents: [
+          {
+            parts: [
+              {
+                text: 'test prompt for aspect ratio',
+              },
+            ],
+          },
+        ],
+        config: {
+          imageConfig: { aspectRatio: '16:9' },
+          responseModalities: ['IMAGE'],
+        },
+      })
+    })
+
+    it('should use default when aspectRatio is not specified', async () => {
+      // Arrange
+      const mockResponse = {
+        response: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: 'base64-default-image',
+                      mimeType: 'image/png',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+
+      mockGeminiClientInstance.models.generateContent = vi.fn().mockResolvedValue(mockResponse)
+
+      const clientResult = createGeminiClient(testConfig)
+      expect(clientResult.success).toBe(true)
+
+      if (!clientResult.success) return
+      const client = clientResult.data
+
+      // Act
+      const result = await client.generateImage({
+        prompt: 'test prompt without aspect ratio',
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+      expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
+        model: 'gemini-2.5-flash-image',
+        contents: [
+          {
+            parts: [
+              {
+                text: 'test prompt without aspect ratio',
+              },
+            ],
+          },
+        ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
+      })
+      // Verify imageConfig.aspectRatio is not included
+      const callArgs = (mockGeminiClientInstance.models.generateContent as any).mock.calls[0][0]
+      expect(callArgs.config.imageConfig).toBeUndefined()
+    })
+
+    it('should include responseModalities: ["IMAGE"] in API call with aspectRatio', async () => {
+      // Arrange
+      const mockResponse = {
+        response: {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    inlineData: {
+                      data: 'base64-image-data-21-9',
+                      mimeType: 'image/png',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+
+      mockGeminiClientInstance.models.generateContent = vi.fn().mockResolvedValue(mockResponse)
+
+      const clientResult = createGeminiClient(testConfig)
+      expect(clientResult.success).toBe(true)
+
+      if (!clientResult.success) return
+      const client = clientResult.data
+
+      // Act
+      const result = await client.generateImage({
+        prompt: 'test prompt with 21:9 aspect ratio',
+        aspectRatio: '21:9',
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+      expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
+        model: 'gemini-2.5-flash-image',
+        contents: [
+          {
+            parts: [
+              {
+                text: 'test prompt with 21:9 aspect ratio',
+              },
+            ],
+          },
+        ],
+        config: {
+          imageConfig: { aspectRatio: '21:9' },
+          responseModalities: ['IMAGE'],
+        },
+      })
+    })
+  })
 })

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -168,6 +168,9 @@ describe('geminiClient', () => {
             ],
           },
         ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
       })
     })
 
@@ -499,6 +502,9 @@ describe('geminiClient', () => {
             ],
           },
         ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
       })
     })
 
@@ -557,6 +563,9 @@ describe('geminiClient', () => {
             ],
           },
         ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
       })
     })
 
@@ -602,7 +611,7 @@ describe('geminiClient', () => {
         expect(result.data.metadata.model).toBe('gemini-2.5-flash-image')
       }
 
-      // Verify API was called without generation config
+      // Verify API was called with config
       expect(mockGeminiClientInstance.models.generateContent).toHaveBeenCalledWith({
         model: 'gemini-2.5-flash-image',
         contents: [
@@ -614,6 +623,9 @@ describe('geminiClient', () => {
             ],
           },
         ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
       })
     })
 
@@ -684,6 +696,9 @@ describe('geminiClient', () => {
             ],
           },
         ],
+        config: {
+          responseModalities: ['IMAGE'],
+        },
       })
     })
   })

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -159,7 +159,7 @@ export interface GeminiClient {
  * Implementation of Gemini API client
  */
 class GeminiClientImpl implements GeminiClient {
-  private readonly modelName = 'gemini-2.5-flash-image-preview'
+  private readonly modelName = 'gemini-2.5-flash-image'
 
   constructor(private readonly genai: GeminiClientInstance) {}
 

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -44,6 +44,12 @@ interface GeminiClientInstance {
       generationConfig?: {
         [key: string]: unknown
       }
+      config?: {
+        imageConfig?: {
+          aspectRatio?: string
+        }
+        responseModalities?: string[]
+      }
     }): Promise<unknown> // Response is unknown, we'll validate with type guards
   }
 }
@@ -136,6 +142,7 @@ export interface GeminiGenerationMetadata {
 export interface GeminiApiParams {
   prompt: string
   inputImage?: string
+  aspectRatio?: string
 }
 
 /**
@@ -197,10 +204,21 @@ class GeminiClientImpl implements GeminiClient {
         })
       }
 
+      // Construct config object for generateContent
+      const config = params.aspectRatio
+        ? {
+            imageConfig: { aspectRatio: params.aspectRatio },
+            responseModalities: ['IMAGE'],
+          }
+        : {
+            responseModalities: ['IMAGE'],
+          }
+
       // Generate content using Gemini API (@google/genai v1.17.0+)
       const rawResponse = await this.genai.models.generateContent({
         model: this.modelName,
         contents: requestContent,
+        config,
       })
 
       // Validate response structure with type guard

--- a/src/business/__tests__/inputValidator.test.ts
+++ b/src/business/__tests__/inputValidator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { GenerateImageParams } from '../../types/mcp'
+import type { AspectRatio, GenerateImageParams } from '../../types/mcp'
 import { validateBase64Image, validateGenerateImageParams, validatePrompt } from '../inputValidator'
 
 describe('inputValidator', () => {
@@ -204,6 +204,81 @@ describe('inputValidator', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data).toEqual(validParams)
+      }
+    })
+  })
+
+  describe('validateGenerateImageParams with aspectRatio', () => {
+    it('should accept all 10 supported aspect ratios', () => {
+      // Arrange
+      const supportedRatios: AspectRatio[] = [
+        '1:1',
+        '2:3',
+        '3:2',
+        '3:4',
+        '4:3',
+        '4:5',
+        '5:4',
+        '9:16',
+        '16:9',
+        '21:9',
+      ]
+
+      // Act & Assert
+      for (const ratio of supportedRatios) {
+        const result = validateGenerateImageParams({
+          prompt: 'test',
+          aspectRatio: ratio,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+
+    it('should reject invalid aspect ratio "4:1"', () => {
+      // Arrange
+      const invalidParams: GenerateImageParams = {
+        prompt: 'test',
+        aspectRatio: '4:1' as AspectRatio, // Type assertion for test
+      }
+
+      // Act
+      const result = validateGenerateImageParams(invalidParams)
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.message).toContain('Invalid aspect ratio')
+      }
+    })
+
+    it('should accept undefined aspectRatio (default)', () => {
+      // Arrange
+      const validParams: GenerateImageParams = {
+        prompt: 'test',
+      }
+
+      // Act
+      const result = validateGenerateImageParams(validParams)
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it('should include supported values list in validation error message', () => {
+      // Arrange
+      const invalidParams: GenerateImageParams = {
+        prompt: 'test',
+        aspectRatio: 'invalid' as AspectRatio,
+      }
+
+      // Act
+      const result = validateGenerateImageParams(invalidParams)
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.message).toContain('1:1')
+        expect(result.error.message).toContain('21:9')
       }
     })
   })

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -220,8 +220,8 @@ export function validateGenerateImageParams(
   if (params.aspectRatio && !SUPPORTED_ASPECT_RATIOS.includes(params.aspectRatio)) {
     return Err(
       new InputValidationError(
-        `Invalid aspect ratio: ${params.aspectRatio}`,
-        `Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`
+        `Invalid aspect ratio: ${params.aspectRatio}. Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`,
+        `Please use one of the supported aspect ratios: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`
       )
     )
   }

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -5,7 +5,7 @@
 
 import { existsSync } from 'node:fs'
 import { extname } from 'node:path'
-import type { GenerateImageParams } from '../types/mcp'
+import type { AspectRatio, GenerateImageParams } from '../types/mcp'
 import type { Result } from '../types/result'
 import { Err, Ok } from '../types/result'
 import { InputValidationError } from '../utils/errors'
@@ -15,6 +15,18 @@ const PROMPT_MIN_LENGTH = 1
 const PROMPT_MAX_LENGTH = 4000
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
 const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/bmp']
+const SUPPORTED_ASPECT_RATIOS: readonly AspectRatio[] = [
+  '1:1',
+  '2:3',
+  '3:2',
+  '3:4',
+  '4:3',
+  '4:5',
+  '5:4',
+  '9:16',
+  '16:9',
+  '21:9',
+] as const
 
 /**
  * Converts bytes to MB with proper formatting
@@ -202,6 +214,16 @@ export function validateGenerateImageParams(
     if (!imageResult.success) {
       return Err(imageResult.error)
     }
+  }
+
+  // Validate aspectRatio parameter
+  if (params.aspectRatio && !SUPPORTED_ASPECT_RATIOS.includes(params.aspectRatio)) {
+    return Err(
+      new InputValidationError(
+        `Invalid aspect ratio: ${params.aspectRatio}`,
+        `Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`
+      )
+    )
   }
 
   return Ok(params)

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -315,3 +315,49 @@ describe('MCP Server', () => {
     expect(responseData.error.suggestion).toContain('descriptive prompt')
   })
 })
+
+// Test suite for aspectRatio parameter in generate_image tool schema
+describe('MCPServer tool schema - aspectRatio', () => {
+  it('should include aspectRatio in generate_image schema', () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    const toolsList = mcpServer.getToolsList()
+    const generateImageTool = toolsList.tools.find((t) => t.name === 'generate_image')
+
+    // Assert
+    expect(generateImageTool).toBeDefined()
+    expect(generateImageTool?.inputSchema.properties).toHaveProperty('aspectRatio')
+    expect(generateImageTool?.inputSchema.properties?.aspectRatio.type).toBe('string')
+  })
+
+  it('should define enum with 10 supported aspect ratios in schema', () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    const toolsList = mcpServer.getToolsList()
+    const generateImageTool = toolsList.tools.find((t) => t.name === 'generate_image')
+    const aspectRatioEnum = generateImageTool?.inputSchema.properties?.aspectRatio.enum
+
+    // Assert
+    expect(aspectRatioEnum).toHaveLength(10)
+    expect(aspectRatioEnum).toContain('1:1')
+    expect(aspectRatioEnum).toContain('16:9')
+    expect(aspectRatioEnum).toContain('21:9')
+  })
+
+  it('should mark aspectRatio as optional in schema', () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    const toolsList = mcpServer.getToolsList()
+    const generateImageTool = toolsList.tools.find((t) => t.name === 'generate_image')
+
+    // Assert
+    expect(generateImageTool?.inputSchema.required).toContain('prompt')
+    expect(generateImageTool?.inputSchema.required).not.toContain('aspectRatio')
+  })
+})

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -119,6 +119,11 @@ export class MCPServerImpl {
                 description:
                   'Use real-world knowledge for accurate context. Enable for historical figures, landmarks, or factual scenarios',
               },
+              aspectRatio: {
+                type: 'string' as const,
+                description: 'Aspect ratio for the generated image (default: "1:1")',
+                enum: ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'],
+              },
             },
             required: ['prompt'],
           },

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -42,6 +42,8 @@ export interface GenerateImageParams {
   maintainCharacterConsistency?: boolean
   /** Use world knowledge integration for more accurate context (default: false) */
   useWorldKnowledge?: boolean
+  /** Aspect ratio for generated image (default: "1:1") */
+  aspectRatio?: AspectRatio
 }
 
 /**

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -8,6 +8,21 @@
  */
 
 /**
+ * Supported aspect ratios for Gemini 2.5 Flash Image
+ */
+export type AspectRatio =
+  | '1:1' // Square (default)
+  | '2:3' // Portrait
+  | '3:2' // Landscape
+  | '3:4' // Portrait
+  | '4:3' // Landscape
+  | '4:5' // Portrait
+  | '5:4' // Landscape
+  | '9:16' // Vertical (social media)
+  | '16:9' // Horizontal (cinematic)
+  | '21:9' // Ultra-wide
+
+/**
  * Parameters for image generation using Gemini API
  */
 export interface GenerateImageParams {


### PR DESCRIPTION
## Summary
  - Updates model from `gemini-2.5-flash-image-preview` to stable
  `gemini-2.5-flash-image`
  - Adds aspect ratio support for image generation with 10 predefined
  options
  - Upgrades `@google/genai` dependency from 1.17.0 to 1.22.0

  ## Changes

  ### Model Update
  - **Model name**: Changed from `gemini-2.5-flash-image-preview` to
  `gemini-2.5-flash-image` (stable release)
  - **API client**: Updated `@google/genai` to v1.22.0
  - **Config enhancement**: Added `responseModalities: ['IMAGE']` to
  all API calls

  ### Aspect Ratio Feature
  - **New parameter**: Added `aspectRatio` to `generate_image` tool
  - **Supported ratios**: 10 options (1:1, 2:3, 3:2, 3:4, 4:3, 4:5,
  5:4, 9:16, 16:9, 21:9)
  - **Type safety**: Created `AspectRatio` union type
  - **Validation**: Implemented comprehensive input validation with
  error messages
  - **API integration**: Passes aspect ratio via
  `config.imageConfig.aspectRatio`