### PR TITLE
feat: add OpenAI image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 OpenAI provider notes:
 - `quality` maps to OpenAI image quality as `fast -> low`, `balanced -> medium`, `quality -> high`.
 - `aspectRatio` maps to the closest supported GPT Image size: square, landscape, or portrait.
-- `useGoogleSearch` is Gemini-specific for generation. In OpenAI mode it only informs prompt enhancement; it does not enable OpenAI web grounding.
+- `imageSize` is Gemini-specific and is rejected in OpenAI mode rather than silently downgraded.
+- `useGoogleSearch` is Gemini-specific and is rejected in OpenAI mode because Google Search grounding is not available through the OpenAI image provider.
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_IMAGE_MODEL=gpt-image-2
 ```
 
-OpenAI mode does not require `GEMINI_API_KEY`. Prompt enhancement also runs through OpenAI by default, using `OPENAI_TEXT_MODEL` (defaults to `gpt-5.2`). Set `SKIP_PROMPT_ENHANCEMENT=true` if you want prompts sent directly to the image model.
+OpenAI mode does not require `GEMINI_API_KEY`. Prompt enhancement also runs through OpenAI by default, using `OPENAI_TEXT_MODEL` (defaults to `gpt-5-mini`). Set `SKIP_PROMPT_ENHANCEMENT=true` if you want prompts sent directly to the image model.
 
 ### 2. MCP Configuration
 
@@ -265,7 +265,7 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 | `GEMINI_API_KEY` | - | Required when `IMAGE_PROVIDER=gemini` |
 | `OPENAI_API_KEY` | - | Required when `IMAGE_PROVIDER=openai` |
 | `OPENAI_IMAGE_MODEL` | `gpt-image-2` | OpenAI image model to use |
-| `OPENAI_TEXT_MODEL` | `gpt-5.2` | OpenAI text model used for prompt enhancement |
+| `OPENAI_TEXT_MODEL` | `gpt-5-mini` | OpenAI text model used for prompt enhancement |
 
 OpenAI provider notes:
 - `quality` maps to OpenAI image quality as `fast -> low`, `balanced -> medium`, `quality -> high`.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 OpenAI provider notes:
 - `quality` maps to OpenAI image quality as `fast -> low`, `balanced -> medium`, `quality -> high`.
 - `aspectRatio` maps to the closest supported GPT Image size: square, landscape, or portrait.
-- `imageSize` is Gemini-specific and is rejected in OpenAI mode rather than silently downgraded.
+- `imageSize` maps to valid `gpt-image-2` dimensions, including 2K/4K outputs. OpenAI 2K+ outputs are experimental and can be slower/more expensive.
 - `useGoogleSearch` is Gemini-specific and is rejected in OpenAI mode because Google Search grounding is not available through the OpenAI image provider.
 
 ## Usage Examples

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Image Generator 🍌
 
-> AI image generation and editing MCP server for Cursor, Claude Code, Codex, and any MCP-compatible tool — powered by Nano Banana 2 and Nano Banana Pro (Google Gemini).
+> AI image generation and editing MCP server for Cursor, Claude Code, Codex, and any MCP-compatible tool — powered by Nano Banana 2 and Nano Banana Pro (Google Gemini), with optional OpenAI GPT Image support.
 
 [![npm version](https://badge.fury.io/js/mcp-image.svg)](https://www.npmjs.com/package/mcp-image)
 [![npm downloads](https://img.shields.io/npm/dm/mcp-image.svg)](https://www.npmjs.com/package/mcp-image)
@@ -27,7 +27,7 @@ You: "cat on a roof"
 
 Your AI assistant interprets your intent — the style, purpose, and context behind your request. The MCP focuses on output quality by refining the prompt to meet a structured visual clarity standard and selecting appropriate generation settings. You just describe what you want.
 
-The prompt optimizer uses a **Subject–Context–Style** framework (powered by Gemini 2.5 Flash) to fill in missing visual details — subject characteristics, environment, lighting, camera work — while preserving your original intent. It doesn't blindly add details: prompts that already meet the quality standard are left largely intact.
+The prompt optimizer uses a **Subject–Context–Style** framework (powered by Gemini 2.5 Flash by default, or OpenAI Responses when `IMAGE_PROVIDER=openai`) to fill in missing visual details — subject characteristics, environment, lighting, camera work — while preserving your original intent. It doesn't blindly add details: prompts that already meet the quality standard are left largely intact.
 
 **Example — what the optimizer does to a short prompt:**
 
@@ -37,7 +37,8 @@ The prompt optimizer uses a **Subject–Context–Style** framework (powered by 
 
 ## Features
 
-- **Built-in Prompt Optimization**: Your simple prompt is automatically enriched with photographic and artistic details — lighting, composition, atmosphere — using Gemini 2.5 Flash. No prompt engineering skills required.
+- **Built-in Prompt Optimization**: Your simple prompt is automatically enriched with photographic and artistic details — lighting, composition, atmosphere — using Gemini 2.5 Flash by default, or OpenAI Responses when `IMAGE_PROVIDER=openai`. No prompt engineering skills required.
+- **Optional OpenAI Provider**: Set `IMAGE_PROVIDER=openai` to generate and edit images with OpenAI GPT Image models such as `gpt-image-2`.
 - **Three Quality Tiers**: Choose between fast iteration, balanced quality, or maximum fidelity with Nano Banana 2 (Gemini 3.1 Flash Image) and Nano Banana Pro (Gemini 3 Pro Image). [See Quality Presets](#quality-presets).
 - **Image Editing**: Transform existing images with natural language instructions (image-to-image) while preserving original style and visual consistency.
 - **High-Resolution Output**: Up to 4K image generation for professional-grade output with superior text rendering and fine details.
@@ -91,7 +92,8 @@ npx mcp-image skills install --path ~/.claude/skills
 ## Prerequisites
 
 - **Node.js** 22 or higher
-- **Gemini API Key** - Get yours at [Google AI Studio](https://aistudio.google.com/apikey)
+- **Gemini API Key** - Get yours at [Google AI Studio](https://aistudio.google.com/apikey) for the default Gemini provider
+- **OpenAI API Key** - Get yours from [OpenAI](https://platform.openai.com/api-keys) when using `IMAGE_PROVIDER=openai`
 - An MCP-compatible AI tool: **Cursor**, **Claude Code**, **Codex**, or others
 - Basic terminal/command line knowledge
 
@@ -100,6 +102,16 @@ npx mcp-image skills install --path ~/.claude/skills
 ### 1. Get Your Gemini API Key
 
 Get your API key from [Google AI Studio](https://aistudio.google.com/apikey)
+
+To use OpenAI instead, get an OpenAI API key and set:
+
+```bash
+IMAGE_PROVIDER=openai
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_IMAGE_MODEL=gpt-image-2
+```
+
+OpenAI mode does not require `GEMINI_API_KEY`. Prompt enhancement also runs through OpenAI by default, using `OPENAI_TEXT_MODEL` (defaults to `gpt-5.2`). Set `SKIP_PROMPT_ENHANCEMENT=true` if you want prompts sent directly to the image model.
 
 ### 2. MCP Configuration
 
@@ -114,6 +126,20 @@ args = ["-y", "mcp-image"]
 
 [mcp_servers.mcp-image.env]
 GEMINI_API_KEY = "your_gemini_api_key_here"
+IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
+```
+
+For OpenAI GPT Image from a local fork:
+
+```toml
+[mcp_servers.mcp-image]
+command = "node"
+args = ["/absolute/path/to/mcp-image/dist/index.js"]
+
+[mcp_servers.mcp-image.env]
+IMAGE_PROVIDER = "openai"
+OPENAI_API_KEY = "your_openai_api_key_here"
+OPENAI_IMAGE_MODEL = "gpt-image-2"
 IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
 ```
 
@@ -138,6 +164,25 @@ Add to your Cursor settings:
 }
 ```
 
+For OpenAI GPT Image from a local fork:
+
+```json
+{
+  "mcpServers": {
+    "mcp-image": {
+      "command": "node",
+      "args": ["/absolute/path/to/mcp-image/dist/index.js"],
+      "env": {
+        "IMAGE_PROVIDER": "openai",
+        "OPENAI_API_KEY": "your_openai_api_key_here",
+        "OPENAI_IMAGE_MODEL": "gpt-image-2",
+        "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"
+      }
+    }
+  }
+}
+```
+
 #### For Claude Code
 
 Run in your project directory to enable for that project:
@@ -151,6 +196,19 @@ Or add globally for all projects:
 
 ```bash
 claude mcp add mcp-image --scope user --env GEMINI_API_KEY=your-api-key --env IMAGE_OUTPUT_DIR=/absolute/path/to/images -- npx -y mcp-image
+```
+
+For OpenAI GPT Image from a local fork:
+
+```bash
+npm install
+npm run build
+claude mcp add mcp-image --scope user \
+  --env IMAGE_PROVIDER=openai \
+  --env OPENAI_API_KEY=your-openai-api-key \
+  --env OPENAI_IMAGE_MODEL=gpt-image-2 \
+  --env IMAGE_OUTPUT_DIR=/absolute/path/to/images \
+  -- node /absolute/path/to/mcp-image/dist/index.js
 ```
 
 ⚠️ **Security Note**: Never commit your API key to version control. Keep it secure and use environment-specific configuration.
@@ -199,6 +257,21 @@ claude mcp add mcp-image --env GEMINI_API_KEY=your-api-key --env IMAGE_QUALITY=b
 
 Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and send your prompts directly to the image generator. Useful when you need full control over the exact prompt wording.
 
+### Provider Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IMAGE_PROVIDER` | `gemini` | `gemini` or `openai` |
+| `GEMINI_API_KEY` | - | Required when `IMAGE_PROVIDER=gemini` |
+| `OPENAI_API_KEY` | - | Required when `IMAGE_PROVIDER=openai` |
+| `OPENAI_IMAGE_MODEL` | `gpt-image-2` | OpenAI image model to use |
+| `OPENAI_TEXT_MODEL` | `gpt-5.2` | OpenAI text model used for prompt enhancement |
+
+OpenAI provider notes:
+- `quality` maps to OpenAI image quality as `fast -> low`, `balanced -> medium`, `quality -> high`.
+- `aspectRatio` maps to the closest supported GPT Image size: square, landscape, or portrait.
+- `useGoogleSearch` is Gemini-specific for generation. In OpenAI mode it only informs prompt enhancement; it does not enable OpenAI web grounding.
+
 ## Usage Examples
 
 Once configured, just describe what you want in natural language:
@@ -243,8 +316,8 @@ Your prompt is automatically enhanced with rich details about lighting, material
 ### `generate_image` Tool
 
 The server uses a two-stage process with separate models for each stage:
-1. **Prompt Optimization** (Gemini 2.5 Flash): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
-2. **Image Generation** (Nano Banana 2 or Pro): Creates the final image. Model varies by quality preset.
+1. **Prompt Optimization** (Gemini 2.5 Flash by default, or OpenAI Responses in OpenAI mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
+2. **Image Generation** (Nano Banana 2/Pro by default, or `OPENAI_IMAGE_MODEL` in OpenAI mode): Creates the final image. Model varies by quality preset and provider configuration.
 
 #### Parameters
 
@@ -274,6 +347,7 @@ The server uses a two-stage process with separate models for each stage:
   },
   "metadata": {
     "model": "gemini-3.1-flash-image-preview",
+    "provider": "gemini",
     "processingTime": 5000,
     "timestamp": "2026-01-01T12:00:00.000Z"
   }
@@ -285,7 +359,7 @@ The server uses a two-stage process with separate models for each stage:
 ### Common Issues
 
 **"API key not found"**
-- Ensure `GEMINI_API_KEY` is set in your environment
+- Ensure `GEMINI_API_KEY` is set when using Gemini, or `OPENAI_API_KEY` is set when `IMAGE_PROVIDER=openai`
 - Verify the API key is valid and has image generation permissions
 
 **"Input image file not found"**

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.42.0",
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "openai": "^6.35.0"
       },
       "bin": {
         "mcp-image": "dist/index.js"
@@ -3938,6 +3939,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.35.0.tgz",
+      "integrity": "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/ora": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "prompt-enhancement",
     "gemini",
     "google-ai",
+    "openai",
+    "gpt-image-2",
     "nano-banana",
     "claude-code",
     "cursor",
@@ -63,7 +65,8 @@
   },
   "dependencies": {
     "@google/genai": "^1.42.0",
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "openai": "^6.35.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",

--- a/server.json
+++ b/server.json
@@ -49,7 +49,7 @@
         },
         {
           "name": "OPENAI_TEXT_MODEL",
-          "description": "OpenAI text model used for prompt enhancement when IMAGE_PROVIDER=openai (defaults to gpt-5.2)",
+          "description": "OpenAI text model used for prompt enhancement when IMAGE_PROVIDER=openai (defaults to gpt-5-mini)",
           "isRequired": false,
           "format": "string",
           "isSecret": false

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/mcp-image",
-  "description": "AI image generation and editing with prompt optimization and quality presets. Powered by Nano Banana",
+  "description": "AI image generation and editing with prompt optimization and quality presets. Powered by Nano Banana or OpenAI GPT Image",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {
@@ -20,11 +20,39 @@
       },
       "environmentVariables": [
         {
+          "name": "IMAGE_PROVIDER",
+          "description": "Image provider to use: 'gemini' (default) or 'openai'",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
           "name": "GEMINI_API_KEY",
-          "description": "Google Gemini API key for image generation (get from https://aistudio.google.com/apikey)",
-          "isRequired": true,
+          "description": "Google Gemini API key for image generation when IMAGE_PROVIDER=gemini (get from https://aistudio.google.com/apikey)",
+          "isRequired": false,
           "format": "string",
           "isSecret": true
+        },
+        {
+          "name": "OPENAI_API_KEY",
+          "description": "OpenAI API key for image generation when IMAGE_PROVIDER=openai",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "OPENAI_IMAGE_MODEL",
+          "description": "OpenAI image model to use when IMAGE_PROVIDER=openai (defaults to gpt-image-2)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "OPENAI_TEXT_MODEL",
+          "description": "OpenAI text model used for prompt enhancement when IMAGE_PROVIDER=openai (defaults to gpt-5.2)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
         },
         {
           "name": "IMAGE_OUTPUT_DIR",
@@ -72,6 +100,8 @@
     "image-editing",
     "prompt-enhancement",
     "gemini",
+    "openai",
+    "gpt-image-2",
     "nano-banana",
     "nano-banana-2",
     "nano-banana-pro",

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -24,7 +24,11 @@ vi.mock('@google/genai', () => ({
 
 describe('geminiClient', () => {
   const testConfig: Config = {
+    imageProvider: 'gemini',
     geminiApiKey: 'test-api-key-12345',
+    openaiApiKey: '',
+    openaiImageModel: 'gpt-image-2',
+    openaiTextModel: 'gpt-5.2',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -28,7 +28,7 @@ describe('geminiClient', () => {
     geminiApiKey: 'test-api-key-12345',
     openaiApiKey: '',
     openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5.2',
+    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -56,9 +56,15 @@ describe('GeminiTextClient', () => {
     vi.clearAllMocks()
 
     config = {
+      imageProvider: 'gemini',
       geminiApiKey: 'test-api-key',
+      openaiApiKey: '',
+      openaiImageModel: 'gpt-image-2',
+      openaiTextModel: 'gpt-5.2',
       imageOutputDir: './test-output',
       apiTimeout: 30000,
+      skipPromptEnhancement: false,
+      imageQuality: 'fast',
     }
 
     const clientResult = createGeminiTextClient(config)

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -60,7 +60,7 @@ describe('GeminiTextClient', () => {
       geminiApiKey: 'test-api-key',
       openaiApiKey: '',
       openaiImageModel: 'gpt-image-2',
-      openaiTextModel: 'gpt-5.2',
+      openaiTextModel: 'gpt-5-mini',
       imageOutputDir: './test-output',
       apiTimeout: 30000,
       skipPromptEnhancement: false,

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from '../../utils/config'
+import { ImageAPIError, NetworkError } from '../../utils/errors'
+import { createOpenAIImageClient } from '../openaiImageClient'
+
+const mockGenerate = vi.fn()
+const mockEdit = vi.fn()
+const mockOpenAI = vi.fn()
+const mockToFile = vi.fn()
+
+vi.mock('openai', () => ({
+  default: class {
+    images = {
+      generate: mockGenerate,
+      edit: mockEdit,
+    }
+
+    constructor(...args: any[]) {
+      mockOpenAI(...args)
+    }
+  },
+  toFile: (...args: any[]) => mockToFile(...args),
+}))
+
+describe('openaiImageClient', () => {
+  const testConfig: Config = {
+    imageProvider: 'openai',
+    geminiApiKey: '',
+    openaiApiKey: 'test-openai-api-key-12345',
+    openaiImageModel: 'gpt-image-2',
+    openaiTextModel: 'gpt-5.2',
+    imageOutputDir: './output',
+    apiTimeout: 30000,
+    skipPromptEnhancement: false,
+    imageQuality: 'fast',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockToFile.mockResolvedValue({ name: 'input.png', type: 'image/png' })
+  })
+
+  describe('createOpenAIImageClient', () => {
+    it('should create client with OpenAI API key', () => {
+      const result = createOpenAIImageClient(testConfig)
+
+      expect(result.success).toBe(true)
+      expect(mockOpenAI).toHaveBeenCalledWith({ apiKey: testConfig.openaiApiKey })
+    })
+
+    it('should return error when SDK initialization fails', () => {
+      mockOpenAI.mockImplementationOnce(() => {
+        throw new Error('Invalid API key')
+      })
+
+      const result = createOpenAIImageClient(testConfig)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.message).toContain('Failed to initialize OpenAI image client')
+      }
+    })
+  })
+
+  describe('OpenAIImageClient.generateImage', () => {
+    it('should generate image successfully with gpt-image-2', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [
+          {
+            b64_json: Buffer.from('mock-openai-image-data').toString('base64'),
+          },
+        ],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a beautiful landscape',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockGenerate).toHaveBeenCalledWith({
+        model: 'gpt-image-2',
+        prompt: 'Generate a beautiful landscape',
+        n: 1,
+        output_format: 'png',
+        quality: 'low',
+        size: '1024x1024',
+      })
+      if (result.success) {
+        expect(result.data.imageData).toEqual(Buffer.from('mock-openai-image-data'))
+        expect(result.data.metadata.model).toBe('gpt-image-2')
+        expect(result.data.metadata.provider).toBe('openai')
+        expect(result.data.metadata.prompt).toBe('Generate a beautiful landscape')
+        expect(result.data.metadata.mimeType).toBe('image/png')
+      }
+    })
+
+    it('should edit image successfully with input image data', async () => {
+      mockEdit.mockResolvedValue({
+        data: [
+          {
+            b64_json: Buffer.from('mock-openai-edited-image-data').toString('base64'),
+          },
+        ],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const inputImage = Buffer.from('input-image-data').toString('base64')
+      const result = await clientResult.data.generateImage({
+        prompt: 'Make this image warmer',
+        inputImage,
+        inputImageMimeType: 'image/png',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockToFile).toHaveBeenCalledWith(Buffer.from('input-image-data'), 'input.png', {
+        type: 'image/png',
+      })
+      expect(mockEdit).toHaveBeenCalledWith({
+        model: 'gpt-image-2',
+        prompt: 'Make this image warmer',
+        image: { name: 'input.png', type: 'image/png' },
+        n: 1,
+        output_format: 'png',
+        quality: 'low',
+        size: '1024x1024',
+      })
+    })
+
+    it('should map balanced quality to medium OpenAI quality', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      await clientResult.data.generateImage({
+        prompt: 'Generate an image',
+        quality: 'balanced',
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          quality: 'medium',
+        })
+      )
+    })
+
+    it('should map quality preset to high OpenAI quality', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      await clientResult.data.generateImage({
+        prompt: 'Generate an image',
+        quality: 'quality',
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          quality: 'high',
+        })
+      )
+    })
+
+    it('should map aspect ratio to closest OpenAI size', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      await clientResult.data.generateImage({
+        prompt: 'Generate a landscape image',
+        aspectRatio: '16:9',
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: '1536x1024',
+        })
+      )
+    })
+
+    it('should return ImageAPIError when response has no base64 image data', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{}],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate image',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.message).toContain('No image data returned')
+      }
+    })
+
+    it('should return NetworkError for network failures', async () => {
+      const networkError = new Error('ECONNRESET') as Error & { code: string }
+      networkError.code = 'ECONNRESET'
+      mockGenerate.mockRejectedValue(networkError)
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate image',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(NetworkError)
+      }
+    })
+  })
+})

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -216,8 +216,49 @@ describe('openaiImageClient', () => {
       }
     })
 
-    it('should reject imageSize because OpenAI provider cannot honor Gemini size presets', async () => {
+    it('should map 2K imageSize with landscape aspect ratio to a GPT Image 2 size', async () => {
       const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a 2K product photo',
+        aspectRatio: '16:9',
+        imageSize: '2K',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: '2048x1152',
+        })
+      )
+    })
+
+    it('should map 4K imageSize with portrait aspect ratio to a GPT Image 2 size', async () => {
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a 4K portrait poster',
+        aspectRatio: '9:16',
+        imageSize: '4K',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: '2160x3840',
+        })
+      )
+    })
+
+    it('should reject imageSize for non-GPT Image 2 OpenAI models', async () => {
+      const clientResult = createOpenAIImageClient({
+        ...testConfig,
+        openaiImageModel: 'gpt-image-1.5',
+      })
       expect(clientResult.success).toBe(true)
       if (!clientResult.success) return
 
@@ -231,7 +272,7 @@ describe('openaiImageClient', () => {
       if (!result.success) {
         expect(result.error).toBeInstanceOf(ImageAPIError)
         expect(result.error.message).toContain('imageSize')
-        expect(result.error.message).toContain('OpenAI')
+        expect(result.error.message).toContain('gpt-image-2')
       }
     })
 

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -28,7 +28,7 @@ describe('openaiImageClient', () => {
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
     openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5.2',
+    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -197,6 +197,44 @@ describe('openaiImageClient', () => {
       )
     })
 
+    it('should reject useGoogleSearch because OpenAI image generation does not support Google Search grounding', async () => {
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a current event image',
+        useGoogleSearch: true,
+      })
+
+      expect(result.success).toBe(false)
+      expect(mockGenerate).not.toHaveBeenCalled()
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.message).toContain('useGoogleSearch')
+        expect(result.error.message).toContain('OpenAI')
+      }
+    })
+
+    it('should reject imageSize because OpenAI provider cannot honor Gemini size presets', async () => {
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a 4K product photo',
+        imageSize: '4K',
+      })
+
+      expect(result.success).toBe(false)
+      expect(mockGenerate).not.toHaveBeenCalled()
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.message).toContain('imageSize')
+        expect(result.error.message).toContain('OpenAI')
+      }
+    })
+
     it('should return ImageAPIError when response has no base64 image data', async () => {
       mockGenerate.mockResolvedValue({
         data: [{}],

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -24,7 +24,7 @@ describe('openaiTextClient', () => {
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
     openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5.2',
+    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
@@ -59,7 +59,7 @@ describe('openaiTextClient', () => {
 
     expect(result.success).toBe(true)
     expect(mockResponsesCreate).toHaveBeenCalledWith({
-      model: 'gpt-5.2',
+      model: 'gpt-5-mini',
       input: 'make a product photo',
       instructions: 'Enhance image prompts',
       max_output_tokens: 1000,

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from '../../utils/config'
+import { ImageAPIError, NetworkError } from '../../utils/errors'
+import { createOpenAITextClient } from '../openaiTextClient'
+
+const mockResponsesCreate = vi.fn()
+const mockOpenAI = vi.fn()
+
+vi.mock('openai', () => ({
+  default: class {
+    responses = {
+      create: mockResponsesCreate,
+    }
+
+    constructor(...args: any[]) {
+      mockOpenAI(...args)
+    }
+  },
+}))
+
+describe('openaiTextClient', () => {
+  const testConfig: Config = {
+    imageProvider: 'openai',
+    geminiApiKey: '',
+    openaiApiKey: 'test-openai-api-key-12345',
+    openaiImageModel: 'gpt-image-2',
+    openaiTextModel: 'gpt-5.2',
+    imageOutputDir: './output',
+    apiTimeout: 30000,
+    skipPromptEnhancement: false,
+    imageQuality: 'fast',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should create client with OpenAI API key', () => {
+    const result = createOpenAITextClient(testConfig)
+
+    expect(result.success).toBe(true)
+    expect(mockOpenAI).toHaveBeenCalledWith({ apiKey: testConfig.openaiApiKey })
+  })
+
+  it('should generate text using OpenAI Responses API', async () => {
+    mockResponsesCreate.mockResolvedValue({
+      output_text: 'Enhanced prompt with precise lighting and composition',
+    })
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const result = await clientResult.data.generateText('make a product photo', {
+      systemInstruction: 'Enhance image prompts',
+      maxTokens: 1000,
+      temperature: 0.2,
+    })
+
+    expect(result.success).toBe(true)
+    expect(mockResponsesCreate).toHaveBeenCalledWith({
+      model: 'gpt-5.2',
+      input: 'make a product photo',
+      instructions: 'Enhance image prompts',
+      max_output_tokens: 1000,
+      temperature: 0.2,
+    })
+    if (result.success) {
+      expect(result.data).toBe('Enhanced prompt with precise lighting and composition')
+    }
+  })
+
+  it('should include input image as a data URL for multimodal prompt enhancement', async () => {
+    mockResponsesCreate.mockResolvedValue({
+      output_text: 'Enhanced edit prompt preserving original style',
+    })
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    await clientResult.data.generateText('make the lighting warmer', {
+      inputImage: Buffer.from('image-bytes').toString('base64'),
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(mockResponsesCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'input_text',
+                text: 'make the lighting warmer',
+              },
+              {
+                type: 'input_image',
+                image_url: `data:image/png;base64,${Buffer.from('image-bytes').toString('base64')}`,
+                detail: 'auto',
+              },
+            ],
+          },
+        ],
+      })
+    )
+  })
+
+  it('should return ImageAPIError for empty OpenAI text response', async () => {
+    mockResponsesCreate.mockResolvedValue({ output_text: '' })
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const result = await clientResult.data.generateText('make a product photo')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(result.error.message).toContain('Empty response')
+    }
+  })
+
+  it('should return NetworkError for network failures', async () => {
+    const networkError = new Error('ECONNRESET') as Error & { code: string }
+    networkError.code = 'ECONNRESET'
+    mockResponsesCreate.mockRejectedValue(networkError)
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const result = await clientResult.data.generateText('make a product photo')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(NetworkError)
+    }
+  })
+})

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -12,6 +12,12 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import type {
+  GeneratedImageResult,
+  ImageApiParams,
+  ImageClient,
+  ImageGenerationMetadata,
+} from './imageClient.js'
 
 /**
  * Simplified Gemini API response types
@@ -132,46 +138,17 @@ interface ErrorWithCode extends Error {
 /**
  * Metadata for generated images
  */
-export interface GeminiGenerationMetadata {
-  model: string
-  prompt: string
-  mimeType: string
-  timestamp: Date
-  inputImageProvided: boolean
-  // Additional metadata from flat structure responses
-  modelVersion?: string
-  responseId?: string
-}
+export type GeminiGenerationMetadata = ImageGenerationMetadata
 
 /**
  * Parameters for Gemini API image generation
  */
-export interface GeminiApiParams {
-  prompt: string
-  inputImage?: string
-  inputImageMimeType?: string
-  aspectRatio?: string
-  imageSize?: string
-  useGoogleSearch?: boolean
-  quality?: ImageQuality
-}
-
-/**
- * Result of image generation
- */
-export interface GeneratedImageResult {
-  imageData: Buffer
-  metadata: GeminiGenerationMetadata
-}
+export type GeminiApiParams = ImageApiParams
 
 /**
  * Gemini API client interface
  */
-export interface GeminiClient {
-  generateImage(
-    params: GeminiApiParams
-  ): Promise<Result<GeneratedImageResult, GeminiAPIError | NetworkError>>
-}
+export type GeminiClient = ImageClient
 
 /**
  * Implementation of Gemini API client

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -10,42 +10,12 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE } from '../utils/mimeUtils.js'
+import type { GenerationConfig, TextClient } from './textClient.js'
 
 /**
  * Options for text generation
  */
-export interface GenerationConfig {
-  temperature?: number
-  maxTokens?: number
-  timeout?: number
-  systemInstruction?: string
-  inputImage?: string // Optional base64-encoded image for multimodal context
-  inputImageMimeType?: string // MIME type of the input image
-  topP?: number
-  topK?: number
-}
-
-/**
- * Interface for Gemini Text Client - pure API client
- */
-export interface GeminiTextClient {
-  /**
-   * Generate text using Gemini API
-   * @param prompt The prompt to send to the API
-   * @param config Optional configuration for generation
-   * @returns Result containing generated text or error
-   */
-  generateText(
-    prompt: string,
-    config?: GenerationConfig
-  ): Promise<Result<string, GeminiAPIError | NetworkError>>
-
-  /**
-   * Validate connection to Gemini API
-   * @returns Result indicating if connection is successful
-   */
-  validateConnection(): Promise<Result<boolean, GeminiAPIError | NetworkError>>
-}
+export type GeminiTextClient = TextClient
 
 /**
  * Default configuration for text generation

--- a/src/api/imageClient.ts
+++ b/src/api/imageClient.ts
@@ -1,0 +1,48 @@
+import type { AspectRatio, ImageQuality, ImageSize } from '../types/mcp.js'
+import type { Result } from '../types/result.js'
+import type { GeminiAPIError, ImageAPIError, NetworkError } from '../utils/errors.js'
+
+/**
+ * Provider-neutral metadata for generated images.
+ */
+export interface ImageGenerationMetadata {
+  model: string
+  prompt: string
+  mimeType: string
+  timestamp: Date
+  inputImageProvided: boolean
+  provider?: string
+  modelVersion?: string
+  responseId?: string
+  revisedPrompt?: string
+}
+
+/**
+ * Provider-neutral image generation/editing parameters.
+ */
+export interface ImageApiParams {
+  prompt: string
+  inputImage?: string
+  inputImageMimeType?: string
+  aspectRatio?: AspectRatio
+  imageSize?: ImageSize
+  useGoogleSearch?: boolean
+  quality?: ImageQuality
+}
+
+/**
+ * Result of image generation.
+ */
+export interface GeneratedImageResult {
+  imageData: Buffer
+  metadata: ImageGenerationMetadata
+}
+
+/**
+ * Provider-neutral image client.
+ */
+export interface ImageClient {
+  generateImage(
+    params: ImageApiParams
+  ): Promise<Result<GeneratedImageResult, GeminiAPIError | ImageAPIError | NetworkError>>
+}

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -76,6 +76,28 @@ function isNetworkError(error: unknown): boolean {
   return false
 }
 
+function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIError> {
+  if (params.useGoogleSearch) {
+    return Err(
+      new ImageAPIError(
+        'useGoogleSearch is not supported by the OpenAI image provider',
+        'Disable useGoogleSearch or use IMAGE_PROVIDER=gemini for Google Search grounding'
+      )
+    )
+  }
+
+  if (params.imageSize) {
+    return Err(
+      new ImageAPIError(
+        'imageSize is not supported by the OpenAI image provider',
+        'Remove imageSize or use IMAGE_PROVIDER=gemini for 1K/2K/4K Gemini size presets. OpenAI mode maps aspectRatio to the closest supported GPT Image size.'
+      )
+    )
+  }
+
+  return Ok(true)
+}
+
 class OpenAIImageClientImpl implements ImageClient {
   private readonly outputFormat: OpenAIOutputFormat = 'png'
 
@@ -89,6 +111,11 @@ class OpenAIImageClientImpl implements ImageClient {
     params: ImageApiParams
   ): Promise<Result<GeneratedImageResult, ImageAPIError | NetworkError>> {
     try {
+      const optionsResult = validateOpenAIOptions(params)
+      if (!optionsResult.success) {
+        return optionsResult
+      }
+
       const quality = mapQuality(params.quality ?? this.defaultQuality)
       const size = mapSize(params)
 

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -11,9 +11,22 @@ import { ImageAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
-type OpenAIImageSize = '1024x1024' | '1536x1024' | '1024x1536'
+type OpenAIImageSize =
+  | '1024x1024'
+  | '1536x1024'
+  | '1024x1536'
+  | '2048x2048'
+  | '2048x1152'
+  | '1152x2048'
+  | '2880x2880'
+  | '3840x2160'
+  | '2160x3840'
 type OpenAIImageQuality = 'low' | 'medium' | 'high'
 type OpenAIOutputFormat = 'png'
+// The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
+// enumerate the older fixed GPT image sizes. Keep the request cast local to this file.
+type OpenAIImageGenerateRequest = Parameters<OpenAI['images']['generate']>[0]
+type OpenAIImageEditRequest = Parameters<OpenAI['images']['edit']>[0]
 
 interface OpenAIImageResponse {
   data?: Array<{
@@ -39,9 +52,9 @@ function mapQuality(quality: ImageQuality): OpenAIImageQuality {
   }
 }
 
-function mapSize(params: ImageApiParams): OpenAIImageSize {
+function getOrientation(params: ImageApiParams): 'square' | 'landscape' | 'portrait' {
   if (!params.aspectRatio) {
-    return '1024x1024'
+    return 'square'
   }
 
   const [widthRaw, heightRaw] = params.aspectRatio.split(':')
@@ -49,10 +62,45 @@ function mapSize(params: ImageApiParams): OpenAIImageSize {
   const height = Number(heightRaw)
 
   if (!Number.isFinite(width) || !Number.isFinite(height) || width === height) {
-    return '1024x1024'
+    return 'square'
   }
 
-  return width > height ? '1536x1024' : '1024x1536'
+  return width > height ? 'landscape' : 'portrait'
+}
+
+function mapSize(params: ImageApiParams): OpenAIImageSize {
+  const orientation = getOrientation(params)
+
+  if (params.imageSize === '2K') {
+    switch (orientation) {
+      case 'landscape':
+        return '2048x1152'
+      case 'portrait':
+        return '1152x2048'
+      case 'square':
+        return '2048x2048'
+    }
+  }
+
+  if (params.imageSize === '4K') {
+    switch (orientation) {
+      case 'landscape':
+        return '3840x2160'
+      case 'portrait':
+        return '2160x3840'
+      case 'square':
+        return '2880x2880'
+    }
+  }
+
+  switch (orientation) {
+    case 'landscape':
+      return '1536x1024'
+    case 'portrait':
+      return '1024x1536'
+    case 'square':
+      return '1024x1024'
+  }
 }
 
 function mimeTypeToExtension(mimeType: string): string {
@@ -76,7 +124,14 @@ function isNetworkError(error: unknown): boolean {
   return false
 }
 
-function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIError> {
+function supportsFlexibleGPTImageSizes(modelName: string): boolean {
+  return modelName === 'gpt-image-2' || modelName.startsWith('gpt-image-2-')
+}
+
+function validateOpenAIOptions(
+  params: ImageApiParams,
+  modelName: string
+): Result<true, ImageAPIError> {
   if (params.useGoogleSearch) {
     return Err(
       new ImageAPIError(
@@ -86,11 +141,11 @@ function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIErr
     )
   }
 
-  if (params.imageSize) {
+  if (params.imageSize && !supportsFlexibleGPTImageSizes(modelName)) {
     return Err(
       new ImageAPIError(
-        'imageSize is not supported by the OpenAI image provider',
-        'Remove imageSize or use IMAGE_PROVIDER=gemini for 1K/2K/4K Gemini size presets. OpenAI mode maps aspectRatio to the closest supported GPT Image size.'
+        `imageSize requires gpt-image-2 when using the OpenAI image provider; current model is ${modelName}`,
+        'Remove imageSize, set OPENAI_IMAGE_MODEL=gpt-image-2, or use IMAGE_PROVIDER=gemini for Gemini size presets.'
       )
     )
   }
@@ -111,7 +166,7 @@ class OpenAIImageClientImpl implements ImageClient {
     params: ImageApiParams
   ): Promise<Result<GeneratedImageResult, ImageAPIError | NetworkError>> {
     try {
-      const optionsResult = validateOpenAIOptions(params)
+      const optionsResult = validateOpenAIOptions(params, this.modelName)
       if (!optionsResult.success) {
         return optionsResult
       }
@@ -158,14 +213,18 @@ class OpenAIImageClientImpl implements ImageClient {
     quality: OpenAIImageQuality,
     size: OpenAIImageSize
   ): Promise<OpenAIImageResponse> {
-    return (await this.client.images.generate({
+    const request = {
       model: this.modelName,
       prompt: params.prompt,
       n: 1,
       output_format: this.outputFormat,
       quality,
       size,
-    })) as OpenAIImageResponse
+    }
+
+    return (await this.client.images.generate(
+      request as unknown as OpenAIImageGenerateRequest
+    )) as OpenAIImageResponse
   }
 
   private async editImage(
@@ -180,7 +239,7 @@ class OpenAIImageClientImpl implements ImageClient {
       { type: mimeType }
     )
 
-    return (await this.client.images.edit({
+    const request = {
       model: this.modelName,
       prompt: params.prompt,
       image: inputFile,
@@ -188,7 +247,11 @@ class OpenAIImageClientImpl implements ImageClient {
       output_format: this.outputFormat,
       quality,
       size,
-    })) as OpenAIImageResponse
+    }
+
+    return (await this.client.images.edit(
+      request as unknown as OpenAIImageEditRequest
+    )) as OpenAIImageResponse
   }
 
   private handleError(error: unknown, prompt: string): Result<never, ImageAPIError | NetworkError> {

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -3,6 +3,11 @@
  */
 
 import OpenAI, { toFile } from 'openai'
+import type {
+  ImageEditParamsNonStreaming,
+  ImageGenerateParamsNonStreaming,
+  ImagesResponse,
+} from 'openai/resources/images'
 import type { ImageQuality } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
@@ -25,16 +30,9 @@ type OpenAIImageQuality = 'low' | 'medium' | 'high'
 type OpenAIOutputFormat = 'png'
 // The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
 // enumerate the older fixed GPT image sizes. Keep the request cast local to this file.
-type OpenAIImageGenerateRequest = Parameters<OpenAI['images']['generate']>[0]
-type OpenAIImageEditRequest = Parameters<OpenAI['images']['edit']>[0]
-
-interface OpenAIImageResponse {
-  data?: Array<{
-    b64_json?: string
-    revised_prompt?: string
-    url?: string
-  }>
-}
+type OpenAIImageGenerateRequest = ImageGenerateParamsNonStreaming
+type OpenAIImageEditRequest = ImageEditParamsNonStreaming
+type ImageEditApiParams = ImageApiParams & { inputImage: string }
 
 interface ErrorWithCode extends Error {
   code?: string
@@ -128,6 +126,10 @@ function supportsFlexibleGPTImageSizes(modelName: string): boolean {
   return modelName === 'gpt-image-2' || modelName.startsWith('gpt-image-2-')
 }
 
+function hasInputImage(params: ImageApiParams): params is ImageEditApiParams {
+  return typeof params.inputImage === 'string' && params.inputImage.length > 0
+}
+
 function validateOpenAIOptions(
   params: ImageApiParams,
   modelName: string
@@ -174,7 +176,7 @@ class OpenAIImageClientImpl implements ImageClient {
       const quality = mapQuality(params.quality ?? this.defaultQuality)
       const size = mapSize(params)
 
-      const response = params.inputImage
+      const response = hasInputImage(params)
         ? await this.editImage(params, quality, size)
         : await this.createImage(params, quality, size)
 
@@ -212,7 +214,7 @@ class OpenAIImageClientImpl implements ImageClient {
     params: ImageApiParams,
     quality: OpenAIImageQuality,
     size: OpenAIImageSize
-  ): Promise<OpenAIImageResponse> {
+  ): Promise<ImagesResponse> {
     const request = {
       model: this.modelName,
       prompt: params.prompt,
@@ -222,19 +224,17 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return (await this.client.images.generate(
-      request as unknown as OpenAIImageGenerateRequest
-    )) as OpenAIImageResponse
+    return await this.client.images.generate(request as unknown as OpenAIImageGenerateRequest)
   }
 
   private async editImage(
-    params: ImageApiParams,
+    params: ImageEditApiParams,
     quality: OpenAIImageQuality,
     size: OpenAIImageSize
-  ): Promise<OpenAIImageResponse> {
+  ): Promise<ImagesResponse> {
     const mimeType = normalizeMimeType(params.inputImageMimeType ?? DEFAULT_MIME_TYPE)
     const inputFile = await toFile(
-      Buffer.from(params.inputImage ?? '', 'base64'),
+      Buffer.from(params.inputImage, 'base64'),
       `input.${mimeTypeToExtension(mimeType)}`,
       { type: mimeType }
     )
@@ -249,9 +249,7 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return (await this.client.images.edit(
-      request as unknown as OpenAIImageEditRequest
-    )) as OpenAIImageResponse
+    return await this.client.images.edit(request as unknown as OpenAIImageEditRequest)
   }
 
   private handleError(error: unknown, prompt: string): Result<never, ImageAPIError | NetworkError> {

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -1,0 +1,237 @@
+/**
+ * OpenAI API client for GPT Image generation and editing.
+ */
+
+import OpenAI, { toFile } from 'openai'
+import type { ImageQuality } from '../types/mcp.js'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import type { Config } from '../utils/config.js'
+import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
+
+type OpenAIImageSize = '1024x1024' | '1536x1024' | '1024x1536'
+type OpenAIImageQuality = 'low' | 'medium' | 'high'
+type OpenAIOutputFormat = 'png'
+
+interface OpenAIImageResponse {
+  data?: Array<{
+    b64_json?: string
+    revised_prompt?: string
+    url?: string
+  }>
+}
+
+interface ErrorWithCode extends Error {
+  code?: string
+  status?: number
+}
+
+function mapQuality(quality: ImageQuality): OpenAIImageQuality {
+  switch (quality) {
+    case 'quality':
+      return 'high'
+    case 'balanced':
+      return 'medium'
+    case 'fast':
+      return 'low'
+  }
+}
+
+function mapSize(params: ImageApiParams): OpenAIImageSize {
+  if (!params.aspectRatio) {
+    return '1024x1024'
+  }
+
+  const [widthRaw, heightRaw] = params.aspectRatio.split(':')
+  const width = Number(widthRaw)
+  const height = Number(heightRaw)
+
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width === height) {
+    return '1024x1024'
+  }
+
+  return width > height ? '1536x1024' : '1024x1536'
+}
+
+function mimeTypeToExtension(mimeType: string): string {
+  switch (normalizeMimeType(mimeType)) {
+    case 'image/jpeg':
+      return 'jpg'
+    case 'image/webp':
+      return 'webp'
+    default:
+      return 'png'
+  }
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
+    return networkErrorCodes.some(
+      (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
+    )
+  }
+  return false
+}
+
+class OpenAIImageClientImpl implements ImageClient {
+  private readonly outputFormat: OpenAIOutputFormat = 'png'
+
+  constructor(
+    private readonly client: OpenAI,
+    private readonly modelName: string,
+    private readonly defaultQuality: ImageQuality = 'fast'
+  ) {}
+
+  async generateImage(
+    params: ImageApiParams
+  ): Promise<Result<GeneratedImageResult, ImageAPIError | NetworkError>> {
+    try {
+      const quality = mapQuality(params.quality ?? this.defaultQuality)
+      const size = mapSize(params)
+
+      const response = params.inputImage
+        ? await this.editImage(params, quality, size)
+        : await this.createImage(params, quality, size)
+
+      const firstImage = response.data?.[0]
+      if (!firstImage?.b64_json) {
+        return Err(
+          new ImageAPIError('No image data returned from OpenAI image API', {
+            provider: 'openai',
+            model: this.modelName,
+            stage: 'image_extraction',
+            suggestion:
+              'Retry the request or verify that the selected model returns base64 image data',
+          })
+        )
+      }
+
+      return Ok({
+        imageData: Buffer.from(firstImage.b64_json, 'base64'),
+        metadata: {
+          model: this.modelName,
+          provider: 'openai',
+          prompt: params.prompt,
+          mimeType: `image/${this.outputFormat}`,
+          timestamp: new Date(),
+          inputImageProvided: !!params.inputImage,
+          ...(firstImage.revised_prompt && { revisedPrompt: firstImage.revised_prompt }),
+        },
+      })
+    } catch (error) {
+      return this.handleError(error, params.prompt)
+    }
+  }
+
+  private async createImage(
+    params: ImageApiParams,
+    quality: OpenAIImageQuality,
+    size: OpenAIImageSize
+  ): Promise<OpenAIImageResponse> {
+    return (await this.client.images.generate({
+      model: this.modelName,
+      prompt: params.prompt,
+      n: 1,
+      output_format: this.outputFormat,
+      quality,
+      size,
+    })) as OpenAIImageResponse
+  }
+
+  private async editImage(
+    params: ImageApiParams,
+    quality: OpenAIImageQuality,
+    size: OpenAIImageSize
+  ): Promise<OpenAIImageResponse> {
+    const mimeType = normalizeMimeType(params.inputImageMimeType ?? DEFAULT_MIME_TYPE)
+    const inputFile = await toFile(
+      Buffer.from(params.inputImage ?? '', 'base64'),
+      `input.${mimeTypeToExtension(mimeType)}`,
+      { type: mimeType }
+    )
+
+    return (await this.client.images.edit({
+      model: this.modelName,
+      prompt: params.prompt,
+      image: inputFile,
+      n: 1,
+      output_format: this.outputFormat,
+      quality,
+      size,
+    })) as OpenAIImageResponse
+  }
+
+  private handleError(error: unknown, prompt: string): Result<never, ImageAPIError | NetworkError> {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+    if (isNetworkError(error)) {
+      return Err(
+        new NetworkError(
+          `Network error during OpenAI image generation: ${errorMessage}`,
+          'Check your internet connection and try again',
+          error instanceof Error ? error : undefined
+        )
+      )
+    }
+
+    return Err(
+      new ImageAPIError(
+        `Failed to generate image with OpenAI for prompt "${prompt}": ${errorMessage}`,
+        this.getAPIErrorSuggestion(errorMessage),
+        this.extractStatusCode(error)
+      )
+    )
+  }
+
+  private getAPIErrorSuggestion(errorMessage: string): string {
+    const lowerMessage = errorMessage.toLowerCase()
+
+    if (lowerMessage.includes('quota') || lowerMessage.includes('rate limit')) {
+      return 'You have exceeded your OpenAI API quota or rate limit. Wait before retrying or upgrade your plan'
+    }
+
+    if (lowerMessage.includes('unauthorized') || lowerMessage.includes('api key')) {
+      return 'Check that your OPENAI_API_KEY is valid and has image generation permissions'
+    }
+
+    if (lowerMessage.includes('model') || lowerMessage.includes('not found')) {
+      return 'Check OPENAI_IMAGE_MODEL. Use gpt-image-2, or another model available to your account'
+    }
+
+    if (lowerMessage.includes('forbidden') || lowerMessage.includes('permission')) {
+      return 'Your OpenAI API key does not have permission for this operation or model'
+    }
+
+    return 'Check OpenAI API configuration and try again'
+  }
+
+  private extractStatusCode(error: unknown): number | undefined {
+    if (error && typeof error === 'object' && 'status' in error) {
+      return typeof error.status === 'number' ? error.status : undefined
+    }
+    return undefined
+  }
+}
+
+/**
+ * Creates a new OpenAI image client.
+ */
+export function createOpenAIImageClient(config: Config): Result<ImageClient, ImageAPIError> {
+  try {
+    const client = new OpenAI({
+      apiKey: config.openaiApiKey,
+    })
+    return Ok(new OpenAIImageClientImpl(client, config.openaiImageModel, config.imageQuality))
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return Err(
+      new ImageAPIError(
+        `Failed to initialize OpenAI image client: ${errorMessage}`,
+        'Verify your OPENAI_API_KEY is valid and the openai package is properly installed'
+      )
+    )
+  }
+}

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -1,0 +1,220 @@
+/**
+ * OpenAI text client for structured prompt enhancement.
+ */
+
+import OpenAI from 'openai'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import type { Config } from '../utils/config.js'
+import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import type { GenerationConfig, TextClient } from './textClient.js'
+
+interface ErrorWithCode extends Error {
+  code?: string
+  status?: number
+}
+
+interface OpenAITextResponse {
+  output_text?: string
+  output?: Array<{
+    content?: Array<{
+      type?: string
+      text?: string
+    }>
+  }>
+}
+
+function isNetworkError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
+    return networkErrorCodes.some(
+      (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
+    )
+  }
+  return false
+}
+
+class OpenAITextClientImpl implements TextClient {
+  private readonly client: OpenAI
+  private readonly modelName: string
+
+  constructor(config: Config) {
+    this.client = new OpenAI({
+      apiKey: config.openaiApiKey,
+    })
+    this.modelName = config.openaiTextModel
+  }
+
+  async generateText(
+    prompt: string,
+    config: GenerationConfig = {}
+  ): Promise<Result<string, ImageAPIError | NetworkError>> {
+    const validationResult = this.validatePromptInput(prompt)
+    if (!validationResult.success) {
+      return validationResult
+    }
+
+    const timeout = config.timeout ?? 15000
+
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('API call timeout')), timeout)
+      })
+
+      const response = (await Promise.race([
+        this.client.responses.create({
+          model: this.modelName,
+          input: this.buildInput(prompt, config),
+          ...(config.systemInstruction && { instructions: config.systemInstruction }),
+          max_output_tokens: config.maxTokens ?? 8192,
+          temperature: config.temperature ?? 0.7,
+        }),
+        timeoutPromise,
+      ])) as OpenAITextResponse
+
+      const responseText = this.extractResponseText(response)
+      if (!responseText || responseText.trim().length === 0) {
+        throw new Error('Empty response from OpenAI text API')
+      }
+
+      return Ok(responseText.trim())
+    } catch (error) {
+      return this.handleError(error, 'text generation')
+    }
+  }
+
+  async validateConnection(): Promise<Result<boolean, ImageAPIError | NetworkError>> {
+    try {
+      if (!this.client.responses) {
+        return Err(
+          new ImageAPIError(
+            'Failed to access OpenAI Responses API',
+            'Check your OPENAI_API_KEY configuration'
+          )
+        )
+      }
+      return Ok(true)
+    } catch (error) {
+      return this.handleError(error, 'connection validation')
+    }
+  }
+
+  private buildInput(prompt: string, config: GenerationConfig) {
+    if (!config.inputImage) {
+      return prompt
+    }
+
+    const mimeType = normalizeMimeType(config.inputImageMimeType ?? DEFAULT_MIME_TYPE)
+
+    return [
+      {
+        role: 'user' as const,
+        content: [
+          {
+            type: 'input_text' as const,
+            text: prompt,
+          },
+          {
+            type: 'input_image' as const,
+            image_url: `data:${mimeType};base64,${config.inputImage}`,
+            detail: 'auto' as const,
+          },
+        ],
+      },
+    ]
+  }
+
+  private extractResponseText(response: OpenAITextResponse): string {
+    if (typeof response.output_text === 'string') {
+      return response.output_text
+    }
+
+    const textParts =
+      response.output?.flatMap((item) =>
+        item.content
+          ?.filter((content) => content.type === 'output_text' && typeof content.text === 'string')
+          .map((content) => content.text ?? '')
+      ) ?? []
+
+    return textParts.join('')
+  }
+
+  private handleError(
+    error: unknown,
+    context: string
+  ): Result<never, ImageAPIError | NetworkError> {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+
+    if (isNetworkError(error)) {
+      return Err(
+        new NetworkError(
+          `Network error during OpenAI ${context}: ${errorMessage}`,
+          'Check your internet connection and try again'
+        )
+      )
+    }
+
+    return Err(
+      new ImageAPIError(
+        `Failed during OpenAI ${context}: ${errorMessage}`,
+        this.getAPIErrorSuggestion(errorMessage),
+        this.extractStatusCode(error)
+      )
+    )
+  }
+
+  private getAPIErrorSuggestion(errorMessage: string): string {
+    const lowerMessage = errorMessage.toLowerCase()
+
+    if (lowerMessage.includes('quota') || lowerMessage.includes('rate limit')) {
+      return 'You have exceeded your OpenAI API quota or rate limit. Wait before retrying or upgrade your plan'
+    }
+
+    if (lowerMessage.includes('unauthorized') || lowerMessage.includes('api key')) {
+      return 'Check that your OPENAI_API_KEY is valid'
+    }
+
+    if (lowerMessage.includes('model') || lowerMessage.includes('not found')) {
+      return 'Check OPENAI_TEXT_MODEL and ensure the model is available to your account'
+    }
+
+    return 'Check OpenAI API configuration and try again'
+  }
+
+  private extractStatusCode(error: unknown): number | undefined {
+    if (error && typeof error === 'object' && 'status' in error) {
+      return typeof error.status === 'number' ? error.status : undefined
+    }
+    return undefined
+  }
+
+  private validatePromptInput(prompt: string): Result<true, ImageAPIError> {
+    if (!prompt || prompt.trim().length === 0) {
+      return Err(new ImageAPIError('Empty prompt provided', 'Please provide a non-empty prompt'))
+    }
+
+    if (prompt.length > 100000) {
+      return Err(new ImageAPIError('Prompt too long', 'Please provide a shorter prompt'))
+    }
+
+    return Ok(true)
+  }
+}
+
+/**
+ * Creates a new OpenAI text client for prompt enhancement.
+ */
+export function createOpenAITextClient(config: Config): Result<TextClient, ImageAPIError> {
+  try {
+    return Ok(new OpenAITextClientImpl(config))
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+    return Err(
+      new ImageAPIError(
+        `Failed to initialize OpenAI Text client: ${errorMessage}`,
+        'Verify your OPENAI_API_KEY is valid and the openai package is properly installed'
+      )
+    )
+  }
+}

--- a/src/api/textClient.ts
+++ b/src/api/textClient.ts
@@ -1,0 +1,28 @@
+import type { Result } from '../types/result.js'
+import type { GeminiAPIError, ImageAPIError, NetworkError } from '../utils/errors.js'
+
+/**
+ * Options for text generation used by the prompt enhancer.
+ */
+export interface GenerationConfig {
+  temperature?: number
+  maxTokens?: number
+  timeout?: number
+  systemInstruction?: string
+  inputImage?: string
+  inputImageMimeType?: string
+  topP?: number
+  topK?: number
+}
+
+/**
+ * Provider-neutral text client for prompt enhancement.
+ */
+export interface TextClient {
+  generateText(
+    prompt: string,
+    config?: GenerationConfig
+  ): Promise<Result<string, GeminiAPIError | ImageAPIError | NetworkError>>
+
+  validateConnection(): Promise<Result<boolean, GeminiAPIError | ImageAPIError | NetworkError>>
+}

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -4,13 +4,14 @@
  */
 
 import * as path from 'node:path'
-import type { GeneratedImageResult } from '../api/geminiClient.js'
+import type { GeneratedImageResult } from '../api/imageClient.js'
 import type { McpToolResponse, StructuredContent } from '../types/mcp.js'
 import {
   type BaseError,
   ConfigError,
   FileOperationError,
   GeminiAPIError,
+  ImageAPIError,
   InputValidationError,
   NetworkError,
   SecurityError,
@@ -64,6 +65,7 @@ function convertErrorToStructured(error: BaseError | Error): {
     error instanceof InputValidationError ||
     error instanceof FileOperationError ||
     error instanceof GeminiAPIError ||
+    error instanceof ImageAPIError ||
     error instanceof NetworkError ||
     error instanceof ConfigError ||
     error instanceof SecurityError
@@ -115,6 +117,9 @@ export function createResponseBuilder(): ResponseBuilder {
         },
         metadata: {
           model: generationResult.metadata.model,
+          ...(generationResult.metadata.provider && {
+            provider: generationResult.metadata.provider,
+          }),
           processingTime: 0, // Not tracked in simplified version
           contextMethod: 'structured_prompt',
           timestamp: generationResult.metadata.timestamp.toISOString(),

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -4,7 +4,7 @@
  * Applies 7 best practices and 3 feature perspectives through intelligent selection
  */
 
-import type { GeminiTextClient } from '../api/geminiTextClient.js'
+import type { TextClient } from '../api/textClient.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { GeminiAPIError } from '../utils/errors.js'
@@ -88,7 +88,7 @@ export interface StructuredPromptGenerator {
  * Implementation of StructuredPromptGenerator using Gemini Flash
  */
 export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator {
-  constructor(private readonly geminiTextClient: GeminiTextClient) {}
+  constructor(private readonly textClient: TextClient) {}
 
   async generateStructuredPrompt(
     userPrompt: string,
@@ -124,7 +124,7 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
         ...(inputImageData && { inputImage: inputImageData }),
         ...(inputImageMimeType && { inputImageMimeType }),
       }
-      const result = await this.geminiTextClient.generateText(completePrompt, config)
+      const result = await this.textClient.generateText(completePrompt, config)
 
       if (!result.success) {
         return Err(result.error)
@@ -310,8 +310,6 @@ Now transform the user's request with similar attention to detail and creative e
 /**
  * Factory function to create StructuredPromptGenerator
  */
-export function createStructuredPromptGenerator(
-  geminiTextClient: GeminiTextClient
-): StructuredPromptGenerator {
-  return new StructuredPromptGeneratorImpl(geminiTextClient)
+export function createStructuredPromptGenerator(textClient: TextClient): StructuredPromptGenerator {
+  return new StructuredPromptGeneratorImpl(textClient)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,6 @@ if (args[0] === 'skills') {
   await import('./server-main.js')
 }
 
-export type { GeneratedImageResult } from './api/geminiClient.js'
+export type { GeneratedImageResult } from './api/imageClient.js'
 export { createMCPServer, MCPServerImpl } from './server/mcpServer.js'
 export type { GenerateImageParams, MCPServerConfig } from './types/mcp.js'

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -26,6 +26,50 @@ vi.mock('../../api/geminiClient', () => {
   }
 })
 
+// Mock the OpenAI image client for provider routing tests
+vi.mock('../../api/openaiImageClient', () => {
+  return {
+    createOpenAIImageClient: vi.fn().mockImplementation(() => {
+      const mockClient = {
+        generateImage: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            imageData: Buffer.from('mock-openai-image-data', 'utf-8'),
+            metadata: {
+              model: 'gpt-image-2',
+              provider: 'openai',
+              prompt: 'test prompt',
+              mimeType: 'image/png',
+              timestamp: new Date(),
+              inputImageProvided: false,
+            },
+          },
+        }),
+      }
+      return { success: true, data: mockClient }
+    }),
+  }
+})
+
+// Mock the OpenAI text client for provider routing tests
+vi.mock('../../api/openaiTextClient', () => {
+  return {
+    createOpenAITextClient: vi.fn().mockImplementation(() => {
+      const mockClient = {
+        generateText: vi.fn().mockResolvedValue({
+          success: true,
+          data: 'Enhanced OpenAI prompt with professional lighting and composition',
+        }),
+        validateConnection: vi.fn().mockResolvedValue({
+          success: true,
+          data: true,
+        }),
+      }
+      return { success: true, data: mockClient }
+    }),
+  }
+})
+
 // Mock the FileManager for unit tests
 vi.mock('../../business/fileManager', () => {
   return {
@@ -160,12 +204,21 @@ vi.mock('../../business/inputValidator', async () => {
 // Basic tests for MCP server startup and tool registration
 describe('MCP Server', () => {
   let originalApiKey: string | undefined
+  let originalImageProvider: string | undefined
+  let originalOpenAIApiKey: string | undefined
+  let originalOpenAIImageModel: string | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
     // Set up environment for testing
     originalApiKey = process.env.GEMINI_API_KEY
+    originalImageProvider = process.env.IMAGE_PROVIDER
+    originalOpenAIApiKey = process.env.OPENAI_API_KEY
+    originalOpenAIImageModel = process.env.OPENAI_IMAGE_MODEL
+    process.env.IMAGE_PROVIDER = undefined
     process.env.GEMINI_API_KEY = 'test-api-key-unit-tests'
+    process.env.OPENAI_API_KEY = undefined
+    process.env.OPENAI_IMAGE_MODEL = undefined
     process.env.IMAGE_OUTPUT_DIR = './test-output'
   })
 
@@ -176,6 +229,9 @@ describe('MCP Server', () => {
     } else {
       process.env.GEMINI_API_KEY = undefined
     }
+    process.env.IMAGE_PROVIDER = originalImageProvider
+    process.env.OPENAI_API_KEY = originalOpenAIApiKey
+    process.env.OPENAI_IMAGE_MODEL = originalOpenAIImageModel
   })
   it('should create MCP server instance', async () => {
     // Arrange & Act
@@ -392,6 +448,38 @@ describe('MCP Server', () => {
     expect(responseData.error.code).toBe('INPUT_VALIDATION_ERROR')
     expect(responseData.error.message).toContain('1 and 4000 characters')
     expect(responseData.error.suggestion).toContain('descriptive prompt')
+  })
+
+  it('should route image generation through OpenAI provider when configured', async () => {
+    // Arrange
+    process.env.IMAGE_PROVIDER = 'openai'
+    process.env.GEMINI_API_KEY = undefined
+    process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
+    process.env.OPENAI_IMAGE_MODEL = 'gpt-image-2'
+    const mcpServer = createMCPServer()
+
+    // Act
+    const result = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+    })
+
+    // Assert
+    expect(result).toBeDefined()
+    expect(result.isError).toBe(false)
+
+    const { createGeminiClient } = await import('../../api/geminiClient')
+    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+    const { createOpenAITextClient } = await import('../../api/openaiTextClient')
+
+    expect(createGeminiClient).not.toHaveBeenCalled()
+    expect(createOpenAIImageClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageProvider: 'openai',
+        openaiApiKey: 'test-openai-api-key-unit-tests',
+        openaiImageModel: 'gpt-image-2',
+      })
+    )
+    expect(createOpenAITextClient).toHaveBeenCalled()
   })
 })
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -13,8 +13,12 @@ import {
   type ListToolsResult,
 } from '@modelcontextprotocol/sdk/types.js'
 // API clients
-import { createGeminiClient, type GeminiClient } from '../api/geminiClient.js'
-import { createGeminiTextClient, type GeminiTextClient } from '../api/geminiTextClient.js'
+import { createGeminiClient } from '../api/geminiClient.js'
+import { createGeminiTextClient } from '../api/geminiTextClient.js'
+import type { ImageClient } from '../api/imageClient.js'
+import { createOpenAIImageClient } from '../api/openaiImageClient.js'
+import { createOpenAITextClient } from '../api/openaiTextClient.js'
+import type { TextClient } from '../api/textClient.js'
 // Business logic
 import { createFileManager, type FileManager } from '../business/fileManager.js'
 import { validateGenerateImageParams } from '../business/inputValidator.js'
@@ -54,8 +58,8 @@ export class MCPServerImpl {
   private responseBuilder: ResponseBuilder
   private securityManager: SecurityManager
   private structuredPromptGenerator: StructuredPromptGenerator | null = null
-  private geminiTextClient: GeminiTextClient | null = null
-  private geminiClient: GeminiClient | null = null
+  private textClient: TextClient | null = null
+  private imageClient: ImageClient | null = null
 
   constructor(config: Partial<MCPServerConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
@@ -183,40 +187,52 @@ export class MCPServerImpl {
   }
 
   /**
-   * Initialize Gemini clients lazily
+   * Initialize provider clients lazily.
    */
   private async initializeClients(): Promise<void> {
-    if (this.structuredPromptGenerator && this.geminiClient) return
-
     const configResult = getConfig()
     if (!configResult.success) {
       throw configResult.error
     }
+    const config = configResult.data
 
-    // Initialize Gemini Text Client for prompt generation
-    if (!this.geminiTextClient) {
-      const textClientResult = createGeminiTextClient(configResult.data)
+    if (this.imageClient && (config.skipPromptEnhancement || this.structuredPromptGenerator)) {
+      return
+    }
+
+    // Initialize Text Client for prompt generation when enhancement is enabled.
+    if (!config.skipPromptEnhancement && !this.textClient) {
+      const textClientResult =
+        config.imageProvider === 'openai'
+          ? createOpenAITextClient(config)
+          : createGeminiTextClient(config)
       if (!textClientResult.success) {
         throw textClientResult.error
       }
-      this.geminiTextClient = textClientResult.data
+      this.textClient = textClientResult.data
     }
 
     // Initialize Structured Prompt Generator
-    if (!this.structuredPromptGenerator) {
-      this.structuredPromptGenerator = createStructuredPromptGenerator(this.geminiTextClient)
+    if (!config.skipPromptEnhancement && this.textClient && !this.structuredPromptGenerator) {
+      this.structuredPromptGenerator = createStructuredPromptGenerator(this.textClient)
     }
 
-    // Initialize Gemini Client for image generation
-    if (!this.geminiClient) {
-      const clientResult = createGeminiClient(configResult.data)
+    // Initialize image generation client.
+    if (!this.imageClient) {
+      const clientResult =
+        config.imageProvider === 'openai'
+          ? createOpenAIImageClient(config)
+          : createGeminiClient(config)
       if (!clientResult.success) {
         throw clientResult.error
       }
-      this.geminiClient = clientResult.data
+      this.imageClient = clientResult.data
     }
 
-    this.logger.info('mcp-server', 'Gemini clients initialized')
+    this.logger.info('mcp-server', 'Image provider clients initialized', {
+      provider: config.imageProvider,
+      promptEnhancement: !config.skipPromptEnhancement,
+    })
   }
 
   /**
@@ -298,12 +314,12 @@ export class MCPServerImpl {
         this.logger.info('mcp-server', 'Prompt enhancement skipped (SKIP_PROMPT_ENHANCEMENT=true)')
       }
 
-      // Generate image using Gemini API
-      if (!this.geminiClient) {
-        throw new Error('Gemini client not initialized')
+      // Generate image using selected provider.
+      if (!this.imageClient) {
+        throw new Error('Image client not initialized')
       }
 
-      const generationResult = await this.geminiClient.generateImage({
+      const generationResult = await this.imageClient.generateImage({
         prompt: structuredPrompt,
         ...(inputImageData && { inputImage: inputImageData }),
         ...(inputImageMimeType && { inputImageMimeType }),

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -40,6 +40,13 @@ export type ImageSize = '1K' | '2K' | '4K'
 export type ImageQuality = 'fast' | 'balanced' | 'quality'
 
 /**
+ * Supported image providers.
+ * - 'gemini': Google Gemini/Nano Banana models (default)
+ * - 'openai': OpenAI GPT Image models such as gpt-image-2
+ */
+export type ImageProvider = 'gemini' | 'openai'
+
+/**
  * Supported quality preset values
  */
 export const IMAGE_QUALITY_VALUES: readonly ImageQuality[] = [
@@ -47,6 +54,11 @@ export const IMAGE_QUALITY_VALUES: readonly ImageQuality[] = [
   'balanced',
   'quality',
 ] as const
+
+/**
+ * Supported image provider values.
+ */
+export const IMAGE_PROVIDER_VALUES: readonly ImageProvider[] = ['gemini', 'openai'] as const
 
 /**
  * Gemini image generation model identifiers
@@ -131,6 +143,7 @@ export interface StructuredContent {
   }
   metadata: {
     model: string
+    provider?: string
     processingTime: number
     contextMethod: string
     timestamp: string

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -8,7 +8,11 @@ describe('config', () => {
   beforeEach(() => {
     // Mock process.env for each test
     process.env = { ...originalEnv }
+    process.env.IMAGE_PROVIDER = undefined
     process.env.GEMINI_API_KEY = undefined
+    process.env.OPENAI_API_KEY = undefined
+    process.env.OPENAI_IMAGE_MODEL = undefined
+    process.env.OPENAI_TEXT_MODEL = undefined
     process.env.IMAGE_OUTPUT_DIR = undefined
     process.env.IMAGE_QUALITY = undefined
   })
@@ -22,7 +26,11 @@ describe('config', () => {
     it('should return error when GEMINI_API_KEY is missing', () => {
       // Arrange
       const config = {
+        imageProvider: 'gemini' as const,
         geminiApiKey: '',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -44,7 +52,11 @@ describe('config', () => {
     it('should return error when GEMINI_API_KEY is too short', () => {
       // Arrange
       const config = {
+        imageProvider: 'gemini' as const,
         geminiApiKey: 'short',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -65,7 +77,11 @@ describe('config', () => {
     it('should return error when apiTimeout is invalid', () => {
       // Arrange
       const config = {
+        imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
         imageOutputDir: './output',
         apiTimeout: -1000, // Invalid negative timeout
         skipPromptEnhancement: false,
@@ -90,7 +106,11 @@ describe('config', () => {
 
       for (const quality of qualities) {
         const config = {
+          imageProvider: 'gemini' as const,
           geminiApiKey: 'valid-api-key-12345',
+          openaiApiKey: '',
+          openaiImageModel: 'gpt-image-2',
+          openaiTextModel: 'gpt-5.2',
           imageOutputDir: './output',
           apiTimeout: 30000,
           skipPromptEnhancement: false,
@@ -108,7 +128,11 @@ describe('config', () => {
     it('should reject invalid imageQuality value', () => {
       // Arrange
       const config = {
+        imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -132,7 +156,11 @@ describe('config', () => {
     it('should return success for valid config', () => {
       // Arrange
       const config = {
+        imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -146,6 +174,52 @@ describe('config', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data).toEqual(config)
+      }
+    })
+
+    it('should accept OpenAI provider without GEMINI_API_KEY', () => {
+      // Arrange
+      const config = {
+        imageProvider: 'openai' as const,
+        geminiApiKey: '',
+        openaiApiKey: 'test-openai-api-key-12345',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
+        imageOutputDir: './output',
+        apiTimeout: 30000,
+        skipPromptEnhancement: false,
+        imageQuality: 'fast' as const,
+      }
+
+      // Act
+      const result = validateConfig(config)
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it('should require OPENAI_API_KEY for OpenAI provider', () => {
+      // Arrange
+      const config = {
+        imageProvider: 'openai' as const,
+        geminiApiKey: '',
+        openaiApiKey: '',
+        openaiImageModel: 'gpt-image-2',
+        openaiTextModel: 'gpt-5.2',
+        imageOutputDir: './output',
+        apiTimeout: 30000,
+        skipPromptEnhancement: false,
+        imageQuality: 'fast' as const,
+      }
+
+      // Act
+      const result = validateConfig(config)
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ConfigError)
+        expect(result.error.message).toContain('OPENAI_API_KEY')
       }
     })
   })
@@ -179,6 +253,24 @@ describe('config', () => {
         expect(result.data.geminiApiKey).toBe('test-api-key-12345')
         expect(result.data.imageOutputDir).toBe('/custom/output')
         expect(result.data.apiTimeout).toBe(30000) // Default timeout
+      }
+    })
+
+    it('should load OpenAI provider config from environment', () => {
+      // Arrange
+      process.env.IMAGE_PROVIDER = 'openai'
+      process.env.OPENAI_API_KEY = 'test-openai-api-key-12345'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.imageProvider).toBe('openai')
+        expect(result.data.openaiApiKey).toBe('test-openai-api-key-12345')
+        expect(result.data.openaiImageModel).toBe('gpt-image-2')
+        expect(result.data.openaiTextModel).toBe('gpt-5.2')
       }
     })
 

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -30,7 +30,7 @@ describe('config', () => {
         geminiApiKey: '',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -56,7 +56,7 @@ describe('config', () => {
         geminiApiKey: 'short',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -81,7 +81,7 @@ describe('config', () => {
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: -1000, // Invalid negative timeout
         skipPromptEnhancement: false,
@@ -110,7 +110,7 @@ describe('config', () => {
           geminiApiKey: 'valid-api-key-12345',
           openaiApiKey: '',
           openaiImageModel: 'gpt-image-2',
-          openaiTextModel: 'gpt-5.2',
+          openaiTextModel: 'gpt-5-mini',
           imageOutputDir: './output',
           apiTimeout: 30000,
           skipPromptEnhancement: false,
@@ -132,7 +132,7 @@ describe('config', () => {
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -160,7 +160,7 @@ describe('config', () => {
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -184,7 +184,7 @@ describe('config', () => {
         geminiApiKey: '',
         openaiApiKey: 'test-openai-api-key-12345',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -205,7 +205,7 @@ describe('config', () => {
         geminiApiKey: '',
         openaiApiKey: '',
         openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5.2',
+        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -270,7 +270,7 @@ describe('config', () => {
         expect(result.data.imageProvider).toBe('openai')
         expect(result.data.openaiApiKey).toBe('test-openai-api-key-12345')
         expect(result.data.openaiImageModel).toBe('gpt-image-2')
-        expect(result.data.openaiTextModel).toBe('gpt-5.2')
+        expect(result.data.openaiTextModel).toBe('gpt-5-mini')
       }
     })
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,8 +3,8 @@
  * Handles environment variables and configuration validation
  */
 
-import type { ImageQuality } from '../types/mcp.js'
-import { IMAGE_QUALITY_VALUES } from '../types/mcp.js'
+import type { ImageProvider, ImageQuality } from '../types/mcp.js'
+import { IMAGE_PROVIDER_VALUES, IMAGE_QUALITY_VALUES } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { ConfigError } from './errors.js'
@@ -13,7 +13,11 @@ import { ConfigError } from './errors.js'
  * Configuration interface
  */
 export interface Config {
+  imageProvider: ImageProvider
   geminiApiKey: string
+  openaiApiKey: string
+  openaiImageModel: string
+  openaiTextModel: string
   imageOutputDir: string
   apiTimeout: number
   skipPromptEnhancement: boolean // Skip prompt enhancement for direct control
@@ -24,9 +28,20 @@ export interface Config {
  * Default configuration values
  */
 const DEFAULT_CONFIG = {
+  imageProvider: 'gemini',
   imageOutputDir: './output',
   apiTimeout: 30000, // 30 seconds
+  openaiImageModel: 'gpt-image-2',
+  openaiTextModel: 'gpt-5.2',
 } as const
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name]
+  if (!value || value === 'undefined' || value === 'null') {
+    return undefined
+  }
+  return value
+}
 
 /**
  * Validates the configuration
@@ -34,8 +49,21 @@ const DEFAULT_CONFIG = {
  * @returns Result containing validated config or ConfigError
  */
 export function validateConfig(config: Config): Result<Config, ConfigError> {
-  // Validate GEMINI_API_KEY
-  if (!config.geminiApiKey || config.geminiApiKey.trim().length === 0) {
+  // Validate IMAGE_PROVIDER
+  if (!IMAGE_PROVIDER_VALUES.includes(config.imageProvider)) {
+    return Err(
+      new ConfigError(
+        `Invalid IMAGE_PROVIDER value: "${config.imageProvider}". Valid options: ${IMAGE_PROVIDER_VALUES.join(', ')}`,
+        `Set IMAGE_PROVIDER to one of: ${IMAGE_PROVIDER_VALUES.join(', ')}`
+      )
+    )
+  }
+
+  // Validate GEMINI_API_KEY only when Gemini is the selected provider.
+  if (
+    config.imageProvider === 'gemini' &&
+    (!config.geminiApiKey || config.geminiApiKey.trim().length === 0)
+  ) {
     return Err(
       new ConfigError(
         'GEMINI_API_KEY is required but not provided',
@@ -44,11 +72,58 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  if (config.geminiApiKey.length < 10) {
+  if (config.imageProvider === 'gemini' && config.geminiApiKey.length < 10) {
     return Err(
       new ConfigError(
         'GEMINI_API_KEY appears to be invalid - must be at least 10 characters',
         'Set the GEMINI_API_KEY environment variable to your valid Google AI API key'
+      )
+    )
+  }
+
+  // Validate OPENAI_API_KEY only when OpenAI is the selected provider.
+  if (
+    config.imageProvider === 'openai' &&
+    (!config.openaiApiKey || config.openaiApiKey.trim().length === 0)
+  ) {
+    return Err(
+      new ConfigError(
+        'OPENAI_API_KEY is required but not provided',
+        'Set OPENAI_API_KEY environment variable with your OpenAI API key'
+      )
+    )
+  }
+
+  if (config.imageProvider === 'openai' && config.openaiApiKey.length < 10) {
+    return Err(
+      new ConfigError(
+        'OPENAI_API_KEY appears to be invalid - must be at least 10 characters',
+        'Set the OPENAI_API_KEY environment variable to your valid OpenAI API key'
+      )
+    )
+  }
+
+  if (
+    config.imageProvider === 'openai' &&
+    (!config.openaiImageModel || config.openaiImageModel.trim().length === 0)
+  ) {
+    return Err(
+      new ConfigError(
+        'OPENAI_IMAGE_MODEL cannot be empty',
+        'Set OPENAI_IMAGE_MODEL to a valid OpenAI image model such as gpt-image-2'
+      )
+    )
+  }
+
+  if (
+    config.imageProvider === 'openai' &&
+    !config.skipPromptEnhancement &&
+    (!config.openaiTextModel || config.openaiTextModel.trim().length === 0)
+  ) {
+    return Err(
+      new ConfigError(
+        'OPENAI_TEXT_MODEL cannot be empty when prompt enhancement is enabled',
+        'Set OPENAI_TEXT_MODEL to a valid OpenAI text model, or set SKIP_PROMPT_ENHANCEMENT=true'
       )
     )
   }
@@ -92,11 +167,15 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
  */
 export function getConfig(): Result<Config, ConfigError> {
   const config: Config = {
-    geminiApiKey: process.env['GEMINI_API_KEY'] || '',
-    imageOutputDir: process.env['IMAGE_OUTPUT_DIR'] || DEFAULT_CONFIG.imageOutputDir,
+    imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
+    geminiApiKey: readEnv('GEMINI_API_KEY') || '',
+    openaiApiKey: readEnv('OPENAI_API_KEY') || '',
+    openaiImageModel: readEnv('OPENAI_IMAGE_MODEL') || DEFAULT_CONFIG.openaiImageModel,
+    openaiTextModel: readEnv('OPENAI_TEXT_MODEL') || DEFAULT_CONFIG.openaiTextModel,
+    imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     apiTimeout: DEFAULT_CONFIG.apiTimeout,
-    skipPromptEnhancement: process.env['SKIP_PROMPT_ENHANCEMENT'] === 'true',
-    imageQuality: (process.env['IMAGE_QUALITY'] || 'fast') as ImageQuality,
+    skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',
+    imageQuality: (readEnv('IMAGE_QUALITY') || 'fast') as ImageQuality,
   }
 
   return validateConfig(config)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,7 +32,7 @@ const DEFAULT_CONFIG = {
   imageOutputDir: './output',
   apiTimeout: 30000, // 30 seconds
   openaiImageModel: 'gpt-image-2',
-  openaiTextModel: 'gpt-5.2',
+  openaiTextModel: 'gpt-5-mini',
 } as const
 
 function readEnv(name: string): string | undefined {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -177,6 +177,70 @@ export class GeminiAPIError extends BaseError {
 }
 
 /**
+ * Error for image provider API failures.
+ */
+export class ImageAPIError extends BaseError {
+  readonly code = 'IMAGE_API_ERROR'
+  private customSuggestion: string | undefined
+
+  constructor(
+    message: string,
+    suggestionOrContext?: string | Record<string, unknown>,
+    statusCodeOrContext?: number | Record<string, unknown>
+  ) {
+    let context: Record<string, unknown> | undefined
+    let statusCode: number | undefined
+    let customSuggestion: string | undefined
+
+    if (typeof suggestionOrContext === 'string') {
+      statusCode = typeof statusCodeOrContext === 'number' ? statusCodeOrContext : undefined
+      customSuggestion = suggestionOrContext
+    } else {
+      context = suggestionOrContext
+      statusCode = typeof statusCodeOrContext === 'number' ? statusCodeOrContext : undefined
+    }
+
+    super(message, context)
+    this.customSuggestion = customSuggestion
+    Object.defineProperty(this, 'statusCode', { value: statusCode, writable: false })
+  }
+
+  get suggestion(): string {
+    if (this.customSuggestion) {
+      return this.customSuggestion
+    }
+
+    if (
+      this.context &&
+      'suggestion' in this.context &&
+      typeof this.context['suggestion'] === 'string'
+    ) {
+      return this.context['suggestion']
+    }
+
+    const message = this.message.toLowerCase()
+
+    if (message.includes('authentication') || message.includes('unauthorized')) {
+      return 'Check provider API key environment variables and ensure they have proper permissions'
+    }
+    if (message.includes('rate limit') || message.includes('quota') || message.includes('429')) {
+      return 'Wait before retrying or upgrade API quota limits'
+    }
+    if (message.includes('model') || message.includes('access') || message.includes('permission')) {
+      return 'Ensure the selected image model is available to your account'
+    }
+    if (message.includes('timeout') || message.includes('503') || message.includes('502')) {
+      return 'The image provider is temporarily unavailable. Please retry after a few moments'
+    }
+    if (message.includes('payload') || message.includes('request') || message.includes('400')) {
+      return 'Check request format and parameters according to the provider API specification'
+    }
+
+    return 'Check image provider configuration and retry the request'
+  }
+}
+
+/**
  * Error for network-related failures with intelligent suggestion system
  */
 export class NetworkError extends BaseError {


### PR DESCRIPTION
## Summary
- add provider-aware config with IMAGE_PROVIDER=gemini|openai
- add OpenAI image generation/editing with OPENAI_IMAGE_MODEL defaulting to gpt-image-2
- add OpenAI Responses prompt enhancement so OpenAI mode does not require a Gemini key
- document local fork usage and provider-specific behavior

## Validation
- npm run check:all