### PR TITLE
fix(server.json): shorten description to fit 100-char registry limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/mcp-image",
-  "description": "AI image generation and editing with prompt optimization and quality presets. Powered by Nano Banana or OpenAI GPT Image",
+  "description": "AI image generation and editing with prompt optimization and quality presets",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

`mcp-publisher publish` against the MCP Registry fails with a 422 because
`server.json#description` is longer than the registry's 100-character limit:

```
Error: publish failed: server returned status 422: {"title":"Unprocessable Entity",
"status":422,"detail":"validation failed","errors":[{"message":"expected length <= 100",
"location":"body.description","value":"AI image generation and editing with prompt
optimization and quality presets. Powered by Nano Banana or OpenAI GPT Image"}]}
```

The previous description was 120 characters. This PR trims it to 76 characters by
dropping the trailing "Powered by Nano Banana or OpenAI GPT Image" clause and keeping
the capability description. Model branding is still surfaced through the README and
package tags, so discoverability is unaffected.

## Test plan

- [x] `node -e "require('./server.json').description.length"` returns ≤ 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)