### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Image Generator 🍌
 
+[![MCP Toplist](https://mcptoplist.com/badge/io.github.shinpr%2Fmcp-image.svg)](https://mcptoplist.com/server/io.github.shinpr%2Fmcp-image)
+
 > AI image generation and editing MCP server for Cursor, Claude Code, Codex, and any MCP-compatible tool — powered by Nano Banana 2 and Nano Banana Pro (Google Gemini), with optional OpenAI GPT Image support.
 
 [![npm version](https://badge.fury.io/js/mcp-image.svg)](https://www.npmjs.com/package/mcp-image)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,686 MCP servers across the major
registries, and **MCP Image** is currently ranked **#829**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/io.github.shinpr%2Fmcp-image.svg)](https://mcptoplist.com/server/io.github.shinpr%2Fmcp-image)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building MCP Image!
