### PR TITLE
Release prep for v0.11.0: OpenAI provider polish + shared error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,9 @@ To use OpenAI instead, get an OpenAI API key and set:
 ```bash
 IMAGE_PROVIDER=openai
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_IMAGE_MODEL=gpt-image-2
 ```
 
-OpenAI mode does not require `GEMINI_API_KEY`. Prompt enhancement also runs through OpenAI by default, using `OPENAI_TEXT_MODEL` (defaults to `gpt-5-mini`). Set `SKIP_PROMPT_ENHANCEMENT=true` if you want prompts sent directly to the image model.
+OpenAI mode requires organization verification — see [Using the OpenAI provider](#using-the-openai-provider) below for setup details and feature differences.
 
 ### 2. MCP Configuration
 
@@ -139,7 +138,6 @@ args = ["/absolute/path/to/mcp-image/dist/index.js"]
 [mcp_servers.mcp-image.env]
 IMAGE_PROVIDER = "openai"
 OPENAI_API_KEY = "your_openai_api_key_here"
-OPENAI_IMAGE_MODEL = "gpt-image-2"
 IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
 ```
 
@@ -175,7 +173,6 @@ For OpenAI GPT Image from a local fork:
       "env": {
         "IMAGE_PROVIDER": "openai",
         "OPENAI_API_KEY": "your_openai_api_key_here",
-        "OPENAI_IMAGE_MODEL": "gpt-image-2",
         "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"
       }
     }
@@ -206,7 +203,6 @@ npm run build
 claude mcp add mcp-image --scope user \
   --env IMAGE_PROVIDER=openai \
   --env OPENAI_API_KEY=your-openai-api-key \
-  --env OPENAI_IMAGE_MODEL=gpt-image-2 \
   --env IMAGE_OUTPUT_DIR=/absolute/path/to/images \
   -- node /absolute/path/to/mcp-image/dist/index.js
 ```
@@ -264,14 +260,22 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 | `IMAGE_PROVIDER` | `gemini` | `gemini` or `openai` |
 | `GEMINI_API_KEY` | - | Required when `IMAGE_PROVIDER=gemini` |
 | `OPENAI_API_KEY` | - | Required when `IMAGE_PROVIDER=openai` |
-| `OPENAI_IMAGE_MODEL` | `gpt-image-2` | OpenAI image model to use |
-| `OPENAI_TEXT_MODEL` | `gpt-5-mini` | OpenAI text model used for prompt enhancement |
 
-OpenAI provider notes:
-- `quality` maps to OpenAI image quality as `fast -> low`, `balanced -> medium`, `quality -> high`.
-- `aspectRatio` maps to the closest supported GPT Image size: square, landscape, or portrait.
-- `imageSize` maps to valid `gpt-image-2` dimensions, including 2K/4K outputs. OpenAI 2K+ outputs are experimental and can be slower/more expensive.
-- `useGoogleSearch` is Gemini-specific and is rejected in OpenAI mode because Google Search grounding is not available through the OpenAI image provider.
+### Using the OpenAI provider
+
+Set `IMAGE_PROVIDER=openai` to use OpenAI for both prompt enhancement and image generation. mcp-image currently uses `gpt-4o-mini` for prompt enhancement and `gpt-image-2` for image generation. These model choices are fixed by the server and are not configurable through environment variables.
+
+OpenAI may require organization verification before allowing access to `gpt-image-2`. If image generation fails with a 403 permission or verification error, check your organization settings: https://platform.openai.com/settings/organization/general
+
+OpenAI provider behavior:
+
+- Supports text-to-image and image-to-image generation.
+- Supports `aspectRatio`, mapped to the closest supported OpenAI image size.
+- Supports `imageSize` values `1K`, `2K`, and `4K`.
+- Maps `quality` as `fast -> low`, `balanced -> medium`, and `quality -> high`.
+- Does not support `useGoogleSearch`; that option is only available with the Gemini provider.
+
+Prompt enhancement uses a separate OpenAI Responses API call. Set `SKIP_PROMPT_ENHANCEMENT=true` to send prompts directly to the image model.
 
 ## Usage Examples
 
@@ -317,8 +321,8 @@ Your prompt is automatically enhanced with rich details about lighting, material
 ### `generate_image` Tool
 
 The server uses a two-stage process with separate models for each stage:
-1. **Prompt Optimization** (Gemini 2.5 Flash by default, or OpenAI Responses in OpenAI mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
-2. **Image Generation** (Nano Banana 2/Pro by default, or `OPENAI_IMAGE_MODEL` in OpenAI mode): Creates the final image. Model varies by quality preset and provider configuration.
+1. **Prompt Optimization** (Gemini 2.5 Flash by default, or `gpt-4o-mini` via OpenAI Responses in OpenAI mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
+2. **Image Generation** (Nano Banana 2/Pro by default, or `gpt-image-2` in OpenAI mode): Creates the final image. In Gemini mode the model varies by quality preset; in OpenAI mode the model is pinned and `quality` maps to OpenAI's `low`/`medium`/`high`.
 
 #### Parameters
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.42.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server for AI image generation",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -35,24 +35,10 @@
         },
         {
           "name": "OPENAI_API_KEY",
-          "description": "OpenAI API key for image generation when IMAGE_PROVIDER=openai",
+          "description": "OpenAI API key for image generation when IMAGE_PROVIDER=openai. Requires OpenAI organization verification to access gpt-image-2 (https://platform.openai.com/settings/organization/general)",
           "isRequired": false,
           "format": "string",
           "isSecret": true
-        },
-        {
-          "name": "OPENAI_IMAGE_MODEL",
-          "description": "OpenAI image model to use when IMAGE_PROVIDER=openai (defaults to gpt-image-2)",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false
-        },
-        {
-          "name": "OPENAI_TEXT_MODEL",
-          "description": "OpenAI text model used for prompt enhancement when IMAGE_PROVIDER=openai (defaults to gpt-5-mini)",
-          "isRequired": false,
-          "format": "string",
-          "isSecret": false
         },
         {
           "name": "IMAGE_OUTPUT_DIR",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.10.0",
+  "version": "0.11.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -180,8 +180,8 @@ describe('geminiClient', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error).toBeInstanceOf(GeminiAPIError)
-        expect(result.error.message).toContain('Failed to generate image')
-        expect(result.error.message).toContain('API quota exceeded')
+        expect(result.error.message).toBe('Failed to generate image with Gemini')
+        expect(result.error.context?.upstreamMessage).toContain('API quota exceeded')
       }
     })
 

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -27,8 +27,6 @@ describe('geminiClient', () => {
     imageProvider: 'gemini',
     geminiApiKey: 'test-api-key-12345',
     openaiApiKey: '',
-    openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -59,8 +59,6 @@ describe('GeminiTextClient', () => {
       imageProvider: 'gemini',
       geminiApiKey: 'test-api-key',
       openaiApiKey: '',
-      openaiImageModel: 'gpt-image-2',
-      openaiTextModel: 'gpt-5-mini',
       imageOutputDir: './test-output',
       apiTimeout: 30000,
       skipPromptEnhancement: false,

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -132,7 +132,8 @@ describe('GeminiTextClient', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error).toBeInstanceOf(GeminiAPIError)
-        expect(result.error.message.toLowerCase()).toContain('rate limit')
+        const upstream = String(result.error.context?.upstreamMessage ?? '').toLowerCase()
+        expect(upstream).toContain('rate limit')
       }
     })
 

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -197,6 +197,48 @@ describe('openaiImageClient', () => {
       )
     })
 
+    it('should fall back to square size when aspect ratio is malformed', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      // 'abc:1' parses to NaN width — current behavior is silent fallback to square.
+      // Pinning this so future changes that promote it to a typed error are deliberate.
+      await clientResult.data.generateImage({
+        prompt: 'Generate an image',
+        // biome-ignore lint/suspicious/noExplicitAny: deliberately exercise malformed input
+        aspectRatio: 'abc:1' as any,
+      })
+
+      expect(mockGenerate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          size: '1024x1024',
+        })
+      )
+    })
+
+    it('should return ImageAPIError when response data array is empty', async () => {
+      mockGenerate.mockResolvedValue({ data: [] })
+
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate image',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.message).toContain('No image data returned')
+      }
+    })
+
     it('should reject useGoogleSearch because OpenAI image generation does not support Google Search grounding', async () => {
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
@@ -217,6 +259,10 @@ describe('openaiImageClient', () => {
     })
 
     it('should map 2K imageSize with landscape aspect ratio to a GPT Image 2 size', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
       if (!clientResult.success) return
@@ -236,6 +282,10 @@ describe('openaiImageClient', () => {
     })
 
     it('should map 4K imageSize with portrait aspect ratio to a GPT Image 2 size', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+      })
+
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
       if (!clientResult.success) return

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -208,10 +208,11 @@ describe('openaiImageClient', () => {
 
       // 'abc:1' parses to NaN width — current behavior is silent fallback to square.
       // Pinning this so future changes that promote it to a typed error are deliberate.
+      // 'abc:1' is not a valid AspectRatio union member; cast through unknown to
+      // exercise the runtime fallback branch in mapSize.
       await clientResult.data.generateImage({
         prompt: 'Generate an image',
-        // biome-ignore lint/suspicious/noExplicitAny: deliberately exercise malformed input
-        aspectRatio: 'abc:1' as any,
+        aspectRatio: 'abc:1' as unknown as never,
       })
 
       expect(mockGenerate).toHaveBeenCalledWith(

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -27,8 +27,6 @@ describe('openaiImageClient', () => {
     imageProvider: 'openai',
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
-    openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
@@ -303,28 +301,6 @@ describe('openaiImageClient', () => {
           size: '2160x3840',
         })
       )
-    })
-
-    it('should reject imageSize for non-GPT Image 2 OpenAI models', async () => {
-      const clientResult = createOpenAIImageClient({
-        ...testConfig,
-        openaiImageModel: 'gpt-image-1.5',
-      })
-      expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
-
-      const result = await clientResult.data.generateImage({
-        prompt: 'Generate a 4K product photo',
-        imageSize: '4K',
-      })
-
-      expect(result.success).toBe(false)
-      expect(mockGenerate).not.toHaveBeenCalled()
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ImageAPIError)
-        expect(result.error.message).toContain('imageSize')
-        expect(result.error.message).toContain('gpt-image-2')
-      }
     })
 
     it('should return ImageAPIError when response has no base64 image data', async () => {

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -126,6 +126,35 @@ describe('openaiTextClient', () => {
     }
   })
 
+  it('should reject prompts that exceed the 100k character cap', async () => {
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const overLimitPrompt = 'a'.repeat(100_001)
+    const result = await clientResult.data.generateText(overLimitPrompt)
+
+    expect(result.success).toBe(false)
+    expect(mockResponsesCreate).not.toHaveBeenCalled()
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(result.error.message).toContain('Prompt too long')
+    }
+  })
+
+  it('should accept prompts at the 100k character cap', async () => {
+    mockResponsesCreate.mockResolvedValue({ output_text: 'ok' })
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const atLimitPrompt = 'a'.repeat(100_000)
+    const result = await clientResult.data.generateText(atLimitPrompt)
+
+    expect(result.success).toBe(true)
+  })
+
   it('should return NetworkError for network failures', async () => {
     const networkError = new Error('ECONNRESET') as Error & { code: string }
     networkError.code = 'ECONNRESET'

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -122,7 +122,7 @@ describe('openaiTextClient', () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error).toBeInstanceOf(ImageAPIError)
-      expect(result.error.message).toContain('Empty response')
+      expect(result.error.context?.upstreamMessage).toContain('Empty response')
     }
   })
 

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -58,13 +58,16 @@ describe('openaiTextClient', () => {
     })
 
     expect(result.success).toBe(true)
-    expect(mockResponsesCreate).toHaveBeenCalledWith({
-      model: 'gpt-5-mini',
-      input: 'make a product photo',
-      instructions: 'Enhance image prompts',
-      max_output_tokens: 1000,
-      temperature: 0.2,
-    })
+    expect(mockResponsesCreate).toHaveBeenCalledWith(
+      {
+        model: 'gpt-5-mini',
+        input: 'make a product photo',
+        instructions: 'Enhance image prompts',
+        max_output_tokens: 1000,
+        temperature: 0.2,
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
     if (result.success) {
       expect(result.data).toBe('Enhanced prompt with precise lighting and composition')
     }
@@ -102,7 +105,8 @@ describe('openaiTextClient', () => {
             ],
           },
         ],
-      })
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     )
   })
 

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -23,8 +23,6 @@ describe('openaiTextClient', () => {
     imageProvider: 'openai',
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
-    openaiImageModel: 'gpt-image-2',
-    openaiTextModel: 'gpt-5-mini',
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
@@ -60,11 +58,12 @@ describe('openaiTextClient', () => {
     expect(result.success).toBe(true)
     expect(mockResponsesCreate).toHaveBeenCalledWith(
       {
-        model: 'gpt-5-mini',
+        model: 'gpt-4o-mini',
         input: 'make a product photo',
         instructions: 'Enhance image prompts',
         max_output_tokens: 1000,
         temperature: 0.2,
+        top_p: 0.95,
       },
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     )

--- a/src/api/errorClassification.ts
+++ b/src/api/errorClassification.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared error classification helpers for API client implementations.
+ * Used by both Gemini and OpenAI clients to identify network failures
+ * and extract HTTP status codes from SDK errors.
+ */
+
+export interface ErrorWithCode extends Error {
+  code?: string
+  status?: number
+}
+
+const NETWORK_ERROR_CODES = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'] as const
+
+export function isNetworkError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return NETWORK_ERROR_CODES.some(
+    (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
+  )
+}
+
+export function extractStatusCode(error: unknown): number | undefined {
+  if (error && typeof error === 'object' && 'status' in error) {
+    const status = (error as ErrorWithCode).status
+    return typeof status === 'number' ? status : undefined
+  }
+  return undefined
+}

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -237,11 +237,14 @@ class GeminiClientImpl implements GeminiClient {
         if (asRecord['error']) {
           const error = asRecord['error'] as Record<string, unknown>
           return Err(
-            new GeminiAPIError(`Gemini API Error: ${error['message'] || 'Unknown error'}`, {
-              code: error['code'],
-              status: error['status'],
-              details: error['details'] || responseStructure,
+            new GeminiAPIError('Gemini API returned an error response', {
+              provider: 'gemini',
               stage: 'api_error',
+              upstreamMessage:
+                typeof error['message'] === 'string' ? error['message'] : 'Unknown error',
+              statusCode: typeof error['status'] === 'number' ? error['status'] : undefined,
+              rawErrorCode: error['code'],
+              rawDetails: error['details'] || responseStructure,
             })
           )
         }

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -443,7 +443,8 @@ class GeminiClientImpl implements GeminiClient {
         provider: 'gemini',
         prompt,
         upstreamMessage: errorMessage,
-        suggestion: 'Check your API key, quota, and prompt validity. Try again with a different prompt',
+        suggestion:
+          'Check your API key, quota, and prompt validity. Try again with a different prompt',
       })
     )
   }

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -414,7 +414,7 @@ class GeminiClientImpl implements GeminiClient {
     if (isNetworkError(error)) {
       return Err(
         new NetworkError(
-          `Network error during image generation: ${errorMessage}`,
+          'Network error during Gemini image generation',
           'Check your internet connection and try again',
           error instanceof Error ? error : undefined
         )
@@ -425,8 +425,13 @@ class GeminiClientImpl implements GeminiClient {
     if (this.isAPIError(error)) {
       return Err(
         new GeminiAPIError(
-          `Failed to generate image: ${errorMessage}`,
-          this.getAPIErrorSuggestion(errorMessage),
+          'Failed to generate image with Gemini',
+          {
+            provider: 'gemini',
+            prompt,
+            upstreamMessage: errorMessage,
+            suggestion: this.getAPIErrorSuggestion(errorMessage),
+          },
           extractStatusCode(error)
         )
       )
@@ -434,10 +439,12 @@ class GeminiClientImpl implements GeminiClient {
 
     // Generic API error
     return Err(
-      new GeminiAPIError(
-        `Failed to generate image with prompt "${prompt}": ${errorMessage}`,
-        'Check your API key, quota, and prompt validity. Try again with a different prompt'
-      )
+      new GeminiAPIError('Failed to generate image with Gemini', {
+        provider: 'gemini',
+        prompt,
+        upstreamMessage: errorMessage,
+        suggestion: 'Check your API key, quota, and prompt validity. Try again with a different prompt',
+      })
     )
   }
 

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -12,6 +12,7 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type {
   GeneratedImageResult,
   ImageApiParams,
@@ -129,10 +130,6 @@ function isGeminiResponse(obj: unknown): obj is GeminiResponse {
 
   // Check direct candidates property (direct response)
   return 'candidates' in response && Array.isArray(response['candidates'])
-}
-
-interface ErrorWithCode extends Error {
-  code?: string
 }
 
 /**
@@ -414,7 +411,7 @@ class GeminiClientImpl implements GeminiClient {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 
     // Check if it's a network error
-    if (this.isNetworkError(error)) {
+    if (isNetworkError(error)) {
       return Err(
         new NetworkError(
           `Network error during image generation: ${errorMessage}`,
@@ -430,7 +427,7 @@ class GeminiClientImpl implements GeminiClient {
         new GeminiAPIError(
           `Failed to generate image: ${errorMessage}`,
           this.getAPIErrorSuggestion(errorMessage),
-          this.extractStatusCode(error)
+          extractStatusCode(error)
         )
       )
     }
@@ -442,16 +439,6 @@ class GeminiClientImpl implements GeminiClient {
         'Check your API key, quota, and prompt validity. Try again with a different prompt'
       )
     )
-  }
-
-  private isNetworkError(error: unknown): boolean {
-    if (error instanceof Error) {
-      const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
-      return networkErrorCodes.some(
-        (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
-      )
-    }
-    return false
   }
 
   private isAPIError(error: unknown): boolean {
@@ -478,13 +465,6 @@ class GeminiClientImpl implements GeminiClient {
     }
 
     return 'Check your API configuration and try again'
-  }
-
-  private extractStatusCode(error: unknown): number | undefined {
-    if (error && typeof error === 'object' && 'status' in error) {
-      return typeof error.status === 'number' ? error.status : undefined
-    }
-    return undefined
   }
 }
 

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -211,7 +211,7 @@ class GeminiTextClientImpl implements GeminiTextClient {
     if (isNetworkError(error)) {
       return Err(
         new NetworkError(
-          `Network error during ${context}: ${errorMessage}`,
+          `Network error during Gemini ${context}`,
           'Check your internet connection and try again'
         )
       )
@@ -220,19 +220,23 @@ class GeminiTextClientImpl implements GeminiTextClient {
     // Check for API errors
     if (this.isAPIError(error)) {
       return Err(
-        new GeminiAPIError(
-          `Failed during ${context}: ${errorMessage}`,
-          this.getAPIErrorSuggestion(errorMessage)
-        )
+        new GeminiAPIError(`Failed during Gemini ${context}`, {
+          provider: 'gemini',
+          stage: context,
+          upstreamMessage: errorMessage,
+          suggestion: this.getAPIErrorSuggestion(errorMessage),
+        })
       )
     }
 
     // Generic error
     return Err(
-      new GeminiAPIError(
-        `Failed during ${context}: ${errorMessage}`,
-        'Check your API configuration and try again'
-      )
+      new GeminiAPIError(`Failed during Gemini ${context}`, {
+        provider: 'gemini',
+        stage: context,
+        upstreamMessage: errorMessage,
+        suggestion: 'Check your API configuration and try again',
+      })
     )
   }
 

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -49,6 +49,7 @@ interface GeminiAIInstance {
         thinkingConfig?: {
           thinkingBudget: number
         }
+        abortSignal?: AbortSignal
       }
     }): Promise<{
       text: string
@@ -107,11 +108,6 @@ class GeminiTextClientImpl implements GeminiTextClient {
    */
   private async callGeminiAPI(prompt: string, config: GenerationConfig): Promise<string> {
     try {
-      // Generate content with timeout
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error('API call timeout')), config.timeout || 15000)
-      })
-
       // Build contents based on whether input image is provided (multimodal support)
       let contents:
         | string
@@ -142,8 +138,8 @@ class GeminiTextClientImpl implements GeminiTextClient {
         contents = prompt
       }
 
-      // Call Gemini API
-      const apiCall = this.genai.models.generateContent({
+      // Call Gemini API with timeout via AbortSignal
+      const response = await this.genai.models.generateContent({
         model: this.modelName,
         contents,
         config: {
@@ -157,10 +153,9 @@ class GeminiTextClientImpl implements GeminiTextClient {
           thinkingConfig: {
             thinkingBudget: 0,
           },
+          abortSignal: AbortSignal.timeout(config.timeout || 15000),
         },
       })
-
-      const response = await Promise.race([apiCall, timeoutPromise])
 
       // Extract text from response - handling both possible response structures
       let responseText: string

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -10,6 +10,7 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE } from '../utils/mimeUtils.js'
+import { isNetworkError } from './errorClassification.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
 
 /**
@@ -212,7 +213,7 @@ class GeminiTextClientImpl implements GeminiTextClient {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
 
     // Check for network errors
-    if (this.isNetworkError(error)) {
+    if (isNetworkError(error)) {
       return Err(
         new NetworkError(
           `Network error during ${context}: ${errorMessage}`,
@@ -238,16 +239,6 @@ class GeminiTextClientImpl implements GeminiTextClient {
         'Check your API configuration and try again'
       )
     )
-  }
-
-  private isNetworkError(error: unknown): boolean {
-    if (error instanceof Error) {
-      const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
-      return networkErrorCodes.some(
-        (code) => error.message.includes(code) || (error as { code?: string }).code === code
-      )
-    }
-    return false
   }
 
   private isAPIError(error: unknown): boolean {

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -244,7 +244,7 @@ class OpenAIImageClientImpl implements ImageClient {
     if (isNetworkError(error)) {
       return Err(
         new NetworkError(
-          `Network error during OpenAI image generation: ${errorMessage}`,
+          'Network error during OpenAI image generation',
           'Check your internet connection and try again',
           error instanceof Error ? error : undefined
         )
@@ -253,8 +253,13 @@ class OpenAIImageClientImpl implements ImageClient {
 
     return Err(
       new ImageAPIError(
-        `Failed to generate image with OpenAI for prompt "${prompt}": ${errorMessage}`,
-        this.getAPIErrorSuggestion(errorMessage),
+        'Failed to generate image with OpenAI',
+        {
+          provider: 'openai',
+          prompt,
+          upstreamMessage: errorMessage,
+          suggestion: this.getAPIErrorSuggestion(errorMessage),
+        },
         extractStatusCode(error)
       )
     )

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -108,18 +108,13 @@ function mimeTypeToExtension(mimeType: string): string {
   }
 }
 
-function supportsFlexibleGPTImageSizes(modelName: string): boolean {
-  return modelName === 'gpt-image-2' || modelName.startsWith('gpt-image-2-')
-}
+const OPENAI_IMAGE_MODEL = 'gpt-image-2'
 
 function hasInputImage(params: ImageApiParams): params is ImageEditApiParams {
   return typeof params.inputImage === 'string' && params.inputImage.length > 0
 }
 
-function validateOpenAIOptions(
-  params: ImageApiParams,
-  modelName: string
-): Result<true, ImageAPIError> {
+function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIError> {
   if (params.useGoogleSearch) {
     return Err(
       new ImageAPIError(
@@ -129,24 +124,15 @@ function validateOpenAIOptions(
     )
   }
 
-  if (params.imageSize && !supportsFlexibleGPTImageSizes(modelName)) {
-    return Err(
-      new ImageAPIError(
-        `imageSize requires gpt-image-2 when using the OpenAI image provider; current model is ${modelName}`,
-        'Remove imageSize, set OPENAI_IMAGE_MODEL=gpt-image-2, or use IMAGE_PROVIDER=gemini for Gemini size presets.'
-      )
-    )
-  }
-
   return Ok(true)
 }
 
 class OpenAIImageClientImpl implements ImageClient {
   private readonly outputFormat: OpenAIOutputFormat = 'png'
+  private readonly modelName = OPENAI_IMAGE_MODEL
 
   constructor(
     private readonly client: OpenAI,
-    private readonly modelName: string,
     private readonly defaultQuality: ImageQuality = 'fast'
   ) {}
 
@@ -154,7 +140,7 @@ class OpenAIImageClientImpl implements ImageClient {
     params: ImageApiParams
   ): Promise<Result<GeneratedImageResult, ImageAPIError | NetworkError>> {
     try {
-      const optionsResult = validateOpenAIOptions(params, this.modelName)
+      const optionsResult = validateOpenAIOptions(params)
       if (!optionsResult.success) {
         return optionsResult
       }
@@ -277,7 +263,7 @@ class OpenAIImageClientImpl implements ImageClient {
     }
 
     if (lowerMessage.includes('model') || lowerMessage.includes('not found')) {
-      return 'Check OPENAI_IMAGE_MODEL. Use gpt-image-2, or another model available to your account'
+      return 'Verify your OpenAI organization has been verified to use gpt-image-2 (https://platform.openai.com/settings/organization/general)'
     }
 
     if (lowerMessage.includes('forbidden') || lowerMessage.includes('permission')) {
@@ -296,7 +282,7 @@ export function createOpenAIImageClient(config: Config): Result<ImageClient, Ima
     const client = new OpenAI({
       apiKey: config.openaiApiKey,
     })
-    return Ok(new OpenAIImageClientImpl(client, config.openaiImageModel, config.imageQuality))
+    return Ok(new OpenAIImageClientImpl(client, config.imageQuality))
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'
     return Err(

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -14,6 +14,7 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
 type OpenAIImageSize =
@@ -33,11 +34,6 @@ type OpenAIOutputFormat = 'png'
 type OpenAIImageGenerateRequest = ImageGenerateParamsNonStreaming
 type OpenAIImageEditRequest = ImageEditParamsNonStreaming
 type ImageEditApiParams = ImageApiParams & { inputImage: string }
-
-interface ErrorWithCode extends Error {
-  code?: string
-  status?: number
-}
 
 function mapQuality(quality: ImageQuality): OpenAIImageQuality {
   switch (quality) {
@@ -110,16 +106,6 @@ function mimeTypeToExtension(mimeType: string): string {
     default:
       return 'png'
   }
-}
-
-function isNetworkError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
-    return networkErrorCodes.some(
-      (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
-    )
-  }
-  return false
 }
 
 function supportsFlexibleGPTImageSizes(modelName: string): boolean {
@@ -269,7 +255,7 @@ class OpenAIImageClientImpl implements ImageClient {
       new ImageAPIError(
         `Failed to generate image with OpenAI for prompt "${prompt}": ${errorMessage}`,
         this.getAPIErrorSuggestion(errorMessage),
-        this.extractStatusCode(error)
+        extractStatusCode(error)
       )
     )
   }
@@ -294,13 +280,6 @@ class OpenAIImageClientImpl implements ImageClient {
     }
 
     return 'Check OpenAI API configuration and try again'
-  }
-
-  private extractStatusCode(error: unknown): number | undefined {
-    if (error && typeof error === 'object' && 'status' in error) {
-      return typeof error.status === 'number' ? error.status : undefined
-    }
-    return undefined
   }
 }
 

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -8,12 +8,8 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
-
-interface ErrorWithCode extends Error {
-  code?: string
-  status?: number
-}
 
 interface OpenAITextResponse {
   output_text?: string
@@ -23,16 +19,6 @@ interface OpenAITextResponse {
       text?: string
     }>
   }>
-}
-
-function isNetworkError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const networkErrorCodes = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND']
-    return networkErrorCodes.some(
-      (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
-    )
-  }
-  return false
 }
 
 class OpenAITextClientImpl implements TextClient {
@@ -159,7 +145,7 @@ class OpenAITextClientImpl implements TextClient {
       new ImageAPIError(
         `Failed during OpenAI ${context}: ${errorMessage}`,
         this.getAPIErrorSuggestion(errorMessage),
-        this.extractStatusCode(error)
+        extractStatusCode(error)
       )
     )
   }
@@ -180,13 +166,6 @@ class OpenAITextClientImpl implements TextClient {
     }
 
     return 'Check OpenAI API configuration and try again'
-  }
-
-  private extractStatusCode(error: unknown): number | undefined {
-    if (error && typeof error === 'object' && 'status' in error) {
-      return typeof error.status === 'number' ? error.status : undefined
-    }
-    return undefined
   }
 
   private validatePromptInput(prompt: string): Result<true, ImageAPIError> {

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -131,7 +131,7 @@ class OpenAITextClientImpl implements TextClient {
     if (isNetworkError(error)) {
       return Err(
         new NetworkError(
-          `Network error during OpenAI ${context}: ${errorMessage}`,
+          `Network error during OpenAI ${context}`,
           'Check your internet connection and try again'
         )
       )
@@ -139,8 +139,13 @@ class OpenAITextClientImpl implements TextClient {
 
     return Err(
       new ImageAPIError(
-        `Failed during OpenAI ${context}: ${errorMessage}`,
-        this.getAPIErrorSuggestion(errorMessage),
+        `Failed during OpenAI ${context}`,
+        {
+          provider: 'openai',
+          stage: context,
+          upstreamMessage: errorMessage,
+          suggestion: this.getAPIErrorSuggestion(errorMessage),
+        },
         extractStatusCode(error)
       )
     )

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -44,20 +44,16 @@ class OpenAITextClientImpl implements TextClient {
     const timeout = config.timeout ?? 15000
 
     try {
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error('API call timeout')), timeout)
-      })
-
-      const response = (await Promise.race([
-        this.client.responses.create({
+      const response = (await this.client.responses.create(
+        {
           model: this.modelName,
           input: this.buildInput(prompt, config),
           ...(config.systemInstruction && { instructions: config.systemInstruction }),
           max_output_tokens: config.maxTokens ?? 8192,
           temperature: config.temperature ?? 0.7,
-        }),
-        timeoutPromise,
-      ])) as OpenAITextResponse
+        },
+        { signal: AbortSignal.timeout(timeout) }
+      )) as OpenAITextResponse
 
       const responseText = this.extractResponseText(response)
       if (!responseText || responseText.trim().length === 0) {

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -21,15 +21,16 @@ interface OpenAITextResponse {
   }>
 }
 
+const OPENAI_TEXT_MODEL = 'gpt-4o-mini'
+
 class OpenAITextClientImpl implements TextClient {
   private readonly client: OpenAI
-  private readonly modelName: string
+  private readonly modelName = OPENAI_TEXT_MODEL
 
   constructor(config: Config) {
     this.client = new OpenAI({
       apiKey: config.openaiApiKey,
     })
-    this.modelName = config.openaiTextModel
   }
 
   async generateText(
@@ -41,7 +42,7 @@ class OpenAITextClientImpl implements TextClient {
       return validationResult
     }
 
-    const timeout = config.timeout ?? 15000
+    const timeout = config.timeout ?? 30000
 
     try {
       const response = (await this.client.responses.create(
@@ -51,6 +52,7 @@ class OpenAITextClientImpl implements TextClient {
           ...(config.systemInstruction && { instructions: config.systemInstruction }),
           max_output_tokens: config.maxTokens ?? 8192,
           temperature: config.temperature ?? 0.7,
+          top_p: config.topP ?? 0.95,
         },
         { signal: AbortSignal.timeout(timeout) }
       )) as OpenAITextResponse
@@ -163,7 +165,7 @@ class OpenAITextClientImpl implements TextClient {
     }
 
     if (lowerMessage.includes('model') || lowerMessage.includes('not found')) {
-      return 'Check OPENAI_TEXT_MODEL and ensure the model is available to your account'
+      return 'Ensure gpt-4o-mini is available to your OpenAI account'
     }
 
     return 'Check OpenAI API configuration and try again'

--- a/src/business/__tests__/responseBuilder.test.ts
+++ b/src/business/__tests__/responseBuilder.test.ts
@@ -205,6 +205,36 @@ describe('ResponseBuilder', () => {
       expect(errorData.error.suggestion).toBe('Please try again later or upgrade your API quota')
     })
 
+    it('should expose allowlisted context fields in details for GeminiAPIError', () => {
+      const error = new GeminiAPIError('Failed to generate image with Gemini', {
+        provider: 'gemini',
+        prompt: 'a photograph of a cat',
+        upstreamMessage: 'content policy violation: NSFW request',
+        suggestion: 'Rephrase the prompt',
+      })
+
+      const response = responseBuilder.buildErrorResponse(error)
+      const errorData = JSON.parse(response.content[0].text)
+
+      expect(errorData.error.details).toBeDefined()
+      expect(errorData.error.details.provider).toBe('gemini')
+      expect(errorData.error.details.upstreamMessage).toContain('content policy violation')
+      expect(errorData.error.details.prompt).toBeUndefined()
+    })
+
+    it('should redact API keys from upstreamMessage in details', () => {
+      const error = new GeminiAPIError('Failed to generate image with Gemini', {
+        provider: 'gemini',
+        upstreamMessage: 'Auth failed for OPENAI_API_KEY=sk-proj-ABCDEF123456789',
+      })
+
+      const response = responseBuilder.buildErrorResponse(error)
+      const errorData = JSON.parse(response.content[0].text)
+
+      expect(errorData.error.details.upstreamMessage).toContain('[REDACTED]')
+      expect(errorData.error.details.upstreamMessage).not.toContain('sk-proj-ABCDEF123456789')
+    })
+
     it('should create error response for NetworkError', () => {
       const error = new NetworkError(
         'Network connection failed',

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -16,10 +16,43 @@ import {
   NetworkError,
   SecurityError,
 } from '../utils/errors.js'
+import { sanitizeText } from '../utils/logger.js'
 import { getMimeTypeFromExtension, SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.js'
 
 const UNKNOWN_ERROR_CODE = 'UNKNOWN_ERROR'
 const DEFAULT_ERROR_SUGGESTION = 'Please try again or contact support if the problem persists'
+
+/**
+ * Context keys safe to surface in MCP error responses. Anything not on this
+ * list (notably `prompt`, which the caller already supplied, and any future
+ * additions) stays out of the wire format.
+ */
+const SAFE_CONTEXT_KEYS = ['provider', 'stage', 'statusCode'] as const
+
+/**
+ * Project an error's context object into a sanitized subset suitable for
+ * inclusion in caller-visible error responses. The upstream API message is
+ * passed through the logger's redaction patterns before exposure.
+ */
+function buildPublicDetails(
+  context: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!context) return undefined
+
+  const details: Record<string, unknown> = {}
+
+  for (const key of SAFE_CONTEXT_KEYS) {
+    if (context[key] !== undefined) {
+      details[key] = context[key]
+    }
+  }
+
+  if (typeof context['upstreamMessage'] === 'string') {
+    details['upstreamMessage'] = sanitizeText(context['upstreamMessage'])
+  }
+
+  return Object.keys(details).length > 0 ? details : undefined
+}
 
 /**
  * Interface for response builder functionality
@@ -56,6 +89,7 @@ function convertErrorToStructured(error: BaseError | Error): {
   message: string
   suggestion: string
   timestamp: string
+  details?: Record<string, unknown>
 } {
   const baseError = {
     timestamp: new Date().toISOString(),
@@ -70,11 +104,13 @@ function convertErrorToStructured(error: BaseError | Error): {
     error instanceof ConfigError ||
     error instanceof SecurityError
   ) {
+    const details = buildPublicDetails(error.context)
     return {
       ...baseError,
       code: error.code,
       message: error.message,
       suggestion: error.suggestion,
+      ...(details && { details }),
     }
   }
 

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -108,7 +108,7 @@ function convertErrorToStructured(error: BaseError | Error): {
     return {
       ...baseError,
       code: error.code,
-      message: error.message,
+      message: sanitizeText(error.message),
       suggestion: error.suggestion,
       ...(details && { details }),
     }

--- a/src/server/__tests__/errorHandler.test.ts
+++ b/src/server/__tests__/errorHandler.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../utils/logger', () => ({
     warn = vi.fn()
     info = vi.fn()
   },
+  sanitizeText: (input: string) => input,
 }))
 
 describe('ErrorHandler', () => {

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -206,7 +206,6 @@ describe('MCP Server', () => {
   let originalApiKey: string | undefined
   let originalImageProvider: string | undefined
   let originalOpenAIApiKey: string | undefined
-  let originalOpenAIImageModel: string | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -214,11 +213,9 @@ describe('MCP Server', () => {
     originalApiKey = process.env.GEMINI_API_KEY
     originalImageProvider = process.env.IMAGE_PROVIDER
     originalOpenAIApiKey = process.env.OPENAI_API_KEY
-    originalOpenAIImageModel = process.env.OPENAI_IMAGE_MODEL
     process.env.IMAGE_PROVIDER = undefined
     process.env.GEMINI_API_KEY = 'test-api-key-unit-tests'
     process.env.OPENAI_API_KEY = undefined
-    process.env.OPENAI_IMAGE_MODEL = undefined
     process.env.IMAGE_OUTPUT_DIR = './test-output'
   })
 
@@ -231,7 +228,6 @@ describe('MCP Server', () => {
     }
     process.env.IMAGE_PROVIDER = originalImageProvider
     process.env.OPENAI_API_KEY = originalOpenAIApiKey
-    process.env.OPENAI_IMAGE_MODEL = originalOpenAIImageModel
   })
   it('should create MCP server instance', async () => {
     // Arrange & Act
@@ -455,7 +451,6 @@ describe('MCP Server', () => {
     process.env.IMAGE_PROVIDER = 'openai'
     process.env.GEMINI_API_KEY = undefined
     process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
-    process.env.OPENAI_IMAGE_MODEL = 'gpt-image-2'
     const mcpServer = createMCPServer()
 
     // Act
@@ -476,7 +471,6 @@ describe('MCP Server', () => {
       expect.objectContaining({
         imageProvider: 'openai',
         openaiApiKey: 'test-openai-api-key-unit-tests',
-        openaiImageModel: 'gpt-image-2',
       })
     )
     expect(createOpenAITextClient).toHaveBeenCalled()

--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -119,7 +119,7 @@ function convertErrorToStructured(error: Error): {
     return {
       ...baseError,
       code: error.code,
-      message: error.message,
+      message: sanitizeText(error.message),
       suggestion: error.suggestion,
       ...(details && { details }),
     }

--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -12,7 +12,29 @@ import {
   NetworkError,
   type Result,
 } from '../utils/errors.js'
-import { Logger } from '../utils/logger.js'
+import { Logger, sanitizeText } from '../utils/logger.js'
+
+const SAFE_CONTEXT_KEYS = ['provider', 'stage', 'statusCode'] as const
+
+function buildPublicDetails(
+  context: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!context) return undefined
+
+  const details: Record<string, unknown> = {}
+
+  for (const key of SAFE_CONTEXT_KEYS) {
+    if (context[key] !== undefined) {
+      details[key] = context[key]
+    }
+  }
+
+  if (typeof context['upstreamMessage'] === 'string') {
+    details['upstreamMessage'] = sanitizeText(context['upstreamMessage'])
+  }
+
+  return Object.keys(details).length > 0 ? details : undefined
+}
 
 // Create logger instance for error handling
 const logger = new Logger()
@@ -92,28 +114,14 @@ function convertErrorToStructured(error: Error): {
     error instanceof NetworkError ||
     error instanceof ConfigError
   ) {
-    const errorResponse = {
+    const details = error instanceof GeminiAPIError ? buildPublicDetails(error.context) : undefined
+
+    return {
       ...baseError,
       code: error.code,
       message: error.message,
       suggestion: error.suggestion,
-    } as Record<string, unknown>
-
-    // Include context details for GeminiAPIError to provide better debugging info
-    if (error instanceof GeminiAPIError && error.context) {
-      // Add non-sensitive context information
-      const { suggestion, ...otherContext } = error.context as Record<string, unknown>
-      if (Object.keys(otherContext).length > 0) {
-        errorResponse['details'] = otherContext
-      }
-    }
-
-    return errorResponse as {
-      code: string
-      message: string
-      suggestion: string
-      timestamp: string
-      details?: Record<string, unknown>
+      ...(details && { details }),
     }
   }
 

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -11,8 +11,6 @@ describe('config', () => {
     process.env.IMAGE_PROVIDER = undefined
     process.env.GEMINI_API_KEY = undefined
     process.env.OPENAI_API_KEY = undefined
-    process.env.OPENAI_IMAGE_MODEL = undefined
-    process.env.OPENAI_TEXT_MODEL = undefined
     process.env.IMAGE_OUTPUT_DIR = undefined
     process.env.IMAGE_QUALITY = undefined
   })

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -29,8 +29,6 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: '',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -55,8 +53,6 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'short',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -80,8 +76,6 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: -1000, // Invalid negative timeout
         skipPromptEnhancement: false,
@@ -109,8 +103,6 @@ describe('config', () => {
           imageProvider: 'gemini' as const,
           geminiApiKey: 'valid-api-key-12345',
           openaiApiKey: '',
-          openaiImageModel: 'gpt-image-2',
-          openaiTextModel: 'gpt-5-mini',
           imageOutputDir: './output',
           apiTimeout: 30000,
           skipPromptEnhancement: false,
@@ -131,8 +123,6 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -159,8 +149,6 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -183,8 +171,6 @@ describe('config', () => {
         imageProvider: 'openai' as const,
         geminiApiKey: '',
         openaiApiKey: 'test-openai-api-key-12345',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -204,8 +190,6 @@ describe('config', () => {
         imageProvider: 'openai' as const,
         geminiApiKey: '',
         openaiApiKey: '',
-        openaiImageModel: 'gpt-image-2',
-        openaiTextModel: 'gpt-5-mini',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -269,8 +253,6 @@ describe('config', () => {
       if (result.success) {
         expect(result.data.imageProvider).toBe('openai')
         expect(result.data.openaiApiKey).toBe('test-openai-api-key-12345')
-        expect(result.data.openaiImageModel).toBe('gpt-image-2')
-        expect(result.data.openaiTextModel).toBe('gpt-5-mini')
       }
     })
 

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -184,6 +184,20 @@ describe('Logger', () => {
       )
     })
 
+    it('should redact OPENAI_API_KEY in environment variable format', () => {
+      // Arrange
+      const message = 'Starting service with OPENAI_API_KEY=sk-proj-ABCDEF123456789'
+
+      // Act
+      logger.info('config', message)
+
+      // Assert
+      expect(mockConsoleError).toHaveBeenCalledWith(expect.stringContaining('[REDACTED]'))
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.not.stringContaining('sk-proj-ABCDEF123456789')
+      )
+    })
+
     it('should redact URLs in log messages', () => {
       // Arrange
       const message = 'Fetching data from https://api.example.com/v1/data?key=secret'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,8 +16,6 @@ export interface Config {
   imageProvider: ImageProvider
   geminiApiKey: string
   openaiApiKey: string
-  openaiImageModel: string
-  openaiTextModel: string
   imageOutputDir: string
   apiTimeout: number
   skipPromptEnhancement: boolean // Skip prompt enhancement for direct control
@@ -31,8 +29,6 @@ const DEFAULT_CONFIG = {
   imageProvider: 'gemini',
   imageOutputDir: './output',
   apiTimeout: 30000, // 30 seconds
-  openaiImageModel: 'gpt-image-2',
-  openaiTextModel: 'gpt-5-mini',
 } as const
 
 function readEnv(name: string): string | undefined {
@@ -103,31 +99,6 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  if (
-    config.imageProvider === 'openai' &&
-    (!config.openaiImageModel || config.openaiImageModel.trim().length === 0)
-  ) {
-    return Err(
-      new ConfigError(
-        'OPENAI_IMAGE_MODEL cannot be empty',
-        'Set OPENAI_IMAGE_MODEL to a valid OpenAI image model such as gpt-image-2'
-      )
-    )
-  }
-
-  if (
-    config.imageProvider === 'openai' &&
-    !config.skipPromptEnhancement &&
-    (!config.openaiTextModel || config.openaiTextModel.trim().length === 0)
-  ) {
-    return Err(
-      new ConfigError(
-        'OPENAI_TEXT_MODEL cannot be empty when prompt enhancement is enabled',
-        'Set OPENAI_TEXT_MODEL to a valid OpenAI text model, or set SKIP_PROMPT_ENHANCEMENT=true'
-      )
-    )
-  }
-
   // Validate apiTimeout
   if (config.apiTimeout <= 0) {
     return Err(
@@ -170,8 +141,6 @@ export function getConfig(): Result<Config, ConfigError> {
     imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
     geminiApiKey: readEnv('GEMINI_API_KEY') || '',
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
-    openaiImageModel: readEnv('OPENAI_IMAGE_MODEL') || DEFAULT_CONFIG.openaiImageModel,
-    openaiTextModel: readEnv('OPENAI_TEXT_MODEL') || DEFAULT_CONFIG.openaiTextModel,
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     apiTimeout: DEFAULT_CONFIG.apiTimeout,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,23 +7,17 @@ import { GEMINI_MODELS } from '../types/mcp.js'
 import { SUPPORTED_EXTENSIONS } from './mimeUtils.js'
 
 /**
- * Structured error format for consistent error reporting
- */
-export interface StructuredError {
-  code: string
-  message: string
-  suggestion: string
-  timestamp: string
-  context?: Record<string, unknown>
-}
-
-/**
  * Result type pattern for explicit error handling
  */
 export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }
 
 /**
- * Base class for all application errors with structured error support
+ * Base class for all application errors with structured error support.
+ *
+ * Caller-visible error fields (code, message, suggestion) are available
+ * directly on the instance. Raw upstream details and prompt content live
+ * in `context` and must be projected through a sanitizer (see
+ * `responseBuilder.buildPublicDetails`) before being placed on the wire.
  */
 export abstract class BaseError extends Error {
   abstract readonly code: string
@@ -36,16 +30,6 @@ export abstract class BaseError extends Error {
     this.name = this.constructor.name
     this.timestamp = new Date().toISOString()
     this.context = context
-  }
-
-  toStructuredError(): StructuredError {
-    return {
-      code: this.code,
-      message: this.message,
-      suggestion: this.suggestion,
-      timestamp: this.timestamp,
-      ...(this.context && { context: this.context }),
-    }
   }
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,6 +24,7 @@ interface StructuredLogEntry {
 export class Logger {
   private readonly sensitivePatterns = [
     /GEMINI_API_KEY=([^\s]+)/gi,
+    /OPENAI_API_KEY=([^\s]+)/gi,
     /api[_-]?key[^\s]*[:=]\s*([^\s]+)/gi,
     /password[^\s]*[:=]\s*([^\s]+)/gi,
     /bearer\s+([a-zA-Z0-9\-._~+/]+=*)/gi,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -18,31 +18,62 @@ interface StructuredLogEntry {
   sessionId?: string
 }
 
+const SENSITIVE_PATTERNS = [
+  /GEMINI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /OPENAI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /api[_-]?key[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /password[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /bearer\s+([a-zA-Z0-9\-._~+/]+=*)/gi,
+  /secret[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /token[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /(sk-(?:proj-)?[A-Za-z0-9_-]{16,})/g,
+]
+
+const URL_PATTERNS = [
+  /(https?:\/\/[^\s]+)/gi, // URLs - separate to handle differently
+]
+
+const FILTER_PATTERNS = [
+  /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/g, // Credit card numbers
+  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN
+  /\b(?:\+?1[-.]?)?\(?\d{3}\)?[-.]?\d{3}[-.]?\d{4}\b/g, // Phone numbers
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/gi, // Emails
+]
+
+/**
+ * Sanitize a string by redacting sensitive information.
+ * Exposed at module scope so non-Logger code paths (response builders,
+ * error handlers) can sanitize before placing values into caller-visible
+ * fields without instantiating a Logger.
+ */
+export function sanitizeText(input: string): string {
+  let sanitized = input
+
+  for (const pattern of SENSITIVE_PATTERNS) {
+    sanitized = sanitized.replace(pattern, (match, group1: string) =>
+      match.replace(group1, '[REDACTED]')
+    )
+  }
+
+  sanitized = sanitized.replace(/\bapi[_-]?key\b/gi, '[REDACTED]')
+  sanitized = sanitized.replace(/\bgemini[_-]?api[_-]?key\b/gi, '[REDACTED]')
+  sanitized = sanitized.replace(/\b[A-Za-z0-9]{20,}\b/g, '[REDACTED]')
+
+  for (const pattern of URL_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '[URL_REDACTED]')
+  }
+
+  for (const pattern of FILTER_PATTERNS) {
+    sanitized = sanitized.replace(pattern, '[FILTERED]')
+  }
+
+  return sanitized
+}
+
 /**
  * Logger class for structured logging with sensitive data protection
  */
 export class Logger {
-  private readonly sensitivePatterns = [
-    /GEMINI_API_KEY=([^\s]+)/gi,
-    /OPENAI_API_KEY=([^\s]+)/gi,
-    /api[_-]?key[^\s]*[:=]\s*([^\s]+)/gi,
-    /password[^\s]*[:=]\s*([^\s]+)/gi,
-    /bearer\s+([a-zA-Z0-9\-._~+/]+=*)/gi,
-    /secret[^\s]*[:=]\s*([^\s]+)/gi,
-    /token[^\s]*[:=]\s*([^\s]+)/gi,
-  ]
-
-  private readonly urlPatterns = [
-    /(https?:\/\/[^\s]+)/gi, // URLs - separate to handle differently
-  ]
-
-  private readonly filterPatterns = [
-    /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/g, // Credit card numbers
-    /\b\d{3}-\d{2}-\d{4}\b/g, // SSN
-    /\b(?:\+?1[-.]?)?\(?\d{3}\)?[-.]?\d{3}[-.]?\d{4}\b/g, // Phone numbers
-    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/gi, // Emails
-  ]
-
   private readonly keyBasedSensitivePatterns = [
     /api[_-]?key/i,
     /gemini[_-]?api[_-]?key/i,
@@ -140,36 +171,9 @@ export class Logger {
 
   /**
    * Sanitize string content by redacting sensitive information
-   * @param input String to sanitize
-   * @returns Sanitized string
    */
   private sanitizeString(input: string): string {
-    let sanitized = input
-
-    // Redact sensitive data patterns (API keys, passwords, etc.)
-    for (const pattern of this.sensitivePatterns) {
-      sanitized = sanitized.replace(pattern, (match, group1) => match.replace(group1, '[REDACTED]'))
-    }
-
-    // Additional broad filter for API key-like strings in text
-    // Remove any reference to API key terms even in plain text
-    sanitized = sanitized.replace(/\bapi[_-]?key\b/gi, '[REDACTED]')
-    sanitized = sanitized.replace(/\bgemini[_-]?api[_-]?key\b/gi, '[REDACTED]')
-
-    // Remove long alphanumeric strings that might be API keys or secrets
-    sanitized = sanitized.replace(/\b[A-Za-z0-9]{20,}\b/g, '[REDACTED]')
-
-    // Redact URLs with specific label
-    for (const pattern of this.urlPatterns) {
-      sanitized = sanitized.replace(pattern, '[URL_REDACTED]')
-    }
-
-    // Filter personal information patterns
-    for (const pattern of this.filterPatterns) {
-      sanitized = sanitized.replace(pattern, '[FILTERED]')
-    }
-
-    return sanitized
+    return sanitizeText(input)
   }
 
   /**


### PR DESCRIPTION
## Summary

Post-merge polish for the OpenAI provider added in #87, prepared for the v0.11.0 release.

The branch consolidates fixes flagged during code/security review of #87, hardens the error handling that the OpenAI path shares with the Gemini path, and pins OpenAI model selection so users cannot accidentally pick incompatible models. Tests, README, and `server.json` are updated to match.

## Changes

### Shared error handling
- Extract `isNetworkError` / `extractStatusCode` / `ErrorWithCode` into `src/api/errorClassification.ts` and migrate all four API clients to it.
- Replace the `Promise.race` + `setTimeout` timeout pattern with `AbortSignal.timeout` in both text clients so the abort propagates into the underlying HTTP request.

### Caller-visible error sanitization
- Move upstream API error text out of the user-facing `message` field and into the structured `context` object.
- Surface an allowlisted, sanitized subset of context (`provider`, `stage`, `statusCode`, `upstreamMessage`) to MCP callers via the new `details` field on error responses, so genuine causes (`invalid_api_key`, content policy rejections, etc.) reach the client without leaking secrets.
- Apply the same allowlist in the legacy `errorHandler.ts` for consistency.
- Run `error.message` through `sanitizeText` as defense-in-depth, and broaden logger redaction patterns to cover JSON-style key/value forms and bare `sk-` tokens.

### OpenAI provider tightening
- Pin the OpenAI text model to `gpt-4o-mini` and the image model to `gpt-image-2`. The corresponding `OPENAI_TEXT_MODEL` and `OPENAI_IMAGE_MODEL` environment variables are removed; mcp-image now manages OpenAI model choice the same way it manages the Gemini path. This eliminates the foot-gun where users could pick reasoning-line models that reject sampling parameters, and lets the implementation drop the model-aware `imageSize` validation branch.
- Bump the OpenAI text-client default timeout to 30s. Gemini stays at 15s.

### Tests
- New tests for the malformed `aspectRatio` fallback, the empty `data: []` response branch, the 100k character prompt cap boundary, the new `OPENAI_API_KEY=` redaction pattern, and the allowlist projection in `responseBuilder`.
- Existing tests updated to assert on `context.upstreamMessage` instead of the sanitized user-facing `message`.

### Docs
- README gains a dedicated **Using the OpenAI provider** section covering the OpenAI organization verification requirement, the supported parameters, the single feature gap (`useGoogleSearch` is Gemini-only), and how to skip prompt enhancement.
- `server.json` mentions the verification requirement on `OPENAI_API_KEY` and drops the now-removed model env vars.

## Versioning

Bumped to `0.11.0` (minor): adds the OpenAI provider as a new capability for users of `0.10.0`. The removed env vars were never released.

## Test plan

- [x] `npm run check:all` (biome lint + format + dpdm + tsc + vitest) — green, 244 tests
- [ ] Manual smoke test: Gemini route generates one image
- [ ] Manual smoke test: OpenAI route generates one image (pending org verification)
- [ ] Confirm error path returns sanitized `details.upstreamMessage` for an invalid OpenAI key

🤖 Generated with [Claude Code](https://claude.com/claude-code)