### PR TITLE
feat: add REMOVE_WATERMARK post-generation step for all providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ claude mcp add mcp-image --env GEMINI_API_KEY=your-api-key --env IMAGE_QUALITY=b
 
 Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and send your prompts directly to the image generator. Useful when you need full control over the exact prompt wording.
 
+### Remove AI Watermark
+
+Set `REMOVE_WATERMARK=true` to strip AI watermarks from every generated image as a post-generation step, regardless of provider. This removes visible marks (e.g. the Gemini / nano banana "sparkle"), invisible watermarks (e.g. SynthID), and provenance metadata (C2PA/EXIF). The cleaned image overwrites the original in place — no duplicate file is produced.
+
+This feature shells out to the external Python tool [`remove-ai-watermarks`](https://github.com/wiltodelta/remove-ai-watermarks), which you must install separately. It is invoked in `all` mode, so the invisible-watermark step requires `torch` + `diffusers`, a GPU, and a ~2GB model download (slow on first run); see that project's README for installation.
+
+Removal is best-effort: if the tool is not installed or fails, a warning is logged and the original (un-cleaned) image is returned so generation still succeeds.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REMOVE_WATERMARK` | `false` | Set to `true` to remove AI watermarks from generated images |
+| `REMOVE_WATERMARK_CMD` | `remove-ai-watermarks` | Command to invoke (e.g. a full path like `/venv/bin/remove-ai-watermarks`, or `python -m remove_ai_watermarks`). Paths containing spaces are not supported |
+| `REMOVE_WATERMARK_TIMEOUT` | `600000` | Timeout in milliseconds for the removal command |
+
 ### Provider Configuration
 
 | Variable | Default | Description |

--- a/server.json
+++ b/server.json
@@ -60,6 +60,27 @@
           "isRequired": false,
           "format": "boolean",
           "isSecret": false
+        },
+        {
+          "name": "REMOVE_WATERMARK",
+          "description": "Set to 'true' to remove AI watermarks (visible + invisible + provenance metadata) from generated images as a post-generation step. Requires the external Python tool 'remove-ai-watermarks' (https://github.com/wiltodelta/remove-ai-watermarks) installed and on PATH; best-effort with graceful fallback",
+          "isRequired": false,
+          "format": "boolean",
+          "isSecret": false
+        },
+        {
+          "name": "REMOVE_WATERMARK_CMD",
+          "description": "Command used to invoke the remove-ai-watermarks CLI (defaults to 'remove-ai-watermarks'). Accepts a full path or a 'python -m remove_ai_watermarks' style invocation; paths with spaces are not supported",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
+        },
+        {
+          "name": "REMOVE_WATERMARK_TIMEOUT",
+          "description": "Timeout in milliseconds for the watermark removal command (defaults to 600000)",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": false
         }
       ],
       "features": {

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -35,6 +35,9 @@ describe('geminiClient', () => {
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
+    removeWatermark: false,
+    removeWatermarkCmd: 'remove-ai-watermarks',
+    removeWatermarkTimeout: 600000,
     imageQuality: 'fast',
   }
 

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -62,6 +62,9 @@ describe('GeminiTextClient', () => {
       imageOutputDir: './test-output',
       apiTimeout: 30000,
       skipPromptEnhancement: false,
+      removeWatermark: false,
+      removeWatermarkCmd: 'remove-ai-watermarks',
+      removeWatermarkTimeout: 600000,
       imageQuality: 'fast',
     }
 

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -30,6 +30,9 @@ describe('openaiImageClient', () => {
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
+    removeWatermark: false,
+    removeWatermarkCmd: 'remove-ai-watermarks',
+    removeWatermarkTimeout: 600000,
     imageQuality: 'fast',
   }
 

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -26,6 +26,9 @@ describe('openaiTextClient', () => {
     imageOutputDir: './output',
     apiTimeout: 30000,
     skipPromptEnhancement: false,
+    removeWatermark: false,
+    removeWatermarkCmd: 'remove-ai-watermarks',
+    removeWatermarkTimeout: 600000,
     imageQuality: 'fast',
   }
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -36,6 +36,7 @@ import { getConfig } from '../utils/config.js'
 import { Logger } from '../utils/logger.js'
 import { ensureExtension, getMimeTypeFromExtension } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
+import { removeWatermark } from '../utils/watermarkRemover.js'
 import { ErrorHandler } from './errorHandler.js'
 
 /**
@@ -352,6 +353,11 @@ export class MCPServerImpl {
       )
       if (!saveResult.success) {
         throw saveResult.error
+      }
+
+      // Remove AI watermarks in place (best-effort; failures are logged, not thrown)
+      if (configResult.data.removeWatermark) {
+        await removeWatermark(saveResult.data, configResult.data, this.logger)
       }
 
       // Build response

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -13,6 +13,9 @@ describe('config', () => {
     process.env.OPENAI_API_KEY = undefined
     process.env.IMAGE_OUTPUT_DIR = undefined
     process.env.IMAGE_QUALITY = undefined
+    process.env.REMOVE_WATERMARK = undefined
+    process.env.REMOVE_WATERMARK_CMD = undefined
+    process.env.REMOVE_WATERMARK_TIMEOUT = undefined
   })
 
   afterEach(() => {
@@ -30,6 +33,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -54,6 +60,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -77,6 +86,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: -1000, // Invalid negative timeout
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -104,6 +116,9 @@ describe('config', () => {
           imageOutputDir: './output',
           apiTimeout: 30000,
           skipPromptEnhancement: false,
+          removeWatermark: false,
+          removeWatermarkCmd: 'remove-ai-watermarks',
+          removeWatermarkTimeout: 600000,
           imageQuality: quality,
         }
 
@@ -124,6 +139,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'invalid' as any,
       }
 
@@ -150,6 +168,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -172,6 +193,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -191,6 +215,9 @@ describe('config', () => {
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
+        removeWatermark: false,
+        removeWatermarkCmd: 'remove-ai-watermarks',
+        removeWatermarkTimeout: 600000,
         imageQuality: 'fast' as const,
       }
 
@@ -312,6 +339,69 @@ describe('config', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error.message).toContain('Invalid IMAGE_QUALITY')
+      }
+    })
+
+    it('should default removeWatermark to false and provide default command/timeout', () => {
+      // Arrange
+      process.env.GEMINI_API_KEY = 'test-api-key-12345'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.removeWatermark).toBe(false)
+        expect(result.data.removeWatermarkCmd).toBe('remove-ai-watermarks')
+        expect(result.data.removeWatermarkTimeout).toBe(600000)
+      }
+    })
+
+    it('should enable removeWatermark when REMOVE_WATERMARK=true', () => {
+      // Arrange
+      process.env.GEMINI_API_KEY = 'test-api-key-12345'
+      process.env.REMOVE_WATERMARK = 'true'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.removeWatermark).toBe(true)
+      }
+    })
+
+    it('should not enable removeWatermark for non-"true" values', () => {
+      // Arrange
+      process.env.GEMINI_API_KEY = 'test-api-key-12345'
+      process.env.REMOVE_WATERMARK = 'yes'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.removeWatermark).toBe(false)
+      }
+    })
+
+    it('should read REMOVE_WATERMARK_CMD and REMOVE_WATERMARK_TIMEOUT overrides', () => {
+      // Arrange
+      process.env.GEMINI_API_KEY = 'test-api-key-12345'
+      process.env.REMOVE_WATERMARK_CMD = '/venv/bin/remove-ai-watermarks'
+      process.env.REMOVE_WATERMARK_TIMEOUT = '120000'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.removeWatermarkCmd).toBe('/venv/bin/remove-ai-watermarks')
+        expect(result.data.removeWatermarkTimeout).toBe(120000)
       }
     })
 

--- a/src/utils/__tests__/watermarkRemover.test.ts
+++ b/src/utils/__tests__/watermarkRemover.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// execFile is promisified at module load, so the mock must invoke the callback.
+const execFileMock = vi.fn()
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}))
+
+import type { Config } from '../config'
+import type { Logger } from '../logger'
+import { removeWatermark } from '../watermarkRemover'
+
+function resolveWith(err: Error | null): void {
+  execFileMock.mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: (e: Error | null, r: unknown) => void) => {
+      cb(err, { stdout: '', stderr: '' })
+    }
+  )
+}
+
+const baseConfig: Config = {
+  imageProvider: 'gemini',
+  geminiApiKey: 'test-api-key-12345',
+  openaiApiKey: '',
+  imageOutputDir: './output',
+  apiTimeout: 30000,
+  skipPromptEnhancement: false,
+  imageQuality: 'fast',
+  removeWatermark: true,
+  removeWatermarkCmd: 'remove-ai-watermarks',
+  removeWatermarkTimeout: 600000,
+}
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger
+
+describe('removeWatermark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('invokes the CLI in place with the "all" mode and logs success', async () => {
+    resolveWith(null)
+
+    await removeWatermark('/tmp/out/image.png', baseConfig, logger)
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+    const [cmd, args, opts] = execFileMock.mock.calls[0]
+    expect(cmd).toBe('remove-ai-watermarks')
+    expect(args).toEqual(['all', '/tmp/out/image.png', '-o', '/tmp/out/image.png'])
+    expect(opts).toMatchObject({ timeout: 600000 })
+    expect(logger.info).toHaveBeenCalled()
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('supports a command override that includes arguments', async () => {
+    resolveWith(null)
+
+    await removeWatermark(
+      '/tmp/out/image.png',
+      {
+        ...baseConfig,
+        removeWatermarkCmd: 'python -m remove_ai_watermarks',
+      },
+      logger
+    )
+
+    const [cmd, args] = execFileMock.mock.calls[0]
+    expect(cmd).toBe('python')
+    expect(args).toEqual([
+      '-m',
+      'remove_ai_watermarks',
+      'all',
+      '/tmp/out/image.png',
+      '-o',
+      '/tmp/out/image.png',
+    ])
+  })
+
+  it('falls back gracefully (no throw, warns) when the CLI is missing', async () => {
+    const enoent = Object.assign(new Error('spawn remove-ai-watermarks ENOENT'), {
+      code: 'ENOENT',
+    })
+    resolveWith(enoent)
+
+    await expect(removeWatermark('/tmp/out/image.png', baseConfig, logger)).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalled()
+    expect(logger.info).not.toHaveBeenCalled()
+  })
+
+  it('falls back gracefully when the CLI exits non-zero', async () => {
+    resolveWith(new Error('Command failed: exit code 1'))
+
+    await expect(removeWatermark('/tmp/out/image.png', baseConfig, logger)).resolves.toBeUndefined()
+
+    expect(logger.warn).toHaveBeenCalled()
+  })
+
+  it('skips and warns when the command is empty', async () => {
+    await removeWatermark(
+      '/tmp/out/image.png',
+      { ...baseConfig, removeWatermarkCmd: '   ' },
+      logger
+    )
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalled()
+  })
+})

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -20,6 +20,9 @@ export interface Config {
   apiTimeout: number
   skipPromptEnhancement: boolean // Skip prompt enhancement for direct control
   imageQuality: ImageQuality
+  removeWatermark: boolean // Remove AI watermarks as a post-generation step
+  removeWatermarkCmd: string // Command for the remove-ai-watermarks CLI
+  removeWatermarkTimeout: number // Timeout (ms) for the watermark removal command
 }
 
 /**
@@ -109,6 +112,16 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
+  // Validate removeWatermarkTimeout
+  if (config.removeWatermarkTimeout <= 0) {
+    return Err(
+      new ConfigError(
+        'REMOVE_WATERMARK_TIMEOUT must be a positive number',
+        'Set a positive timeout value in milliseconds (e.g., 600000 for 10 minutes)'
+      )
+    )
+  }
+
   // Validate imageOutputDir (basic check - non-empty string)
   if (!config.imageOutputDir || config.imageOutputDir.trim().length === 0) {
     return Err(
@@ -145,6 +158,9 @@ export function getConfig(): Result<Config, ConfigError> {
     apiTimeout: DEFAULT_CONFIG.apiTimeout,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',
     imageQuality: (readEnv('IMAGE_QUALITY') || 'fast') as ImageQuality,
+    removeWatermark: readEnv('REMOVE_WATERMARK') === 'true',
+    removeWatermarkCmd: readEnv('REMOVE_WATERMARK_CMD') || 'remove-ai-watermarks',
+    removeWatermarkTimeout: Number(readEnv('REMOVE_WATERMARK_TIMEOUT')) || 600000,
   }
 
   return validateConfig(config)

--- a/src/utils/watermarkRemover.ts
+++ b/src/utils/watermarkRemover.ts
@@ -1,0 +1,55 @@
+/**
+ * Post-generation watermark removal.
+ *
+ * Delegates to the external Python tool `remove-ai-watermarks`
+ * (https://github.com/wiltodelta/remove-ai-watermarks) to strip AI watermarks
+ * (e.g. Gemini "nano banana" sparkle + SynthID) and provenance metadata from a
+ * generated image, overwriting the file in place.
+ *
+ * This is a best-effort step: if the tool is missing or fails, the original
+ * image is left untouched and the error is logged (graceful fallback) so image
+ * generation still succeeds.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import type { Config } from './config.js'
+import type { Logger } from './logger.js'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Removes AI watermarks from the image at `filePath`, overwriting it in place.
+ *
+ * Never throws: failures (missing binary, non-zero exit, timeout) are logged as
+ * warnings and the original file is preserved.
+ *
+ * @param filePath Absolute path to the generated image to clean.
+ * @param config Validated configuration (provides command + timeout).
+ * @param logger Logger for success/warning output.
+ */
+export async function removeWatermark(
+  filePath: string,
+  config: Config,
+  logger: Logger
+): Promise<void> {
+  // The override may include arguments (e.g. "python -m remove_ai_watermarks").
+  // Split on whitespace: first token is the command, the rest are leading args.
+  // Note: command paths containing spaces are not supported in the override.
+  const [command, ...prefixArgs] = config.removeWatermarkCmd.trim().split(/\s+/)
+  if (!command) {
+    logger.warn('watermark', 'Watermark removal skipped: empty REMOVE_WATERMARK_CMD')
+    return
+  }
+
+  const args = [...prefixArgs, 'all', filePath, '-o', filePath]
+
+  try {
+    await execFileAsync(command, args, { timeout: config.removeWatermarkTimeout })
+    logger.info('watermark', 'Watermark removed', { filePath })
+  } catch (error) {
+    logger.warn('watermark', 'Watermark removal skipped', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `REMOVE_WATERMARK` flag that strips AI watermarks from **every** generated image (Gemini / "nano banana", OpenAI, Ideogram) as a single shared post-generation step.

It removes:
- **visible** marks (e.g. the Gemini "sparkle"),
- **invisible** watermarks (e.g. SynthID),
- **provenance metadata** (C2PA / EXIF).

The cleaned image **overwrites the original in place** — no duplicate file.

## How it works

Removal is delegated to the external Python tool [`remove-ai-watermarks`](https://github.com/wiltodelta/remove-ai-watermarks), invoked in `all` mode on the saved file. The single injection point is in `handleGenerateImage`, right after `saveImage` succeeds, so all providers converge there.

It is **best-effort with graceful fallback**: if the tool is not installed or fails, a warning is logged and the original image is returned, so generation still succeeds.

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `REMOVE_WATERMARK` | `false` | `true` to remove AI watermarks from generated images |
| `REMOVE_WATERMARK_CMD` | `remove-ai-watermarks` | Command to invoke (full path, or `python -m remove_ai_watermarks`) |
| `REMOVE_WATERMARK_TIMEOUT` | `600000` | Timeout (ms) for the removal command |

> Note: `all` mode requires `torch` + `diffusers`, a GPU, and a ~2GB model download for the invisible-watermark (SynthID) step — see the upstream README.

## Changes
- New `src/utils/watermarkRemover.ts` — `execFile`-based (no shell), in-place, never throws.
- `src/utils/config.ts` — three new config fields + timeout validation.
- `src/server/mcpServer.ts` — wires the step in after save.
- Docs: `README.md` + `server.json`.
- Tests: new `watermarkRemover.test.ts`, new config cases, and updated `Config` literals.

## Verification
- `npm run build` — clean
- `npx biome check src` — no issues
- `npm test` — 243 tests pass

## Note on the Ideogram branch
This PR targets `main` and is independent of the in-progress `feat/ideogram-provider` work. ⚠️ Whichever of these two PRs merges **second** will need a small follow-up: the Ideogram branch's `Config` literals (in `ideogramImageClient.test.ts` and the Ideogram cases in `config.test.ts`) must add the three new `removeWatermark*` fields, otherwise the build will fail on the now-required config fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)