### PR TITLE
fix: Correct file extension and MIME type handling based on Gemini API response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP server for AI image generation",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.9.0",
+  "version": "0.10.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -11,10 +11,7 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
-import { Logger } from '../utils/logger.js'
-import { SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.js'
-
-const logger = new Logger()
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
 
 /**
  * Simplified Gemini API response types
@@ -152,6 +149,7 @@ export interface GeminiGenerationMetadata {
 export interface GeminiApiParams {
   prompt: string
   inputImage?: string
+  inputImageMimeType?: string
   aspectRatio?: string
   imageSize?: string
   useGoogleSearch?: boolean
@@ -199,7 +197,7 @@ class GeminiClientImpl implements GeminiClient {
             {
               inlineData: {
                 data: params.inputImage,
-                mimeType: 'image/jpeg', // TODO: Dynamic MIME type support
+                mimeType: params.inputImageMimeType ?? DEFAULT_MIME_TYPE,
               },
             },
             {
@@ -410,14 +408,7 @@ class GeminiClientImpl implements GeminiClient {
 
       // Convert base64 image data to Buffer
       const imageBuffer = Buffer.from(imagePart.inlineData.data, 'base64')
-      const rawMimeType = imagePart.inlineData.mimeType || 'image/png'
-      const mimeType = SUPPORTED_MIME_TYPES.includes(rawMimeType) ? rawMimeType : 'image/png'
-      if (rawMimeType !== mimeType) {
-        logger.warn(
-          'gemini-client',
-          `Unknown MIME type from API: ${rawMimeType}, falling back to image/png`
-        )
-      }
+      const mimeType = normalizeMimeType(imagePart.inlineData.mimeType || DEFAULT_MIME_TYPE)
 
       // Create metadata
       const metadata: GeminiGenerationMetadata = {

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -11,6 +11,10 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
+import { Logger } from '../utils/logger.js'
+import { SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.js'
+
+const logger = new Logger()
 
 /**
  * Simplified Gemini API response types
@@ -406,7 +410,14 @@ class GeminiClientImpl implements GeminiClient {
 
       // Convert base64 image data to Buffer
       const imageBuffer = Buffer.from(imagePart.inlineData.data, 'base64')
-      const mimeType = imagePart.inlineData.mimeType || 'image/png'
+      const rawMimeType = imagePart.inlineData.mimeType || 'image/png'
+      const mimeType = SUPPORTED_MIME_TYPES.includes(rawMimeType) ? rawMimeType : 'image/png'
+      if (rawMimeType !== mimeType) {
+        logger.warn(
+          'gemini-client',
+          `Unknown MIME type from API: ${rawMimeType}, falling back to image/png`
+        )
+      }
 
       // Create metadata
       const metadata: GeminiGenerationMetadata = {

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -9,6 +9,7 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE } from '../utils/mimeUtils.js'
 
 /**
  * Options for text generation
@@ -19,6 +20,7 @@ export interface GenerationConfig {
   timeout?: number
   systemInstruction?: string
   inputImage?: string // Optional base64-encoded image for multimodal context
+  inputImageMimeType?: string // MIME type of the input image
   topP?: number
   topK?: number
 }
@@ -155,7 +157,7 @@ class GeminiTextClientImpl implements GeminiTextClient {
               {
                 inlineData: {
                   data: config.inputImage,
-                  mimeType: 'image/jpeg', // Assuming JPEG for simplicity; can be enhanced later
+                  mimeType: config.inputImageMimeType ?? DEFAULT_MIME_TYPE,
                 },
               },
               {

--- a/src/business/__tests__/fileManager.test.ts
+++ b/src/business/__tests__/fileManager.test.ts
@@ -102,12 +102,6 @@ describe('FileManager', () => {
   })
 
   describe('generateFileName', () => {
-    it('should generate timestamp-based filename with correct format', () => {
-      const fileName = fileManager.generateFileName()
-
-      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.png$/)
-    })
-
     it('should return .png extension when called without mimeType argument', () => {
       const fileName = fileManager.generateFileName()
 

--- a/src/business/__tests__/fileManager.test.ts
+++ b/src/business/__tests__/fileManager.test.ts
@@ -107,5 +107,47 @@ describe('FileManager', () => {
 
       expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.png$/)
     })
+
+    it('should return .png extension when called without mimeType argument', () => {
+      const fileName = fileManager.generateFileName()
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.png$/)
+    })
+
+    it('should return .jpg extension when mimeType is image/jpeg', () => {
+      const fileName = fileManager.generateFileName('image/jpeg')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.jpg$/)
+    })
+
+    it('should return .webp extension when mimeType is image/webp', () => {
+      const fileName = fileManager.generateFileName('image/webp')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.webp$/)
+    })
+
+    it('should return .png extension when mimeType is image/png', () => {
+      const fileName = fileManager.generateFileName('image/png')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.png$/)
+    })
+
+    it('should return .gif extension when mimeType is image/gif', () => {
+      const fileName = fileManager.generateFileName('image/gif')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.gif$/)
+    })
+
+    it('should return .bmp extension when mimeType is image/bmp', () => {
+      const fileName = fileManager.generateFileName('image/bmp')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.bmp$/)
+    })
+
+    it('should return .png extension as fallback for unknown mimeType', () => {
+      const fileName = fileManager.generateFileName('image/unknown')
+
+      expect(fileName).toMatch(/^image-\d{13}-[0-9a-f]{8}\.png$/)
+    })
   })
 })

--- a/src/business/__tests__/responseBuilder.test.ts
+++ b/src/business/__tests__/responseBuilder.test.ts
@@ -139,7 +139,7 @@ describe('ResponseBuilder', () => {
       expect(contentData.resource.mimeType).toBe('image/jpeg')
     })
 
-    it('should use unknown metadata MIME type as-is (trust API response)', () => {
+    it('should fall back to default MIME type for unsupported metadata MIME type', () => {
       const generationResult: GeneratedImageResult = {
         imageData: Buffer.from('fake-image-data'),
         metadata: {
@@ -153,7 +153,7 @@ describe('ResponseBuilder', () => {
 
       const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.tiff')
       const contentData = JSON.parse(response.content[0].text)
-      expect(contentData.resource.mimeType).toBe('image/tiff')
+      expect(contentData.resource.mimeType).toBe('image/png')
     })
   })
 

--- a/src/business/__tests__/responseBuilder.test.ts
+++ b/src/business/__tests__/responseBuilder.test.ts
@@ -54,10 +54,43 @@ describe('ResponseBuilder', () => {
       })
     })
 
-    it('should handle different file extensions for MIME type detection', () => {
-      const testImageData = Buffer.from('fake-image-data')
+    it('should use metadata MIME type image/jpeg when available', () => {
       const generationResult: GeneratedImageResult = {
-        imageData: testImageData,
+        imageData: Buffer.from('fake-image-data'),
+        metadata: {
+          model: 'gemini-3.1-flash-image-preview',
+          prompt: 'test prompt',
+          mimeType: 'image/jpeg',
+          timestamp: new Date('2025-08-28T12:00:00Z'),
+          inputImageProvided: false,
+        },
+      }
+
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.jpg')
+      const contentData = JSON.parse(response.content[0].text)
+      expect(contentData.resource.mimeType).toBe('image/jpeg')
+    })
+
+    it('should use metadata MIME type image/webp when available', () => {
+      const generationResult: GeneratedImageResult = {
+        imageData: Buffer.from('fake-image-data'),
+        metadata: {
+          model: 'gemini-3.1-flash-image-preview',
+          prompt: 'test prompt',
+          mimeType: 'image/webp',
+          timestamp: new Date('2025-08-28T12:00:00Z'),
+          inputImageProvided: false,
+        },
+      }
+
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.webp')
+      const contentData = JSON.parse(response.content[0].text)
+      expect(contentData.resource.mimeType).toBe('image/webp')
+    })
+
+    it('should use metadata MIME type image/png when available', () => {
+      const generationResult: GeneratedImageResult = {
+        imageData: Buffer.from('fake-image-data'),
         metadata: {
           model: 'gemini-3.1-flash-image-preview',
           prompt: 'test prompt',
@@ -67,23 +100,60 @@ describe('ResponseBuilder', () => {
         },
       }
 
-      // Test JPEG file
-      let response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.jpg')
-      let contentData = JSON.parse(response.content[0].text)
-      expect(contentData.resource.mimeType).toBe('image/jpeg')
-      expect(contentData.resource.uri).toBe('file:///path/to/image.jpg')
-
-      // Test WEBP file
-      response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.webp')
-      contentData = JSON.parse(response.content[0].text)
-      expect(contentData.resource.mimeType).toBe('image/webp')
-      expect(contentData.resource.uri).toBe('file:///path/to/image.webp')
-
-      // Test unknown extension (defaults to PNG)
-      response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.unknown')
-      contentData = JSON.parse(response.content[0].text)
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.png')
+      const contentData = JSON.parse(response.content[0].text)
       expect(contentData.resource.mimeType).toBe('image/png')
-      expect(contentData.resource.uri).toBe('file:///path/to/image.unknown')
+    })
+
+    it('should fall back to extension-based detection when metadata MIME is undefined', () => {
+      const generationResult: GeneratedImageResult = {
+        imageData: Buffer.from('fake-image-data'),
+        metadata: {
+          model: 'gemini-3.1-flash-image-preview',
+          prompt: 'test prompt',
+          mimeType: undefined as unknown as string,
+          timestamp: new Date('2025-08-28T12:00:00Z'),
+          inputImageProvided: false,
+        },
+      }
+
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.webp')
+      const contentData = JSON.parse(response.content[0].text)
+      expect(contentData.resource.mimeType).toBe('image/webp')
+    })
+
+    it('should fall back to extension-based detection when metadata MIME is empty string', () => {
+      const generationResult: GeneratedImageResult = {
+        imageData: Buffer.from('fake-image-data'),
+        metadata: {
+          model: 'gemini-3.1-flash-image-preview',
+          prompt: 'test prompt',
+          mimeType: '',
+          timestamp: new Date('2025-08-28T12:00:00Z'),
+          inputImageProvided: false,
+        },
+      }
+
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.jpg')
+      const contentData = JSON.parse(response.content[0].text)
+      expect(contentData.resource.mimeType).toBe('image/jpeg')
+    })
+
+    it('should use unknown metadata MIME type as-is (trust API response)', () => {
+      const generationResult: GeneratedImageResult = {
+        imageData: Buffer.from('fake-image-data'),
+        metadata: {
+          model: 'gemini-3.1-flash-image-preview',
+          prompt: 'test prompt',
+          mimeType: 'image/tiff',
+          timestamp: new Date('2025-08-28T12:00:00Z'),
+          inputImageProvided: false,
+        },
+      }
+
+      const response = responseBuilder.buildSuccessResponse(generationResult, '/path/to/image.tiff')
+      const contentData = JSON.parse(response.content[0].text)
+      expect(contentData.resource.mimeType).toBe('image/tiff')
     })
   })
 

--- a/src/business/fileManager.ts
+++ b/src/business/fileManager.ts
@@ -9,12 +9,11 @@ import * as path from 'node:path'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { FileOperationError } from '../utils/errors.js'
-import { getExtensionFromMimeType } from '../utils/mimeUtils.js'
+import { DEFAULT_MIME_TYPE, getExtensionFromMimeType } from '../utils/mimeUtils.js'
 
 // Constants for file naming and error messages
 const FILE_NAME_PREFIX = 'image' as const
 const RANDOM_BYTES_LENGTH = 4 as const
-const DEFAULT_MIME_TYPE = 'image/png' as const
 
 const ERROR_MESSAGES = {
   SAVE_FAILED: 'Failed to save image file',

--- a/src/business/fileManager.ts
+++ b/src/business/fileManager.ts
@@ -9,11 +9,12 @@ import * as path from 'node:path'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { FileOperationError } from '../utils/errors.js'
+import { getExtensionFromMimeType } from '../utils/mimeUtils.js'
 
 // Constants for file naming and error messages
 const FILE_NAME_PREFIX = 'image' as const
-const DEFAULT_EXTENSION = '.png' as const
 const RANDOM_BYTES_LENGTH = 4 as const
+const DEFAULT_MIME_TYPE = 'image/png' as const
 
 const ERROR_MESSAGES = {
   SAVE_FAILED: 'Failed to save image file',
@@ -32,7 +33,7 @@ export interface FileManager {
     format?: string
   ): Promise<Result<string, FileOperationError>>
   ensureDirectoryExists(dirPath: string): Result<void, FileOperationError>
-  generateFileName(): string
+  generateFileName(mimeType?: string): string
 }
 
 /**
@@ -56,12 +57,14 @@ function ensureDirectoryExists(dirPath: string): Result<void, FileOperationError
 
 /**
  * Generates a unique filename based on timestamp and random component
- * @returns Generated filename in the format: gemini-image-{timestamp}.png
+ * @param mimeType Optional MIME type to determine file extension (defaults to image/png)
+ * @returns Generated filename in the format: image-{timestamp}-{hex}.{ext}
  */
-function generateFileName(): string {
+function generateFileName(mimeType?: string): string {
   const timestamp = Date.now()
   const random = randomBytes(RANDOM_BYTES_LENGTH).toString('hex')
-  return `${FILE_NAME_PREFIX}-${timestamp}-${random}${DEFAULT_EXTENSION}`
+  const extension = getExtensionFromMimeType(mimeType ?? DEFAULT_MIME_TYPE)
+  return `${FILE_NAME_PREFIX}-${timestamp}-${random}${extension}`
 }
 
 /**

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -10,12 +10,12 @@ import { IMAGE_QUALITY_VALUES } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { InputValidationError } from '../utils/errors.js'
+import { SUPPORTED_EXTENSIONS, SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.js'
 
 // Constants for validation limits
 const PROMPT_MIN_LENGTH = 1
 const PROMPT_MAX_LENGTH = 4000
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
-const SUPPORTED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/bmp']
 const SUPPORTED_ASPECT_RATIOS: readonly AspectRatio[] = [
   '1:1',
   '1:4',
@@ -151,12 +151,11 @@ export function validateImagePath(
 
   // Check file extension
   const ext = extname(imagePath).toLowerCase()
-  const supportedExtensions = ['.jpg', '.jpeg', '.png', '.webp', '.gif', '.bmp']
-  if (!supportedExtensions.includes(ext)) {
+  if (!SUPPORTED_EXTENSIONS.includes(ext)) {
     return Err(
       new InputValidationError(
-        `Unsupported image format: ${ext}. Supported formats: ${supportedExtensions.join(', ')}`,
-        `Please provide an image with one of these extensions: ${supportedExtensions.join(', ')}`
+        `Unsupported image format: ${ext}. Supported formats: ${SUPPORTED_EXTENSIONS.join(', ')}`,
+        `Please provide an image with one of these extensions: ${SUPPORTED_EXTENSIONS.join(', ')}`
       )
     )
   }

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -15,7 +15,7 @@ import {
   NetworkError,
   SecurityError,
 } from '../utils/errors.js'
-import { getMimeTypeFromExtension } from '../utils/mimeUtils.js'
+import { getMimeTypeFromExtension, SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.js'
 
 const UNKNOWN_ERROR_CODE = 'UNKNOWN_ERROR'
 const DEFAULT_ERROR_SUGGESTION = 'Please try again or contact support if the problem persists'
@@ -38,7 +38,7 @@ export interface ResponseBuilder {
  * @returns MIME type string
  */
 function resolveMimeType(metadataMimeType: string | undefined, filePath: string): string {
-  if (metadataMimeType) {
+  if (metadataMimeType && SUPPORTED_MIME_TYPES.includes(metadataMimeType)) {
     return metadataMimeType
   }
   const ext = path.extname(filePath).toLowerCase()

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -29,11 +29,18 @@ export interface ResponseBuilder {
 }
 
 /**
- * Determines MIME type based on file extension
- * @param filePath Path to the image file
+ * Determines MIME type from generation metadata with extension-based fallback.
+ * Uses the API-reported MIME type as the primary source of truth.
+ * Falls back to file extension detection when metadata MIME is unavailable.
+ *
+ * @param metadataMimeType MIME type from API generation metadata
+ * @param filePath Path to the image file (used for fallback)
  * @returns MIME type string
  */
-function getMimeTypeFromPath(filePath: string): string {
+function resolveMimeType(metadataMimeType: string | undefined, filePath: string): string {
+  if (metadataMimeType) {
+    return metadataMimeType
+  }
   const ext = path.extname(filePath).toLowerCase()
   return getMimeTypeFromExtension(ext)
 }
@@ -96,7 +103,7 @@ export function createResponseBuilder(): ResponseBuilder {
     ): McpToolResponse {
       // File-based implementation: Always return file path, never base64
       // This avoids MCP token limit issues (25,000 tokens max)
-      const mimeType = getMimeTypeFromPath(filePath)
+      const mimeType = resolveMimeType(generationResult.metadata.mimeType, filePath)
       const fileName = path.basename(filePath)
 
       const structuredContent: StructuredContent = {

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -15,21 +15,8 @@ import {
   NetworkError,
   SecurityError,
 } from '../utils/errors.js'
+import { getMimeTypeFromExtension } from '../utils/mimeUtils.js'
 
-// Constants for MIME types and error handling
-const MIME_TYPES = {
-  PNG: 'image/png',
-  JPEG: 'image/jpeg',
-  WEBP: 'image/webp',
-} as const
-
-const FILE_EXTENSIONS = {
-  PNG: ['.png'],
-  JPEG: ['.jpg', '.jpeg'],
-  WEBP: ['.webp'],
-} as const
-
-const DEFAULT_MIME_TYPE = MIME_TYPES.PNG
 const UNKNOWN_ERROR_CODE = 'UNKNOWN_ERROR'
 const DEFAULT_ERROR_SUGGESTION = 'Please try again or contact support if the problem persists'
 
@@ -48,18 +35,7 @@ export interface ResponseBuilder {
  */
 function getMimeTypeFromPath(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase()
-
-  if (FILE_EXTENSIONS.PNG.includes(ext as '.png')) {
-    return MIME_TYPES.PNG
-  }
-  if (FILE_EXTENSIONS.JPEG.includes(ext as '.jpg' | '.jpeg')) {
-    return MIME_TYPES.JPEG
-  }
-  if (FILE_EXTENSIONS.WEBP.includes(ext as '.webp')) {
-    return MIME_TYPES.WEBP
-  }
-
-  return DEFAULT_MIME_TYPE
+  return getMimeTypeFromExtension(ext)
 }
 
 /**

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -79,7 +79,8 @@ export interface StructuredPromptGenerator {
     userPrompt: string,
     features?: FeatureFlags,
     inputImageData?: string, // Optional base64-encoded image for context
-    purpose?: string // Optional intended use for the image
+    purpose?: string, // Optional intended use for the image
+    inputImageMimeType?: string // MIME type of the input image
   ): Promise<Result<StructuredPromptResult, Error>>
 }
 
@@ -93,7 +94,8 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
     userPrompt: string,
     features: FeatureFlags = {},
     inputImageData?: string,
-    purpose?: string
+    purpose?: string,
+    inputImageMimeType?: string
   ): Promise<Result<StructuredPromptResult, Error>> {
     try {
       // Validate input
@@ -119,7 +121,8 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
         temperature: 0.7,
         maxTokens: 1000,
         systemInstruction,
-        ...(inputImageData && { inputImage: inputImageData }), // Only include if available
+        ...(inputImageData && { inputImage: inputImageData }),
+        ...(inputImageMimeType && { inputImageMimeType }),
       }
       const result = await this.geminiTextClient.generateText(completePrompt, config)
 

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -39,7 +39,11 @@ vi.mock('../../business/fileManager', () => {
           success: true,
           data: undefined,
         }),
-        generateFileName: vi.fn().mockReturnValue('test-image.png'),
+        generateFileName: vi.fn().mockImplementation((mimeType?: string) => {
+          if (mimeType === 'image/jpeg') return 'test-image.jpg'
+          if (mimeType === 'image/webp') return 'test-image.webp'
+          return 'test-image.png'
+        }),
       }
     }),
   }
@@ -158,6 +162,7 @@ describe('MCP Server', () => {
   let originalApiKey: string | undefined
 
   beforeEach(() => {
+    vi.clearAllMocks()
     // Set up environment for testing
     originalApiKey = process.env.GEMINI_API_KEY
     process.env.GEMINI_API_KEY = 'test-api-key-unit-tests'
@@ -289,6 +294,81 @@ describe('MCP Server', () => {
     expect(responseData.error.code).toBe('INTERNAL_ERROR')
     expect(responseData.error.message).toContain('Unknown tool: invalid_tool')
     expect(responseData.error.suggestion).toBe('Contact system administrator')
+  })
+
+  it('should pass mimeType to generateFileName for auto-generated filenames', async () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+    })
+
+    // Assert: generateFileName should be called with the mimeType from API metadata
+    const { createFileManager } = await import('../../business/fileManager')
+    const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
+      .value
+    expect(fileManagerInstance.generateFileName).toHaveBeenCalledWith('image/png')
+  })
+
+  it('should append extension to user-provided filename without extension via ensureExtension', async () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      fileName: 'my-photo',
+    })
+
+    // Assert: saveImage should be called with a path ending in .png (ensureExtension adds it)
+    const { createFileManager } = await import('../../business/fileManager')
+    const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
+      .value
+    const saveImageCall = fileManagerInstance.saveImage.mock.calls[0]
+    const savedPath = saveImageCall[1] as string
+    expect(savedPath).toMatch(/my-photo\.png$/)
+  })
+
+  it('should preserve user-provided filename with existing extension', async () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      fileName: 'my-photo.jpg',
+    })
+
+    // Assert: saveImage should be called with path preserving the .jpg extension
+    const { createFileManager } = await import('../../business/fileManager')
+    const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
+      .value
+    const saveImageCall = fileManagerInstance.saveImage.mock.calls[0]
+    const savedPath = saveImageCall[1] as string
+    expect(savedPath).toMatch(/my-photo\.jpg$/)
+  })
+
+  it('should sanitize filename before applying ensureExtension', async () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act: filename with control chars and no extension
+    await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      fileName: '...my-photo\x00',
+    })
+
+    // Assert: sanitizeFilename runs first (strips leading dots, null bytes),
+    // then ensureExtension adds .png
+    const { createFileManager } = await import('../../business/fileManager')
+    const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
+      .value
+    const saveImageCall = fileManagerInstance.saveImage.mock.calls[0]
+    const savedPath = saveImageCall[1] as string
+    // After sanitize: 'my-photo', after ensureExtension: 'my-photo.png'
+    expect(savedPath).toMatch(/my-photo\.png$/)
   })
 
   it('should validate prompt parameter', async () => {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -30,7 +30,7 @@ import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
 // Utilities
 import { getConfig } from '../utils/config.js'
 import { Logger } from '../utils/logger.js'
-import { ensureExtension } from '../utils/mimeUtils.js'
+import { ensureExtension, getMimeTypeFromExtension } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
 import { ErrorHandler } from './errorHandler.js'
 
@@ -241,6 +241,7 @@ export class MCPServerImpl {
 
       // Handle input image if provided
       let inputImageData: string | undefined
+      let inputImageMimeType: string | undefined
       if (params.inputImagePath) {
         const sanitizedInputPath = this.securityManager.sanitizeInputFilePath(params.inputImagePath)
         if (!sanitizedInputPath.success) {
@@ -252,6 +253,7 @@ export class MCPServerImpl {
         }
         const imageBuffer = await fs.readFile(sanitizedInputPath.data)
         inputImageData = imageBuffer.toString('base64')
+        inputImageMimeType = getMimeTypeFromExtension(path.extname(sanitizedInputPath.data))
       }
 
       // Generate structured prompt (unless skipped)
@@ -274,8 +276,9 @@ export class MCPServerImpl {
         const promptResult = await this.structuredPromptGenerator.generateStructuredPrompt(
           params.prompt,
           features,
-          inputImageData, // Pass image data for context-aware prompt generation
-          params.purpose // Pass intended use for purpose-aware prompt generation
+          inputImageData,
+          params.purpose,
+          inputImageMimeType
         )
 
         if (promptResult.success) {
@@ -303,6 +306,7 @@ export class MCPServerImpl {
       const generationResult = await this.geminiClient.generateImage({
         prompt: structuredPrompt,
         ...(inputImageData && { inputImage: inputImageData }),
+        ...(inputImageMimeType && { inputImageMimeType }),
         ...(params.aspectRatio && { aspectRatio: params.aspectRatio }),
         ...(params.imageSize && { imageSize: params.imageSize }),
         ...(params.useGoogleSearch !== undefined && { useGoogleSearch: params.useGoogleSearch }),

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -30,6 +30,7 @@ import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
 // Utilities
 import { getConfig } from '../utils/config.js'
 import { Logger } from '../utils/logger.js'
+import { ensureExtension } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
 import { ErrorHandler } from './errorHandler.js'
 
@@ -313,10 +314,11 @@ export class MCPServerImpl {
       }
 
       // Save image file
-      const rawFileName = params.fileName || this.fileManager.generateFileName()
-      const fileName = params.fileName
-        ? this.securityManager.sanitizeFilename(rawFileName)
-        : rawFileName
+      const mimeType = generationResult.data.metadata.mimeType
+      const rawFileName = params.fileName
+        ? this.securityManager.sanitizeFilename(params.fileName)
+        : this.fileManager.generateFileName(mimeType)
+      const fileName = params.fileName ? ensureExtension(rawFileName, mimeType) : rawFileName
       const outputPath = path.join(configResult.data.imageOutputDir, fileName)
 
       const sanitizedPath = this.securityManager.sanitizeFilePath(outputPath)

--- a/src/tests/mocks/geminiImageClientMock.ts
+++ b/src/tests/mocks/geminiImageClientMock.ts
@@ -23,6 +23,8 @@ export interface ImageMockScenario {
   delay?: number
   customResponse?: Partial<GeneratedImageResult>
   errorMessage?: string
+  /** MIME type to use in mock responses. Defaults to 'image/png'. */
+  mimeType?: string
   features?: {
     aspectRatioPreserved?: boolean
     aspectRatioSource?: 'original' | 'last_image' | 'default'
@@ -156,7 +158,7 @@ class GeminiImageClientMock implements GeminiClient {
     const metadata: GeminiGenerationMetadata = {
       model: GEMINI_MODELS.FLASH,
       prompt: params.prompt,
-      mimeType: 'image/png',
+      mimeType: this.scenario.mimeType ?? 'image/png',
       timestamp: new Date(),
       inputImageProvided: !!params.inputImage,
     }
@@ -288,6 +290,8 @@ export function createStructuredPromptImageMock(options?: {
   qualityImprovement?: number // 0-100
   processingTime?: number // milliseconds
   practicesApplied?: string[]
+  /** MIME type to use in mock metadata. Defaults to 'image/png'. */
+  mimeType?: string
 }): GeminiClient {
   const factory = new GeminiImageClientMockFactory()
 
@@ -307,7 +311,7 @@ export function createStructuredPromptImageMock(options?: {
       metadata: {
         model: GEMINI_MODELS.FLASH,
         prompt: 'Enhanced structured prompt',
-        mimeType: 'image/png',
+        mimeType: options?.mimeType ?? 'image/png',
         timestamp: new Date(),
         inputImageProvided: false,
       },

--- a/src/utils/__tests__/mimeUtils.test.ts
+++ b/src/utils/__tests__/mimeUtils.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for mimeUtils utility
+ * Covers MIME-to-extension mapping, extension-to-MIME mapping,
+ * extension detection, and extension ensurance for filenames
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ensureExtension,
+  getExtensionFromMimeType,
+  getMimeTypeFromExtension,
+  hasImageExtension,
+  SUPPORTED_EXTENSIONS,
+  SUPPORTED_MIME_TYPES,
+} from '../mimeUtils'
+
+describe('mimeUtils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('SUPPORTED_MIME_TYPES', () => {
+    it('should contain all 5 supported MIME types', () => {
+      // Assert
+      expect(SUPPORTED_MIME_TYPES).toContain('image/jpeg')
+      expect(SUPPORTED_MIME_TYPES).toContain('image/png')
+      expect(SUPPORTED_MIME_TYPES).toContain('image/webp')
+      expect(SUPPORTED_MIME_TYPES).toContain('image/gif')
+      expect(SUPPORTED_MIME_TYPES).toContain('image/bmp')
+      expect(SUPPORTED_MIME_TYPES).toHaveLength(5)
+    })
+  })
+
+  describe('SUPPORTED_EXTENSIONS', () => {
+    it('should contain all supported extensions', () => {
+      // Assert
+      expect(SUPPORTED_EXTENSIONS).toContain('.jpg')
+      expect(SUPPORTED_EXTENSIONS).toContain('.jpeg')
+      expect(SUPPORTED_EXTENSIONS).toContain('.png')
+      expect(SUPPORTED_EXTENSIONS).toContain('.webp')
+      expect(SUPPORTED_EXTENSIONS).toContain('.gif')
+      expect(SUPPORTED_EXTENSIONS).toContain('.bmp')
+    })
+  })
+
+  describe('getExtensionFromMimeType', () => {
+    it('should map image/jpeg to .jpg', () => {
+      // Act
+      const result = getExtensionFromMimeType('image/jpeg')
+
+      // Assert
+      expect(result).toBe('.jpg')
+    })
+
+    it('should map image/png to .png', () => {
+      // Act
+      const result = getExtensionFromMimeType('image/png')
+
+      // Assert
+      expect(result).toBe('.png')
+    })
+
+    it('should map image/webp to .webp', () => {
+      // Act
+      const result = getExtensionFromMimeType('image/webp')
+
+      // Assert
+      expect(result).toBe('.webp')
+    })
+
+    it('should map image/gif to .gif', () => {
+      // Act
+      const result = getExtensionFromMimeType('image/gif')
+
+      // Assert
+      expect(result).toBe('.gif')
+    })
+
+    it('should map image/bmp to .bmp', () => {
+      // Act
+      const result = getExtensionFromMimeType('image/bmp')
+
+      // Assert
+      expect(result).toBe('.bmp')
+    })
+
+    it('should return .png with warning log for unknown MIME type', () => {
+      // Arrange
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // Act
+      const result = getExtensionFromMimeType('image/tiff')
+
+      // Assert
+      expect(result).toBe('.png')
+      expect(consoleErrorSpy).toHaveBeenCalled()
+      const logOutput = consoleErrorSpy.mock.calls[0]?.[0] as string
+      expect(logOutput).toContain('warn')
+      expect(logOutput).toContain('image/tiff')
+    })
+  })
+
+  describe('getMimeTypeFromExtension', () => {
+    it('should map .jpg to image/jpeg', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.jpg')
+
+      // Assert
+      expect(result).toBe('image/jpeg')
+    })
+
+    it('should map .jpeg to image/jpeg', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.jpeg')
+
+      // Assert
+      expect(result).toBe('image/jpeg')
+    })
+
+    it('should map .png to image/png', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.png')
+
+      // Assert
+      expect(result).toBe('image/png')
+    })
+
+    it('should map .webp to image/webp', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.webp')
+
+      // Assert
+      expect(result).toBe('image/webp')
+    })
+
+    it('should map .gif to image/gif', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.gif')
+
+      // Assert
+      expect(result).toBe('image/gif')
+    })
+
+    it('should map .bmp to image/bmp', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.bmp')
+
+      // Assert
+      expect(result).toBe('image/bmp')
+    })
+
+    it('should return image/png for unknown extension', () => {
+      // Act
+      const result = getMimeTypeFromExtension('.tiff')
+
+      // Assert
+      expect(result).toBe('image/png')
+    })
+  })
+
+  describe('hasImageExtension', () => {
+    it('should return true for .png', () => {
+      expect(hasImageExtension('photo.png')).toBe(true)
+    })
+
+    it('should return true for .jpg', () => {
+      expect(hasImageExtension('photo.jpg')).toBe(true)
+    })
+
+    it('should return true for .jpeg', () => {
+      expect(hasImageExtension('photo.jpeg')).toBe(true)
+    })
+
+    it('should return true for .webp', () => {
+      expect(hasImageExtension('photo.webp')).toBe(true)
+    })
+
+    it('should return true for .gif', () => {
+      expect(hasImageExtension('photo.gif')).toBe(true)
+    })
+
+    it('should return true for .bmp', () => {
+      expect(hasImageExtension('photo.bmp')).toBe(true)
+    })
+
+    it('should return false for no extension', () => {
+      expect(hasImageExtension('photo')).toBe(false)
+    })
+
+    it('should return false for .txt', () => {
+      expect(hasImageExtension('document.txt')).toBe(false)
+    })
+  })
+
+  describe('ensureExtension', () => {
+    it('should add extension when filename has none', () => {
+      // Act
+      const result = ensureExtension('photo', 'image/jpeg')
+
+      // Assert
+      expect(result).toBe('photo.jpg')
+    })
+
+    it('should preserve existing correct extension', () => {
+      // Act
+      const result = ensureExtension('photo.jpg', 'image/jpeg')
+
+      // Assert
+      expect(result).toBe('photo.jpg')
+    })
+
+    it('should preserve existing extension even if different from MIME type', () => {
+      // Act
+      const result = ensureExtension('photo.png', 'image/jpeg')
+
+      // Assert
+      expect(result).toBe('photo.png')
+    })
+
+    it('should add extension for image/png when filename has no extension', () => {
+      // Act
+      const result = ensureExtension('screenshot', 'image/png')
+
+      // Assert
+      expect(result).toBe('screenshot.png')
+    })
+
+    it('should add extension for image/webp when filename has no extension', () => {
+      // Act
+      const result = ensureExtension('artwork', 'image/webp')
+
+      // Assert
+      expect(result).toBe('artwork.webp')
+    })
+  })
+})

--- a/src/utils/__tests__/mimeUtils.test.ts
+++ b/src/utils/__tests__/mimeUtils.test.ts
@@ -10,6 +10,7 @@ import {
   getExtensionFromMimeType,
   getMimeTypeFromExtension,
   hasImageExtension,
+  normalizeMimeType,
   SUPPORTED_EXTENSIONS,
   SUPPORTED_MIME_TYPES,
 } from '../mimeUtils'
@@ -97,6 +98,18 @@ describe('mimeUtils', () => {
       const logOutput = consoleErrorSpy.mock.calls[0]?.[0] as string
       expect(logOutput).toContain('warn')
       expect(logOutput).toContain('image/tiff')
+    })
+
+    it('should return .png with warning log for empty string', () => {
+      // Arrange
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // Act
+      const result = getExtensionFromMimeType('')
+
+      // Assert
+      expect(result).toBe('.png')
+      expect(consoleErrorSpy).toHaveBeenCalled()
     })
   })
 
@@ -231,6 +244,32 @@ describe('mimeUtils', () => {
 
       // Assert
       expect(result).toBe('artwork.webp')
+    })
+  })
+
+  describe('normalizeMimeType', () => {
+    it('should return supported MIME type as-is', () => {
+      expect(normalizeMimeType('image/jpeg')).toBe('image/jpeg')
+      expect(normalizeMimeType('image/png')).toBe('image/png')
+      expect(normalizeMimeType('image/webp')).toBe('image/webp')
+    })
+
+    it('should return image/png for unknown MIME type', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = normalizeMimeType('image/tiff')
+
+      expect(result).toBe('image/png')
+      expect(consoleErrorSpy).toHaveBeenCalled()
+    })
+
+    it('should return image/png for empty string', () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const result = normalizeMimeType('')
+
+      expect(result).toBe('image/png')
+      expect(consoleErrorSpy).toHaveBeenCalled()
     })
   })
 })

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,6 +4,7 @@
  */
 
 import { GEMINI_MODELS } from '../types/mcp.js'
+import { SUPPORTED_EXTENSIONS } from './mimeUtils.js'
 
 /**
  * Structured error format for consistent error reporting
@@ -273,7 +274,7 @@ export class SecurityError extends BaseError {
       message.includes('filetype') ||
       message.includes('format')
     ) {
-      return 'Use supported file extensions: .png, .jpg, .jpeg, .webp'
+      return `Use supported file extensions: ${SUPPORTED_EXTENSIONS.join(', ')}`
     }
     if (message.includes('size') || message.includes('large') || message.includes('limit')) {
       return 'Ensure file size is within allowed limits (max 10MB)'

--- a/src/utils/mimeUtils.ts
+++ b/src/utils/mimeUtils.ts
@@ -90,15 +90,6 @@ export function hasImageExtension(fileName: string): boolean {
 }
 
 /**
- * Ensure a filename has an appropriate file extension based on MIME type.
- * - If the filename already has an extension (any extension), it is preserved as-is.
- * - If the filename has no extension, one is appended based on the MIME type.
- *
- * @param fileName - The filename, with or without extension
- * @param mimeType - The MIME type to derive the extension from
- * @returns The filename with an appropriate extension
- */
-/**
  * Normalize a MIME type against the supported allowlist.
  * Returns the MIME type as-is if supported, otherwise falls back to image/png with a warning.
  *
@@ -113,6 +104,15 @@ export function normalizeMimeType(mimeType: string): string {
   return DEFAULT_MIME_TYPE
 }
 
+/**
+ * Ensure a filename has an appropriate file extension based on MIME type.
+ * - If the filename already has an extension (any extension), it is preserved as-is.
+ * - If the filename has no extension, one is appended based on the MIME type.
+ *
+ * @param fileName - The filename, with or without extension
+ * @param mimeType - The MIME type to derive the extension from
+ * @returns The filename with an appropriate extension
+ */
 export function ensureExtension(fileName: string, mimeType: string): string {
   const ext = path.extname(fileName)
   if (ext) {

--- a/src/utils/mimeUtils.ts
+++ b/src/utils/mimeUtils.ts
@@ -33,7 +33,7 @@ const EXTENSION_TO_MIME: ReadonlyMap<string, string> = new Map([
   ['.bmp', 'image/bmp'],
 ])
 
-const DEFAULT_MIME_TYPE = 'image/png'
+export const DEFAULT_MIME_TYPE = 'image/png'
 const DEFAULT_EXTENSION = '.png'
 
 /**
@@ -98,6 +98,21 @@ export function hasImageExtension(fileName: string): boolean {
  * @param mimeType - The MIME type to derive the extension from
  * @returns The filename with an appropriate extension
  */
+/**
+ * Normalize a MIME type against the supported allowlist.
+ * Returns the MIME type as-is if supported, otherwise falls back to image/png with a warning.
+ *
+ * @param mimeType - The MIME type to normalize
+ * @returns A supported MIME type string
+ */
+export function normalizeMimeType(mimeType: string): string {
+  if (MIME_TO_EXTENSION.has(mimeType)) {
+    return mimeType
+  }
+  logger.warn('mimeUtils', `Unknown MIME type, normalizing to ${DEFAULT_MIME_TYPE}`, { mimeType })
+  return DEFAULT_MIME_TYPE
+}
+
 export function ensureExtension(fileName: string, mimeType: string): string {
   const ext = path.extname(fileName)
   if (ext) {

--- a/src/utils/mimeUtils.ts
+++ b/src/utils/mimeUtils.ts
@@ -1,0 +1,109 @@
+/**
+ * Centralized MIME type and file extension mapping utility.
+ * Single source of truth for all MIME type and extension operations.
+ */
+
+import * as path from 'node:path'
+import { Logger } from './logger.js'
+
+const logger = new Logger()
+
+/**
+ * MIME type to file extension mapping.
+ * Primary extension is used for each MIME type.
+ */
+const MIME_TO_EXTENSION: ReadonlyMap<string, string> = new Map([
+  ['image/jpeg', '.jpg'],
+  ['image/png', '.png'],
+  ['image/webp', '.webp'],
+  ['image/gif', '.gif'],
+  ['image/bmp', '.bmp'],
+])
+
+/**
+ * File extension to MIME type mapping.
+ * Includes aliases (e.g., .jpeg -> image/jpeg).
+ */
+const EXTENSION_TO_MIME: ReadonlyMap<string, string> = new Map([
+  ['.jpg', 'image/jpeg'],
+  ['.jpeg', 'image/jpeg'],
+  ['.png', 'image/png'],
+  ['.webp', 'image/webp'],
+  ['.gif', 'image/gif'],
+  ['.bmp', 'image/bmp'],
+])
+
+const DEFAULT_MIME_TYPE = 'image/png'
+const DEFAULT_EXTENSION = '.png'
+
+/**
+ * All supported MIME types for image processing.
+ */
+export const SUPPORTED_MIME_TYPES: readonly string[] = [...MIME_TO_EXTENSION.keys()]
+
+/**
+ * All supported file extensions for image processing.
+ * Includes aliases (e.g., both .jpg and .jpeg).
+ */
+export const SUPPORTED_EXTENSIONS: readonly string[] = [...EXTENSION_TO_MIME.keys()]
+
+/**
+ * Get the file extension for a given MIME type.
+ * Returns .png with a warning log for unknown MIME types.
+ *
+ * @param mimeType - The MIME type string (e.g., "image/jpeg")
+ * @returns The corresponding file extension (e.g., ".jpg")
+ */
+export function getExtensionFromMimeType(mimeType: string): string {
+  const extension = MIME_TO_EXTENSION.get(mimeType)
+  if (extension) {
+    return extension
+  }
+
+  logger.warn('mimeUtils', `Unknown MIME type encountered, falling back to ${DEFAULT_EXTENSION}`, {
+    mimeType,
+  })
+  return DEFAULT_EXTENSION
+}
+
+/**
+ * Get the MIME type for a given file extension.
+ * Returns image/png for unknown extensions.
+ *
+ * @param ext - The file extension (e.g., ".jpg" or ".jpeg")
+ * @returns The corresponding MIME type (e.g., "image/jpeg")
+ */
+export function getMimeTypeFromExtension(ext: string): string {
+  const normalized = ext.toLowerCase()
+  return EXTENSION_TO_MIME.get(normalized) ?? DEFAULT_MIME_TYPE
+}
+
+/**
+ * Check if a filename has a recognized image file extension.
+ *
+ * @param fileName - The filename to check
+ * @returns true if the filename has a recognized image extension
+ */
+export function hasImageExtension(fileName: string): boolean {
+  const ext = path.extname(fileName).toLowerCase()
+  return EXTENSION_TO_MIME.has(ext)
+}
+
+/**
+ * Ensure a filename has an appropriate file extension based on MIME type.
+ * - If the filename already has an extension (any extension), it is preserved as-is.
+ * - If the filename has no extension, one is appended based on the MIME type.
+ *
+ * @param fileName - The filename, with or without extension
+ * @param mimeType - The MIME type to derive the extension from
+ * @returns The filename with an appropriate extension
+ */
+export function ensureExtension(fileName: string, mimeType: string): string {
+  const ext = path.extname(fileName)
+  if (ext) {
+    return fileName
+  }
+
+  const newExt = getExtensionFromMimeType(mimeType)
+  return `${fileName}${newExt}`
+}

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -8,6 +8,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Err, Ok, type Result } from '../types/result.js'
 import { SecurityError } from './errors.js'
+import { SUPPORTED_EXTENSIONS } from './mimeUtils.js'
 
 /**
  * Security manager for handling file path validation and sanitization
@@ -83,11 +84,9 @@ export class SecurityManager {
    * @returns Result indicating validation success or security error
    */
   validateImageFile(filePath: string): Result<void, SecurityError> {
-    // Allowed image file extensions
-    const allowedExtensions = ['.png', '.jpg', '.jpeg', '.webp']
     const extension = path.extname(filePath).toLowerCase()
 
-    if (!allowedExtensions.includes(extension)) {
+    if (!SUPPORTED_EXTENSIONS.includes(extension)) {
       return Err(new SecurityError(`Unsupported file extension: ${extension}`))
     }
 


### PR DESCRIPTION
## Summary

- Fix auto-generated filenames always using `.png` regardless of actual image format from Gemini API
- Add correct file extension to user-provided filenames when extension is missing
- Use Gemini API metadata MIME type as primary source in MCP responses instead of deriving from file extension
- Create centralized `mimeUtils` utility as single source of truth for MIME/extension mapping (DRY consolidation across 4 files)
- Validate API-sourced MIME types against allowlist for defense-in-depth
- Replace hardcoded input image MIME type (`image/jpeg`) with dynamic detection from file extension across full pipeline

Supersedes #71 — covers the same user-provided filename issue plus auto-generated filenames, response MIME type, input image MIME type, and DRY consolidation.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Auto-generated name (Gemini returns jpeg) | `image-xxx.png` | `image-xxx.jpg` |
| User provides `banana-test` (Gemini returns jpeg) | `banana-test` (no ext) | `banana-test.jpg` |
| User provides `photo.png` | `photo.png` (preserved) | `photo.png` (preserved) |
| MCP response MIME type | Always derived from extension | Metadata from API (fallback to extension) |
| Input image MIME type sent to API | Always `image/jpeg` | Derived from file extension |

## Files Changed

- `src/utils/mimeUtils.ts` — **NEW**: Centralized MIME-to-extension mapping with `normalizeMimeType`
- `src/business/fileManager.ts` — `generateFileName(mimeType?)` uses API MIME type
- `src/server/mcpServer.ts` — Propagates MIME type for both output filenames and input images
- `src/business/responseBuilder.ts` — Uses metadata MIME type as primary source
- `src/business/inputValidator.ts` — DRY: imports from mimeUtils
- `src/utils/security.ts` — DRY: imports from mimeUtils
- `src/utils/errors.ts` — DRY: dynamic extension list from mimeUtils
- `src/api/geminiClient.ts` — Validates output MIME type, accepts input image MIME type
- `src/api/geminiTextClient.ts` — Accepts input image MIME type
- `src/business/structuredPromptGenerator.ts` — Passes input image MIME type through

## Test Plan

- [x] 212 tests pass (`npm run check` — lint, type-check, tests, circular deps)
- [x] Manual: `fileName: "banana-test"` → saved as `banana-test.jpg`
- [x] Manual: No fileName → auto-generated as `image-xxx.jpg`
- [x] Manual: Input image (png) editing → correct MIME sent, output generated successfully
- [x] Backward compat: `generateFileName()` without args still defaults to `.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)