### PR TITLE
fix: Update Node.js version requirement in README from 20 to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npx mcp-image skills install --path ~/.claude/skills
 
 ## Prerequisites
 
-- **Node.js** 20 or higher
+- **Node.js** 22 or higher
 - **Gemini API Key** - Get yours at [Google AI Studio](https://aistudio.google.com/apikey)
 - An MCP-compatible AI tool: **Cursor**, **Claude Code**, **Codex**, or others
 - Basic terminal/command line knowledge


### PR DESCRIPTION
## Summary
- Update the Node.js version prerequisite in README from 20 to 22, aligning it with the `engines` field in `package.json` which was updated in #76.

## Test plan
- [x] Verify README now states Node.js 22 or higher
- [x] Confirm consistency with `package.json` engines field (`>=22`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)