### PR TITLE
feat: add BytePlus Seedream image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MCP Image Generator 🍌
 
-> AI image generation and editing MCP server for Cursor, Claude Code, Codex, and any MCP-compatible tool — powered by Nano Banana 2 and Nano Banana Pro (Google Gemini), with optional OpenAI GPT Image support.
+> AI image generation and editing MCP server for Cursor, Claude Code, Codex, and any MCP-compatible tool — powered by Google Gemini, OpenAI GPT Image, or BytePlus Seedream.
 
 [![npm version](https://badge.fury.io/js/mcp-image.svg)](https://www.npmjs.com/package/mcp-image)
 [![npm downloads](https://img.shields.io/npm/dm/mcp-image.svg)](https://www.npmjs.com/package/mcp-image)
@@ -27,7 +27,7 @@ You: "cat on a roof"
 
 Your AI assistant interprets your intent — the style, purpose, and context behind your request. The MCP focuses on output quality by refining the prompt to meet a structured visual clarity standard and selecting appropriate generation settings. You just describe what you want.
 
-The prompt optimizer uses a **Subject–Context–Style** framework (powered by Gemini 2.5 Flash by default, or OpenAI Responses when `IMAGE_PROVIDER=openai`) to fill in missing visual details — subject characteristics, environment, lighting, camera work — while preserving your original intent. It doesn't blindly add details: prompts that already meet the quality standard are left largely intact.
+The prompt optimizer uses a **Subject–Context–Style** framework (powered by Gemini 2.5 Flash by default, OpenAI Responses when `IMAGE_PROVIDER=openai`, or ModelArk Responses when `IMAGE_PROVIDER=seedream`) to fill in missing visual details — subject characteristics, environment, lighting, camera work — while preserving your original intent. It doesn't blindly add details: prompts that already meet the quality standard are left largely intact.
 
 **Example — what the optimizer does to a short prompt:**
 
@@ -37,19 +37,19 @@ The prompt optimizer uses a **Subject–Context–Style** framework (powered by 
 
 ## Features
 
-- **Built-in Prompt Optimization**: Your simple prompt is automatically enriched with photographic and artistic details — lighting, composition, atmosphere — using Gemini 2.5 Flash by default, or OpenAI Responses when `IMAGE_PROVIDER=openai`. No prompt engineering skills required.
-- **Optional OpenAI Provider**: Set `IMAGE_PROVIDER=openai` to generate and edit images with OpenAI GPT Image models such as `gpt-image-2`.
-- **Three Quality Tiers**: Choose between fast iteration, balanced quality, or maximum fidelity with Nano Banana 2 (Gemini 3.1 Flash Image) and Nano Banana Pro (Gemini 3 Pro Image). [See Quality Presets](#quality-presets).
+- **Built-in Prompt Optimization**: Your simple prompt is automatically enriched with photographic and artistic details — lighting, composition, atmosphere — using the selected provider's text path. No prompt engineering skills required.
+- **Optional Image Providers**: Set `IMAGE_PROVIDER=openai` for OpenAI GPT Image or `IMAGE_PROVIDER=seedream` for BytePlus Seedream through ModelArk.
+- **Three Quality Presets**: Select `fast`, `balanced`, or `quality`; each provider maps these values to its own supported model route. [See Quality Presets](#quality-presets).
 - **Image Editing**: Transform existing images with natural language instructions (image-to-image) while preserving original style and visual consistency.
-- **High-Resolution Output**: Up to 4K image generation for professional-grade output with superior text rendering and fine details.
+- **High-Resolution Output**: Up to a 4K resolution token, depending on the selected provider and quality route.
 - **Flexible Aspect Ratios**: From square (1:1) to ultra-wide (21:9) and ultra-tall (1:8) formats.
 - **Character Consistency**: Maintain consistent character appearance across multiple generations — ideal for storyboards, product shots, and visual series.
 - **Advanced Capabilities**:
-  - Google Search grounding for real-time factual accuracy
+  - Google Search grounding for real-time factual accuracy with the Gemini provider
   - World knowledge for photorealistic depictions of historical figures, landmarks, and factual scenarios
-  - Multi-image blending for composite scenes
+  - Prompt-level blending guidance for composite scenes
   - Purpose-aware generation (e.g., "cookbook cover" produces different results than "social media post")
-- **Multiple Output Formats**: PNG, JPEG, WebP support.
+- **Multiple Output Formats**: PNG, JPEG, and WebP support where the selected provider supports them; Seedream output is PNG.
 
 ## Agent Skill: Image Generation Prompt Guide
 
@@ -83,8 +83,8 @@ npx mcp-image skills install --path ~/.claude/skills
 | | MCP Server | Agent Skill |
 |---|---|---|
 | **Use when** | Your AI tool does not have built-in image generation | Your AI tool already generates images natively |
-| **Requires** | Gemini API key | Nothing |
-| **What it does** | Generates images via Gemini API with automatic prompt optimization | Teaches the AI to write better prompts |
+| **Requires** | API key for the selected image provider | Nothing |
+| **What it does** | Generates images through the selected provider with automatic prompt optimization | Teaches the AI to write better prompts |
 | **Works with** | MCP-compatible tools (Cursor, Claude Code, Codex, etc.) | Any tool supporting the [Agent Skills](https://agentskills.io) open standard |
 
 ---
@@ -94,6 +94,7 @@ npx mcp-image skills install --path ~/.claude/skills
 - **Node.js** 22 or higher
 - **Gemini API Key** - Get yours at [Google AI Studio](https://aistudio.google.com/apikey) for the default Gemini provider
 - **OpenAI API Key** - Get yours from [OpenAI](https://platform.openai.com/api-keys) when using `IMAGE_PROVIDER=openai`
+- **BytePlus ModelArk API Key** - Create one in the [AP region ModelArk console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey) when using `IMAGE_PROVIDER=seedream`
 - An MCP-compatible AI tool: **Cursor**, **Claude Code**, **Codex**, or others
 - Basic terminal/command line knowledge
 
@@ -111,6 +112,15 @@ OPENAI_API_KEY=your_openai_api_key_here
 ```
 
 OpenAI mode requires organization verification — see [Using the OpenAI provider](#using-the-openai-provider) below for setup details and feature differences.
+
+To use BytePlus Seedream instead, create an API key in the ModelArk AP region and set:
+
+```bash
+IMAGE_PROVIDER=seedream
+ARK_API_KEY=<your-api-key>
+```
+
+See [Using the BytePlus Seedream provider](#using-the-byteplus-seedream-provider) for its exact compatibility matrix and restart requirements.
 
 ### 2. MCP Configuration
 
@@ -257,9 +267,53 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `IMAGE_PROVIDER` | `gemini` | `gemini` or `openai` |
+| `IMAGE_PROVIDER` | `gemini` | `gemini`, `openai`, or `seedream` |
 | `GEMINI_API_KEY` | - | Required when `IMAGE_PROVIDER=gemini` |
 | `OPENAI_API_KEY` | - | Required when `IMAGE_PROVIDER=openai` |
+| `ARK_API_KEY` | - | Required when `IMAGE_PROVIDER=seedream`; use a ModelArk AP region key |
+
+### Using the BytePlus Seedream provider
+
+Seedream uses the BytePlus ModelArk AP endpoint at `https://ark.ap-southeast.bytepluses.com/api/v3/images/generations`. Create an API key in the [AP region ModelArk console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey), ensure the account can access the required Seedream models, and place only a placeholder in shared configuration examples:
+
+```toml
+[mcp_servers.mcp-image.env]
+IMAGE_PROVIDER = "seedream"
+ARK_API_KEY = "<your-api-key>"
+IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
+```
+
+The equivalent environment block for JSON-based MCP clients is:
+
+```json
+{
+  "IMAGE_PROVIDER": "seedream",
+  "ARK_API_KEY": "<your-api-key>",
+  "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"
+}
+```
+
+After changing `IMAGE_PROVIDER`, `ARK_API_KEY`, or the Seedream `IMAGE_QUALITY` default, fully restart the MCP server process (and reconnect or restart the owning client if it keeps the process alive). The selected provider clients and their API key are retained after lazy initialization, and the Seedream image client captures the default quality when it is created. Later environment changes do not replace those initialized clients; request-level `quality` still overrides the captured default.
+
+Seedream quality routing is fixed:
+
+| Public preset | Seedream route | Native image optimizer | Supported `imageSize` | Default when omitted |
+|---------------|----------------|------------------------|-----------------------|----------------------|
+| `fast` | Seedream 5.0 Lite | `standard` | `2K`, `4K` | `2K` |
+| `balanced` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
+| `quality` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
+
+For Seedream, these presets are routing names rather than a promise that one route is visually superior to another. Unsupported model/resolution pairs fail explicitly; `3K` is not a public value.
+
+All 14 public aspect ratios (`1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, and `21:9`) use BytePlus Method 1. The selected resolution token is sent as `size`, and one `Output aspect ratio: <ratio>.` instruction is appended to the final image prompt. The model chooses the final pixel dimensions, so an exact width × height is not promised.
+
+Prompt enhancement uses the same ModelArk Responses path for `fast`, `balanced`, and `quality`; it is not rerun or changed by the image tier. A successful enhancement is used once, an enhancement error preserves the existing original-prompt behavior, and `SKIP_PROMPT_ENHANCEMENT=true` sends the original prompt without a text request. The Method 1 ratio instruction is applied afterward in every path. This prompt-only fallback does not switch provider, model, or option values.
+
+Seedream does not support Google Search. A request with `useGoogleSearch=true` fails capability validation before prompt-enhancement or image-provider requests. Native multi-image/output, streaming, layers, online search, and provider/model/value fallback are not part of the Seedream integration.
+
+Seedream direct image requests use a fixed `180000` ms timeout. This timeout is not configurable and is independent of the existing `30000` ms `apiTimeout` default. Seedream text requests retain their separate `30000` ms default, and other providers' timeout behavior is unchanged.
+
+The authorized one-call Method 1 validation probe passed with sanitized evidence: request count 1; retries 0; one Lite `2K` request using the `16:9` suffix; HTTP 200; decoded PNG dimensions 2848 × 1600; duration 27,602 ms; relative-ratio error 0.125% against `16:9`; sanitized error category none. This was a one-time billable gate, not a permanent paid test or a visual-quality evaluation.
 
 ### Using the OpenAI provider
 
@@ -321,8 +375,8 @@ Your prompt is automatically enhanced with rich details about lighting, material
 ### `generate_image` Tool
 
 The server uses a two-stage process with separate models for each stage:
-1. **Prompt Optimization** (Gemini 2.5 Flash by default, or `gpt-4o-mini` via OpenAI Responses in OpenAI mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
-2. **Image Generation** (Nano Banana 2/Pro by default, or `gpt-image-2` in OpenAI mode): Creates the final image. In Gemini mode the model varies by quality preset; in OpenAI mode the model is pinned and `quality` maps to OpenAI's `low`/`medium`/`high`.
+1. **Prompt Optimization** (Gemini 2.5 Flash by default, `gpt-4o-mini` via OpenAI Responses in OpenAI mode, or the pinned ModelArk Responses text model in Seedream mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
+2. **Image Generation** (Nano Banana 2/Pro by default, `gpt-image-2` in OpenAI mode, or Seedream 5.0 Lite/Pro in Seedream mode): Creates the final image. Provider-specific quality mappings are described above.
 
 #### Parameters
 
@@ -337,7 +391,7 @@ The server uses a two-stage process with separate models for each stage:
 | `blendImages` | boolean | - | Enable multi-image blending for combining multiple visual elements naturally |
 | `maintainCharacterConsistency` | boolean | - | Maintain character appearance consistency across different poses and scenes |
 | `useWorldKnowledge` | boolean | - | Use real-world knowledge for accurate context (historical figures, landmarks, factual scenarios) |
-| `useGoogleSearch` | boolean | - | Enable Google Search grounding for real-time factual accuracy |
+| `useGoogleSearch` | boolean | - | Enable Google Search grounding with Gemini. OpenAI and Seedream reject `true` |
 | `purpose` | string | - | Intended use (e.g., "cookbook cover", "social media post"). Helps tailor visual style and details |
 
 #### Response
@@ -364,7 +418,7 @@ The server uses a two-stage process with separate models for each stage:
 ### Common Issues
 
 **"API key not found"**
-- Ensure `GEMINI_API_KEY` is set when using Gemini, or `OPENAI_API_KEY` is set when `IMAGE_PROVIDER=openai`
+- Ensure `GEMINI_API_KEY` is set when using Gemini, `OPENAI_API_KEY` is set when `IMAGE_PROVIDER=openai`, or `ARK_API_KEY` is set when `IMAGE_PROVIDER=seedream`
 - Verify the API key is valid and has image generation permissions
 
 **"Input image file not found"**
@@ -379,10 +433,10 @@ The server uses a two-stage process with separate models for each stage:
 
 ### Performance Tips
 
-- `fast` preset: ~30–40 seconds typical (includes prompt optimization)
-- `balanced` preset: Slightly longer due to enhanced thinking
-- `quality` preset: Slower but highest fidelity output
-- High-resolution (2K/4K): Additional processing time for superior detail
+- In Gemini mode, the `fast` preset typically takes ~30–40 seconds including prompt optimization
+- In Gemini mode, `balanced` uses additional thinking and `quality` selects Nano Banana Pro
+- In Seedream mode, use the route table above; `balanced` and `quality` both select Pro `standard`
+- High-resolution (2K/4K): Processing time varies by provider and route
 - Simple prompts work great — the optimizer automatically adds professional details
 - Complex prompts are preserved and further enhanced
 - Consider `useWorldKnowledge` for historical or factual subjects

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Seedream quality routing is fixed:
 
 | Public preset | Seedream route | Native image optimizer | Supported `imageSize` | Default when omitted |
 |---------------|----------------|------------------------|-----------------------|----------------------|
-| `fast` | Seedream 5.0 Lite | `standard` | `2K`, `4K` | `2K` |
+| `fast` | Seedream 5.0 Pro | `fast` | `1K`, `2K` | `1K` |
 | `balanced` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
 | `quality` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
 
@@ -311,9 +311,7 @@ Prompt enhancement uses the same ModelArk Responses path for `fast`, `balanced`,
 
 Seedream does not support Google Search. A request with `useGoogleSearch=true` fails capability validation before prompt-enhancement or image-provider requests. Native multi-image/output, streaming, layers, online search, and provider/model/value fallback are not part of the Seedream integration.
 
-Seedream direct image requests use a fixed `180000` ms timeout. This timeout is not configurable and is independent of the existing `30000` ms `apiTimeout` default. Seedream text requests retain their separate `30000` ms default, and other providers' timeout behavior is unchanged.
-
-The authorized one-call Method 1 validation probe passed with sanitized evidence: request count 1; retries 0; one Lite `2K` request using the `16:9` suffix; HTTP 200; decoded PNG dimensions 2848 × 1600; duration 27,602 ms; relative-ratio error 0.125% against `16:9`; sanitized error category none. This was a one-time billable gate, not a permanent paid test or a visual-quality evaluation.
+Seedream direct image requests use a fixed `300000` ms timeout. This timeout is not configurable and is independent of the existing `30000` ms `apiTimeout` default. Seedream text requests retain their separate `30000` ms default, and other providers' timeout behavior is unchanged.
 
 ### Using the OpenAI provider
 
@@ -435,12 +433,13 @@ The server uses a two-stage process with separate models for each stage:
 
 - In Gemini mode, the `fast` preset typically takes ~30–40 seconds including prompt optimization
 - In Gemini mode, `balanced` uses additional thinking and `quality` selects Nano Banana Pro
-- In Seedream mode, use the route table above; `balanced` and `quality` both select Pro `standard`
+- In Seedream mode, use the route table above; all tiers use Pro, with `fast` selecting native `fast`
+  optimization and `balanced`/`quality` selecting `standard`
 - High-resolution (2K/4K): Processing time varies by provider and route
 - Simple prompts work great — the optimizer automatically adds professional details
 - Complex prompts are preserved and further enhanced
 - Consider `useWorldKnowledge` for historical or factual subjects
-- Use `imageSize: "4K"` when text clarity and fine details are critical
+- Use `imageSize: "4K"` when the selected provider supports it; Seedream accepts `1K` and `2K`
 
 ## Usage Notes
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 
 ### Using the BytePlus Seedream provider
 
-Create an API key in the [ModelArk AP region console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey). Restart the MCP server after changing provider settings.
+As of July 29, 2026, Seedream 5.0 Pro is available only in ModelArk AP (`ap-southeast-1`). Create an
+API key in the [ModelArk AP region console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey).
 
 Seedream quality routing is fixed:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ IMAGE_PROVIDER=seedream
 ARK_API_KEY=<your-api-key>
 ```
 
-See [Using the BytePlus Seedream provider](#using-the-byteplus-seedream-provider) for its exact compatibility matrix and restart requirements.
+See [Using the BytePlus Seedream provider](#using-the-byteplus-seedream-provider) for compatibility details.
 
 ### 2. MCP Configuration
 
@@ -274,26 +274,7 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to disable automatic prompt optimization and 
 
 ### Using the BytePlus Seedream provider
 
-Seedream uses the BytePlus ModelArk AP endpoint at `https://ark.ap-southeast.bytepluses.com/api/v3/images/generations`. Create an API key in the [AP region ModelArk console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey), ensure the account can access the required Seedream models, and place only a placeholder in shared configuration examples:
-
-```toml
-[mcp_servers.mcp-image.env]
-IMAGE_PROVIDER = "seedream"
-ARK_API_KEY = "<your-api-key>"
-IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
-```
-
-The equivalent environment block for JSON-based MCP clients is:
-
-```json
-{
-  "IMAGE_PROVIDER": "seedream",
-  "ARK_API_KEY": "<your-api-key>",
-  "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"
-}
-```
-
-After changing `IMAGE_PROVIDER`, `ARK_API_KEY`, or the Seedream `IMAGE_QUALITY` default, fully restart the MCP server process (and reconnect or restart the owning client if it keeps the process alive). The selected provider clients and their API key are retained after lazy initialization, and the Seedream image client captures the default quality when it is created. Later environment changes do not replace those initialized clients; request-level `quality` still overrides the captured default.
+Create an API key in the [ModelArk AP region console](https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey). Restart the MCP server after changing provider settings.
 
 Seedream quality routing is fixed:
 
@@ -303,15 +284,9 @@ Seedream quality routing is fixed:
 | `balanced` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
 | `quality` | Seedream 5.0 Pro | `standard` | `1K`, `2K` | `1K` |
 
-For Seedream, these presets are routing names rather than a promise that one route is visually superior to another. Unsupported model/resolution pairs fail explicitly; `3K` is not a public value.
-
-All 14 public aspect ratios (`1:1`, `1:4`, `1:8`, `2:3`, `3:2`, `3:4`, `4:1`, `4:3`, `4:5`, `5:4`, `8:1`, `9:16`, `16:9`, and `21:9`) use BytePlus Method 1. The selected resolution token is sent as `size`, and one `Output aspect ratio: <ratio>.` instruction is appended to the final image prompt. The model chooses the final pixel dimensions, so an exact width × height is not promised.
-
-Prompt enhancement uses the same ModelArk Responses path for `fast`, `balanced`, and `quality`; it is not rerun or changed by the image tier. A successful enhancement is used once, an enhancement error preserves the existing original-prompt behavior, and `SKIP_PROMPT_ENHANCEMENT=true` sends the original prompt without a text request. The Method 1 ratio instruction is applied afterward in every path. This prompt-only fallback does not switch provider, model, or option values.
-
-Seedream does not support Google Search. A request with `useGoogleSearch=true` fails capability validation before prompt-enhancement or image-provider requests. Native multi-image/output, streaming, layers, online search, and provider/model/value fallback are not part of the Seedream integration.
-
-Seedream direct image requests use a fixed `300000` ms timeout. This timeout is not configurable and is independent of the existing `30000` ms `apiTimeout` default. Seedream text requests retain their separate `30000` ms default, and other providers' timeout behavior is unchanged.
+All supported aspect ratios use BytePlus Method 1, so final pixel dimensions are model-selected.
+Seedream rejects `imageSize: "4K"` and `useGoogleSearch: true`. Image requests have a fixed
+300-second timeout.
 
 ### Using the OpenAI provider
 
@@ -374,7 +349,7 @@ Your prompt is automatically enhanced with rich details about lighting, material
 
 The server uses a two-stage process with separate models for each stage:
 1. **Prompt Optimization** (Gemini 2.5 Flash by default, `gpt-4o-mini` via OpenAI Responses in OpenAI mode, or the pinned ModelArk Responses text model in Seedream mode): Refines your prompt using the Subject–Context–Style framework. Skippable via `SKIP_PROMPT_ENHANCEMENT`.
-2. **Image Generation** (Nano Banana 2/Pro by default, `gpt-image-2` in OpenAI mode, or Seedream 5.0 Lite/Pro in Seedream mode): Creates the final image. Provider-specific quality mappings are described above.
+2. **Image Generation** (Nano Banana 2/Pro by default, `gpt-image-2` in OpenAI mode, or Seedream 5.0 Pro in Seedream mode): Creates the final image. Provider-specific quality mappings are described above.
 
 #### Parameters
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/mcp-image",
-  "description": "AI image generation and editing with prompt optimization and provider-specific quality presets for Gemini, OpenAI, and BytePlus Seedream",
+  "description": "AI image generation and editing with prompt optimization and quality presets",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {
@@ -21,7 +21,7 @@
       "environmentVariables": [
         {
           "name": "IMAGE_PROVIDER",
-          "description": "Image provider to use: 'gemini' (default), 'openai', or 'seedream'. Restart the MCP server after changing providers because initialized clients are cached for the process lifetime",
+          "description": "Image provider to use: 'gemini' (default), 'openai', or 'seedream'",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -42,7 +42,7 @@
         },
         {
           "name": "ARK_API_KEY",
-          "description": "BytePlus ModelArk AP region API key required when IMAGE_PROVIDER=seedream (create at https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey). Restart the MCP server after changing this value because initialized Seedream clients retain it for the process lifetime",
+          "description": "BytePlus ModelArk AP region API key required when IMAGE_PROVIDER=seedream",
           "isRequired": false,
           "format": "string",
           "isSecret": true
@@ -56,14 +56,14 @@
         },
         {
           "name": "IMAGE_QUALITY",
-          "description": "Default quality preset: 'fast' (default), 'balanced', or 'quality'. Seedream routes fast to Lite standard (2K default; 2K/4K supported) and balanced/quality to Pro standard (1K default; 1K/2K supported). Restart the MCP server after changing the Seedream default because the initialized image client retains it",
+          "description": "Default quality preset: 'fast' (default), 'balanced', or 'quality'",
           "isRequired": false,
           "format": "string",
           "isSecret": false
         },
         {
           "name": "SKIP_PROMPT_ENHANCEMENT",
-          "description": "Set to 'true' to disable automatic prompt optimization and use direct prompts for any provider",
+          "description": "Set to 'true' to disable automatic prompt optimization and use direct prompts",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.shinpr/mcp-image",
-  "description": "AI image generation and editing with prompt optimization and quality presets",
+  "description": "AI image generation and editing with prompt optimization and provider-specific quality presets for Gemini, OpenAI, and BytePlus Seedream",
   "vendor": "Shinsuke Kagawa",
   "license": "MIT",
   "repository": {
@@ -21,7 +21,7 @@
       "environmentVariables": [
         {
           "name": "IMAGE_PROVIDER",
-          "description": "Image provider to use: 'gemini' (default) or 'openai'",
+          "description": "Image provider to use: 'gemini' (default), 'openai', or 'seedream'. Restart the MCP server after changing providers because initialized clients are cached for the process lifetime",
           "isRequired": false,
           "format": "string",
           "isSecret": false
@@ -41,6 +41,13 @@
           "isSecret": true
         },
         {
+          "name": "ARK_API_KEY",
+          "description": "BytePlus ModelArk AP region API key required when IMAGE_PROVIDER=seedream (create at https://console.byteplus.com/ark/region:ark+ap-southeast-1/apikey). Restart the MCP server after changing this value because initialized Seedream clients retain it for the process lifetime",
+          "isRequired": false,
+          "format": "string",
+          "isSecret": true
+        },
+        {
           "name": "IMAGE_OUTPUT_DIR",
           "description": "Absolute path to directory where generated images will be saved (defaults to ./output)",
           "isRequired": false,
@@ -49,14 +56,14 @@
         },
         {
           "name": "IMAGE_QUALITY",
-          "description": "Default quality preset: 'fast' (Nano Banana 2, default), 'balanced' (Nano Banana 2 + thinking), 'quality' (Nano Banana Pro)",
+          "description": "Default quality preset: 'fast' (default), 'balanced', or 'quality'. Seedream routes fast to Lite standard (2K default; 2K/4K supported) and balanced/quality to Pro standard (1K default; 1K/2K supported). Restart the MCP server after changing the Seedream default because the initialized image client retains it",
           "isRequired": false,
           "format": "string",
           "isSecret": false
         },
         {
           "name": "SKIP_PROMPT_ENHANCEMENT",
-          "description": "Set to 'true' to disable automatic prompt optimization and use direct prompts",
+          "description": "Set to 'true' to disable automatic prompt optimization and use direct prompts for any provider",
           "isRequired": false,
           "format": "boolean",
           "isSecret": false
@@ -88,6 +95,9 @@
     "gemini",
     "openai",
     "gpt-image-2",
+    "byteplus",
+    "modelark",
+    "seedream",
     "nano-banana",
     "nano-banana-2",
     "nano-banana-pro",

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Config } from '../../utils/config'
+import { type Config, getConfig } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
 import type { ImageApiParams, ImageClient } from '../imageClient'
 import { createSeedreamImageClient, validateSeedreamCapabilities } from '../seedreamImageClient'
 
 const API_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
 const DUMMY_API_KEY = 'ark-dummy-seedream-image-key'
+const WRAPPED_DUMMY_API_KEY = ` \t${DUMMY_API_KEY}\n `
 const PRIVATE_PROMPT = 'private-seedream-image-prompt'
 const RAW_BODY_MARKER = 'private-upstream-body-marker'
 const MIB = 1024 * 1024
@@ -93,6 +94,17 @@ function disclosedError(error: ImageAPIError | NetworkError): string {
   })
 }
 
+function stubSeedreamEnvironment(): void {
+  vi.stubEnv('IMAGE_PROVIDER', 'seedream')
+  vi.stubEnv('GEMINI_API_KEY', 'gemini-dummy-seedream-image-key')
+  vi.stubEnv('OPENAI_API_KEY', 'openai-dummy-seedream-image-key')
+  vi.stubEnv('ARK_API_KEY', WRAPPED_DUMMY_API_KEY)
+  vi.stubEnv('IMAGE_OUTPUT_DIR', './output')
+  vi.stubEnv('IMAGE_QUALITY', 'fast')
+  vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', 'false')
+  vi.stubEnv('NODE_ENV', 'test')
+}
+
 beforeEach(() => {
   fetchMock.mockReset()
   fetchMock.mockResolvedValue(successfulResponse())
@@ -102,9 +114,28 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
 })
 
 describe('seedreamImageClient', () => {
+  it('uses the configuration-normalized environment key in direct HTTP Authorization', async () => {
+    stubSeedreamEnvironment()
+    const configResult = getConfig()
+    expect(configResult.success).toBe(true)
+    if (!configResult.success) {
+      throw configResult.error
+    }
+    expect(configResult.data.arkApiKey).toBe(DUMMY_API_KEY)
+
+    const result = await createClient(configResult.data).generateImage({
+      prompt: PRIVATE_PROMPT,
+    })
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(readRequest().headers.get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+  })
+
   it.each([
     {
       name: 'fast default',

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -1,0 +1,680 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from '../../utils/config'
+import { ImageAPIError, NetworkError } from '../../utils/errors'
+import type { ImageApiParams, ImageClient } from '../imageClient'
+import { createSeedreamImageClient, validateSeedreamCapabilities } from '../seedreamImageClient'
+
+const API_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
+const DUMMY_API_KEY = 'ark-dummy-seedream-image-key'
+const PRIVATE_PROMPT = 'private-seedream-image-prompt'
+const RAW_BODY_MARKER = 'private-upstream-body-marker'
+const MIB = 1024 * 1024
+const MAX_RESPONSE_BYTES = 48 * MIB
+const MAX_DECODED_BYTES = 32 * MIB
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x66, 0x69, 0x78, 0x74, 0x75, 0x72, 0x65,
+])
+const PRIVATE_INPUT_IMAGE = PNG_BYTES.toString('base64')
+const ALL_ASPECT_RATIOS = [
+  '1:1',
+  '1:4',
+  '1:8',
+  '2:3',
+  '3:2',
+  '3:4',
+  '4:1',
+  '4:3',
+  '4:5',
+  '5:4',
+  '8:1',
+  '9:16',
+  '16:9',
+  '21:9',
+] as const
+
+const testConfig: Config = {
+  imageProvider: 'seedream',
+  geminiApiKey: '',
+  openaiApiKey: '',
+  arkApiKey: DUMMY_API_KEY,
+  imageOutputDir: './output',
+  apiTimeout: 30000,
+  skipPromptEnhancement: false,
+  imageQuality: 'fast',
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function successfulResponse(bytes = PNG_BYTES): Response {
+  return jsonResponse({
+    data: [{ b64_json: bytes.toString('base64'), mime_type: 'image/png' }],
+  })
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function createClient(config: Config = testConfig): ImageClient {
+  const result = createSeedreamImageClient(config)
+  expect(result.success).toBe(true)
+  if (!result.success) {
+    throw result.error
+  }
+  return result.data
+}
+
+function readRequest(callIndex = -1): {
+  body: Record<string, unknown>
+  headers: Headers
+  init: RequestInit
+  url: string
+} {
+  const [url, rawInit] = fetchMock.mock.calls.at(callIndex) ?? []
+  const init = rawInit ?? {}
+  expect(typeof init.body).toBe('string')
+  return {
+    body: JSON.parse(String(init.body)) as Record<string, unknown>,
+    headers: new Headers(init.headers),
+    init,
+    url: String(url),
+  }
+}
+
+function disclosedError(error: ImageAPIError | NetworkError): string {
+  return JSON.stringify({
+    code: error.code,
+    context: error.context,
+    message: error.message,
+    suggestion: error.suggestion,
+  })
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(successfulResponse())
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('seedreamImageClient', () => {
+  it.each([
+    {
+      name: 'fast default',
+      quality: 'fast' as const,
+      imageSize: undefined,
+      model: 'seedream-5-0-260128',
+      size: '2K',
+      sequential: true,
+    },
+    {
+      name: 'fast 4K override',
+      quality: 'fast' as const,
+      imageSize: '4K' as const,
+      model: 'seedream-5-0-260128',
+      size: '4K',
+      sequential: true,
+    },
+    {
+      name: 'balanced default',
+      quality: 'balanced' as const,
+      imageSize: undefined,
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '1K',
+      sequential: false,
+    },
+    {
+      name: 'balanced 2K override',
+      quality: 'balanced' as const,
+      imageSize: '2K' as const,
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '2K',
+      sequential: false,
+    },
+    {
+      name: 'quality default',
+      quality: 'quality' as const,
+      imageSize: undefined,
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '1K',
+      sequential: false,
+    },
+    {
+      name: 'quality 2K override',
+      quality: 'quality' as const,
+      imageSize: '2K' as const,
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '2K',
+      sequential: false,
+    },
+  ])('routes and serializes the exact $name request', async (row) => {
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      quality: row.quality,
+      ...(row.imageSize && { imageSize: row.imageSize }),
+    })
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const request = readRequest()
+    const expectedBody = {
+      model: row.model,
+      prompt: `${PRIVATE_PROMPT}\n\nOutput aspect ratio: 1:1.`,
+      size: row.size,
+      response_format: 'b64_json',
+      output_format: 'png',
+      stream: false,
+      watermark: false,
+      optimize_prompt_options: { mode: 'standard' },
+      ...(row.sequential && { sequential_image_generation: 'disabled' }),
+    }
+
+    expect(request.url).toBe(API_ENDPOINT)
+    expect(request.init.method).toBe('POST')
+    expect(request.headers.get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+    expect(request.headers.get('content-type')).toBe('application/json')
+    expect(request.body).toEqual(expectedBody)
+    expect(Object.hasOwn(request.body, 'sequential_image_generation')).toBe(row.sequential)
+    expect(Object.hasOwn(request.body, 'reasoning_effort')).toBe(false)
+    expect(Object.hasOwn(request.body, 'thinking')).toBe(false)
+
+    if (result.success) {
+      expect(result.data).toEqual({
+        imageData: PNG_BYTES,
+        metadata: {
+          model: row.model,
+          provider: 'seedream',
+          prompt: `${PRIVATE_PROMPT}\n\nOutput aspect ratio: 1:1.`,
+          mimeType: 'image/png',
+          timestamp: expect.any(Date),
+          inputImageProvided: false,
+        },
+      })
+    }
+  })
+
+  it('uses request quality before captured default quality', async () => {
+    const client = createClient({ ...testConfig, imageQuality: 'fast' })
+
+    const result = await client.generateImage({
+      prompt: PRIVATE_PROMPT,
+      quality: 'quality',
+    })
+
+    expect(result.success).toBe(true)
+    expect(readRequest().body).toMatchObject({
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '1K',
+      optimize_prompt_options: { mode: 'standard' },
+    })
+  })
+
+  it('uses one unchanged Method 1 suffix rule for all 14 aspect ratios', async () => {
+    const client = createClient()
+
+    for (const aspectRatio of ALL_ASPECT_RATIOS) {
+      fetchMock.mockResolvedValueOnce(successfulResponse())
+
+      const result = await client.generateImage({
+        prompt: PRIVATE_PROMPT,
+        quality: 'fast',
+        imageSize: '2K',
+        aspectRatio,
+      })
+
+      expect(result.success, aspectRatio).toBe(true)
+      const body = readRequest().body
+      expect(body.size, aspectRatio).toBe('2K')
+      expect(body.prompt, aspectRatio).toBe(
+        `${PRIVATE_PROMPT}\n\nOutput aspect ratio: ${aspectRatio}.`
+      )
+      expect(String(body.prompt), aspectRatio).not.toMatch(/\d+x\d+/)
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(ALL_ASPECT_RATIOS.length)
+  })
+
+  it('serializes one supported input image as a data URI', async () => {
+    const inputImage = PNG_BYTES.toString('base64')
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(true)
+    expect(readRequest().body.image).toBe(`data:image/png;base64,${inputImage}`)
+    if (result.success) {
+      expect(result.data.metadata.inputImageProvided).toBe(true)
+    }
+  })
+
+  it.each([
+    {
+      name: 'Google Search',
+      params: { useGoogleSearch: true },
+    },
+    {
+      name: 'Lite 1K',
+      params: { quality: 'fast', imageSize: '1K' },
+    },
+    {
+      name: 'balanced Pro 4K',
+      params: { quality: 'balanced', imageSize: '4K' },
+    },
+    {
+      name: 'quality Pro 4K',
+      params: { quality: 'quality', imageSize: '4K' },
+    },
+    {
+      name: 'input image without MIME',
+      params: { inputImage: PNG_BYTES.toString('base64') },
+    },
+    {
+      name: 'MIME without input image',
+      params: { inputImageMimeType: 'image/png' },
+    },
+    {
+      name: 'unsupported editing MIME',
+      params: {
+        inputImage: PNG_BYTES.toString('base64'),
+        inputImageMimeType: 'image/gif',
+      },
+    },
+    {
+      name: 'malformed editing base64',
+      params: { inputImage: '***', inputImageMimeType: 'image/png' },
+    },
+    {
+      name: 'unknown quality',
+      params: { quality: 'unknown' },
+    },
+    {
+      name: 'unknown aspect ratio',
+      params: { aspectRatio: '3:1' },
+    },
+  ])('rejects unsupported $name before transport without coercion', async ({ params }) => {
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      ...(params as ImageApiParams),
+    })
+
+    expect(result.success).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(disclosedError(result.error)).not.toContain(PRIVATE_PROMPT)
+    }
+  })
+
+  it('exports provider-neutral capability preflight for orchestration', () => {
+    expect(
+      validateSeedreamCapabilities(
+        {
+          quality: 'quality',
+          imageSize: '2K',
+          aspectRatio: '21:9',
+        },
+        'fast'
+      )
+    ).toEqual({ success: true, data: undefined })
+
+    const rejected = validateSeedreamCapabilities({ useGoogleSearch: true }, 'fast')
+    expect(rejected.success).toBe(false)
+  })
+
+  it.each([
+    {
+      name: 'missing data',
+      response: () => jsonResponse({}),
+    },
+    {
+      name: 'extra images',
+      response: () =>
+        jsonResponse({
+          data: [
+            { b64_json: PNG_BYTES.toString('base64'), mime_type: 'image/png' },
+            { b64_json: PNG_BYTES.toString('base64'), mime_type: 'image/png' },
+          ],
+        }),
+    },
+    {
+      name: 'URL-only data',
+      response: () => jsonResponse({ data: [{ url: 'https://attacker.invalid/image.png' }] }),
+    },
+    {
+      name: 'URL plus base64 data',
+      response: () =>
+        jsonResponse({
+          data: [
+            {
+              b64_json: PNG_BYTES.toString('base64'),
+              mime_type: 'image/png',
+              url: 'https://attacker.invalid/image.png',
+            },
+          ],
+        }),
+    },
+    {
+      name: 'stream property plus base64 data',
+      response: () =>
+        jsonResponse({
+          data: [
+            {
+              b64_json: PNG_BYTES.toString('base64'),
+              mime_type: 'image/png',
+              stream: false,
+            },
+          ],
+        }),
+    },
+    {
+      name: 'malformed base64',
+      response: () => jsonResponse({ data: [{ b64_json: '***', mime_type: 'image/png' }] }),
+    },
+    {
+      name: 'empty base64',
+      response: () => jsonResponse({ data: [{ b64_json: '', mime_type: 'image/png' }] }),
+    },
+    {
+      name: 'non-PNG bytes',
+      response: () =>
+        jsonResponse({
+          data: [
+            {
+              b64_json: Buffer.from('not a png').toString('base64'),
+              mime_type: 'image/png',
+            },
+          ],
+        }),
+    },
+    {
+      name: 'non-PNG MIME',
+      response: () =>
+        jsonResponse({
+          data: [{ b64_json: PNG_BYTES.toString('base64'), mime_type: 'image/jpeg' }],
+        }),
+    },
+  ])('rejects $name without returning image bytes', async ({ response }) => {
+    fetchMock.mockResolvedValueOnce(response())
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(disclosedError(result.error)).not.toContain(PRIVATE_PROMPT)
+    }
+  })
+
+  it.each([
+    {
+      name: 'missing body',
+      response: () =>
+        new Response(null, {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    },
+    {
+      name: 'malformed JSON',
+      response: () =>
+        new Response('{"data":', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    },
+  ])('normalizes a $name response as a sanitized contract failure', async ({ response }) => {
+    fetchMock.mockResolvedValueOnce(response())
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: PRIVATE_INPUT_IMAGE,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      const disclosed = disclosedError(result.error)
+      expect(disclosed).not.toContain(DUMMY_API_KEY)
+      expect(disclosed).not.toContain(PRIVATE_PROMPT)
+      expect(disclosed).not.toContain(PRIVATE_INPUT_IMAGE)
+    }
+  })
+
+  it('rejects a streaming event shape before JSON parsing', async () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    fetchMock.mockResolvedValueOnce(
+      new Response(`data: ${JSON.stringify({ data: [] })}\n\n`, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    )
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(false)
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized numeric Content-Length before reading or parsing and cancels the body', async () => {
+    const cancel = vi.fn()
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    const body = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('must not be parsed'))
+      },
+    })
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        headers: {
+          'content-length': String(MAX_RESPONSE_BYTES + 1),
+          'content-type': 'application/json',
+        },
+      })
+    )
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(false)
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('counts a chunked body, cancels immediately after 48 MiB, and never parses it', async () => {
+    const cancel = vi.fn()
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    let chunk = 0
+    const body = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        if (chunk === 0) {
+          controller.enqueue(new Uint8Array(MAX_RESPONSE_BYTES))
+        } else if (chunk === 1) {
+          controller.enqueue(new Uint8Array(1))
+        }
+        chunk += 1
+      },
+    })
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(false)
+    expect(cancel).toHaveBeenCalledTimes(1)
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('rejects decoded data above 32 MiB before Buffer base64 decode', async () => {
+    const decodedSize = MAX_DECODED_BYTES + 1
+    const padding = (3 - (decodedSize % 3)) % 3
+    const encodedLength = Math.ceil(decodedSize / 3) * 4
+    const oversizedBase64 = `${'A'.repeat(encodedLength - padding)}${'='.repeat(padding)}`
+    const bufferFromSpy = vi.spyOn(Buffer, 'from')
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ b64_json: oversizedBase64, mime_type: 'image/png' }],
+      })
+    )
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(false)
+    expect(
+      bufferFromSpy.mock.calls.filter(
+        ([value, encoding]) => value === oversizedBase64 && encoding === 'base64'
+      )
+    ).toHaveLength(0)
+  })
+
+  it('constructs the image AbortSignal from the fixed 180000 ms timeout only', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+
+    const result = await createClient({
+      ...testConfig,
+      apiTimeout: 1,
+    }).generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(true)
+    expect(timeoutSpy).toHaveBeenCalledTimes(1)
+    expect(timeoutSpy).toHaveBeenCalledWith(180000)
+    expect(timeoutSpy).not.toHaveBeenCalledWith(1)
+    expect(timeoutSpy).not.toHaveBeenCalledWith(30000)
+  })
+
+  it('rejects missing or whitespace auth during factory preflight', () => {
+    for (const arkApiKey of ['', '   ']) {
+      const result = createSeedreamImageClient({ ...testConfig, arkApiKey })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(disclosedError(result.error)).not.toContain(DUMMY_API_KEY)
+      }
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      name: 'HTTP 401',
+      response: () =>
+        jsonResponse({ error: { message: `${RAW_BODY_MARKER}:${PRIVATE_PROMPT}` } }, 401),
+      errorType: ImageAPIError,
+    },
+    {
+      name: 'HTTP 429',
+      response: () =>
+        jsonResponse({ error: { message: `${RAW_BODY_MARKER}:${PRIVATE_PROMPT}` } }, 429),
+      errorType: ImageAPIError,
+    },
+    {
+      name: 'HTTP 500',
+      response: () =>
+        jsonResponse({ error: { message: `${RAW_BODY_MARKER}:${PRIVATE_PROMPT}` } }, 500),
+      errorType: NetworkError,
+    },
+  ])('normalizes and sanitizes $name without reading its upstream body', async (row) => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    fetchMock.mockResolvedValueOnce(row.response())
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: PRIVATE_INPUT_IMAGE,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(false)
+    expect(parseSpy).not.toHaveBeenCalled()
+    expect(consoleSpy).not.toHaveBeenCalled()
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(row.errorType)
+      const disclosed = disclosedError(result.error)
+      expect(disclosed).not.toContain(DUMMY_API_KEY)
+      expect(disclosed).not.toContain(PRIVATE_PROMPT)
+      expect(disclosed).not.toContain(PRIVATE_INPUT_IMAGE)
+      expect(disclosed).not.toContain(RAW_BODY_MARKER)
+    }
+  })
+
+  it.each([
+    {
+      name: 'network',
+      error: new TypeError(`fetch failed: ${RAW_BODY_MARKER}:${PRIVATE_PROMPT}`),
+      expectedMessage: 'Network error',
+    },
+    {
+      name: 'abort',
+      error: new DOMException(`${RAW_BODY_MARKER}:${PRIVATE_PROMPT}`, 'AbortError'),
+      expectedMessage: 'Timeout',
+    },
+    {
+      name: 'timeout',
+      error: new DOMException(`${RAW_BODY_MARKER}:${PRIVATE_PROMPT}`, 'TimeoutError'),
+      expectedMessage: 'Timeout',
+    },
+  ])('normalizes and sanitizes a $name failure', async (row) => {
+    fetchMock.mockRejectedValueOnce(row.error)
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: PRIVATE_INPUT_IMAGE,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(NetworkError)
+      expect(result.error.message).toContain(row.expectedMessage)
+      const disclosed = disclosedError(result.error)
+      expect(disclosed).not.toContain(DUMMY_API_KEY)
+      expect(disclosed).not.toContain(PRIVATE_PROMPT)
+      expect(disclosed).not.toContain(PRIVATE_INPUT_IMAGE)
+      expect(disclosed).not.toContain(RAW_BODY_MARKER)
+    }
+  })
+
+  it('sanitizes a parsed contract failure without disclosing the upstream payload', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        marker: `${RAW_BODY_MARKER}:${PRIVATE_PROMPT}:${DUMMY_API_KEY}`,
+        data: [],
+      })
+    )
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: PRIVATE_INPUT_IMAGE,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      const disclosed = disclosedError(result.error)
+      expect(disclosed).not.toContain(DUMMY_API_KEY)
+      expect(disclosed).not.toContain(PRIVATE_PROMPT)
+      expect(disclosed).not.toContain(PRIVATE_INPUT_IMAGE)
+      expect(disclosed).not.toContain(RAW_BODY_MARKER)
+    }
+  })
+})

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -48,7 +48,13 @@ const fetchMock = vi.fn<typeof fetch>()
 
 function successfulResponse(bytes = PNG_BYTES): Response {
   return jsonResponse({
-    data: [{ b64_json: bytes.toString('base64'), mime_type: 'image/png' }],
+    data: [
+      {
+        b64_json: bytes.toString('base64'),
+        size: '1024x1024',
+        output_format: 'png',
+      },
+    ],
   })
 }
 
@@ -141,17 +147,9 @@ describe('seedreamImageClient', () => {
       name: 'fast default',
       quality: 'fast' as const,
       imageSize: undefined,
-      model: 'seedream-5-0-260128',
-      size: '2K',
-      sequential: true,
-    },
-    {
-      name: 'fast 4K override',
-      quality: 'fast' as const,
-      imageSize: '4K' as const,
-      model: 'seedream-5-0-260128',
-      size: '4K',
-      sequential: true,
+      model: 'dola-seedream-5-0-pro-260628',
+      size: '1K',
+      optimizer: 'fast' as const,
     },
     {
       name: 'balanced default',
@@ -159,7 +157,7 @@ describe('seedreamImageClient', () => {
       imageSize: undefined,
       model: 'dola-seedream-5-0-pro-260628',
       size: '1K',
-      sequential: false,
+      optimizer: 'standard' as const,
     },
     {
       name: 'balanced 2K override',
@@ -167,7 +165,7 @@ describe('seedreamImageClient', () => {
       imageSize: '2K' as const,
       model: 'dola-seedream-5-0-pro-260628',
       size: '2K',
-      sequential: false,
+      optimizer: 'standard' as const,
     },
     {
       name: 'quality default',
@@ -175,7 +173,7 @@ describe('seedreamImageClient', () => {
       imageSize: undefined,
       model: 'dola-seedream-5-0-pro-260628',
       size: '1K',
-      sequential: false,
+      optimizer: 'standard' as const,
     },
     {
       name: 'quality 2K override',
@@ -183,7 +181,7 @@ describe('seedreamImageClient', () => {
       imageSize: '2K' as const,
       model: 'dola-seedream-5-0-pro-260628',
       size: '2K',
-      sequential: false,
+      optimizer: 'standard' as const,
     },
   ])('routes and serializes the exact $name request', async (row) => {
     const result = await createClient().generateImage({
@@ -204,8 +202,7 @@ describe('seedreamImageClient', () => {
       output_format: 'png',
       stream: false,
       watermark: false,
-      optimize_prompt_options: { mode: 'standard' },
-      ...(row.sequential && { sequential_image_generation: 'disabled' }),
+      optimize_prompt_options: { mode: row.optimizer },
     }
 
     expect(request.url).toBe(API_ENDPOINT)
@@ -213,7 +210,7 @@ describe('seedreamImageClient', () => {
     expect(request.headers.get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
     expect(request.headers.get('content-type')).toBe('application/json')
     expect(request.body).toEqual(expectedBody)
-    expect(Object.hasOwn(request.body, 'sequential_image_generation')).toBe(row.sequential)
+    expect(Object.hasOwn(request.body, 'sequential_image_generation')).toBe(false)
     expect(Object.hasOwn(request.body, 'reasoning_effort')).toBe(false)
     expect(Object.hasOwn(request.body, 'thinking')).toBe(false)
 
@@ -295,8 +292,8 @@ describe('seedreamImageClient', () => {
       params: { useGoogleSearch: true },
     },
     {
-      name: 'Lite 1K',
-      params: { quality: 'fast', imageSize: '1K' },
+      name: 'fast Pro 4K',
+      params: { quality: 'fast', imageSize: '4K' },
     },
     {
       name: 'balanced Pro 4K',
@@ -433,6 +430,13 @@ describe('seedreamImageClient', () => {
       response: () =>
         jsonResponse({
           data: [{ b64_json: PNG_BYTES.toString('base64'), mime_type: 'image/jpeg' }],
+        }),
+    },
+    {
+      name: 'non-PNG output format',
+      response: () =>
+        jsonResponse({
+          data: [{ b64_json: PNG_BYTES.toString('base64'), output_format: 'jpeg' }],
         }),
     },
   ])('rejects $name without returning image bytes', async ({ response }) => {
@@ -576,7 +580,7 @@ describe('seedreamImageClient', () => {
     ).toHaveLength(0)
   })
 
-  it('constructs the image AbortSignal from the fixed 180000 ms timeout only', async () => {
+  it('constructs the image AbortSignal from the fixed 300000 ms timeout only', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
 
     const result = await createClient({
@@ -586,7 +590,7 @@ describe('seedreamImageClient', () => {
 
     expect(result.success).toBe(true)
     expect(timeoutSpy).toHaveBeenCalledTimes(1)
-    expect(timeoutSpy).toHaveBeenCalledWith(180000)
+    expect(timeoutSpy).toHaveBeenCalledWith(300000)
     expect(timeoutSpy).not.toHaveBeenCalledWith(1)
     expect(timeoutSpy).not.toHaveBeenCalledWith(30000)
   })

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { Config } from '../../utils/config'
+import { type Config, getConfig } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
 import { createSeedreamTextClient } from '../seedreamTextClient'
 
 const MODELARK_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3'
 const DUMMY_API_KEY = 'ark-dummy-seedream-text-key'
+const WRAPPED_DUMMY_API_KEY = ` \t${DUMMY_API_KEY}\n `
 const PRIVATE_PROMPT = 'private-seedream-text-prompt'
 
 const testConfig: Config = {
@@ -39,12 +40,51 @@ function createClient() {
   return clientResult.data
 }
 
+function stubSeedreamEnvironment(): void {
+  vi.stubEnv('IMAGE_PROVIDER', 'seedream')
+  vi.stubEnv('GEMINI_API_KEY', 'gemini-dummy-seedream-text-key')
+  vi.stubEnv('OPENAI_API_KEY', 'openai-dummy-seedream-text-key')
+  vi.stubEnv('ARK_API_KEY', WRAPPED_DUMMY_API_KEY)
+  vi.stubEnv('IMAGE_OUTPUT_DIR', './output')
+  vi.stubEnv('IMAGE_QUALITY', 'fast')
+  vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', 'false')
+  vi.stubEnv('NODE_ENV', 'test')
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
 })
 
 describe('seedreamTextClient', () => {
+  it('uses the configuration-normalized environment key in SDK Authorization', async () => {
+    stubSeedreamEnvironment()
+    const configResult = getConfig()
+    expect(configResult.success).toBe(true)
+    if (!configResult.success) {
+      throw configResult.error
+    }
+    expect(configResult.data.arkApiKey).toBe(DUMMY_API_KEY)
+
+    const transport = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(successfulResponse('normalized authorization response'))
+    vi.stubGlobal('fetch', transport)
+    const clientResult = createSeedreamTextClient(configResult.data)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) {
+      throw clientResult.error
+    }
+
+    const result = await clientResult.data.generateText(PRIVATE_PROMPT)
+
+    expect(result).toEqual({ success: true, data: 'normalized authorization response' })
+    expect(transport).toHaveBeenCalledTimes(1)
+    const [, init] = transport.mock.calls[0]
+    expect(new Headers(init?.headers).get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+  })
+
   it('serializes the pinned Responses request through the installed SDK and returns exact text', async () => {
     const enhancedPrompt = '  fixture enhanced prompt\n'
     const transport = vi.fn<typeof fetch>().mockResolvedValue(successfulResponse(enhancedPrompt))

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Config } from '../../utils/config'
+import { ImageAPIError, NetworkError } from '../../utils/errors'
+import { createSeedreamTextClient } from '../seedreamTextClient'
+
+const MODELARK_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3'
+const DUMMY_API_KEY = 'ark-dummy-seedream-text-key'
+const PRIVATE_PROMPT = 'private-seedream-text-prompt'
+
+const testConfig: Config = {
+  imageProvider: 'seedream',
+  geminiApiKey: '',
+  openaiApiKey: '',
+  arkApiKey: DUMMY_API_KEY,
+  imageOutputDir: './output',
+  apiTimeout: 30000,
+  skipPromptEnhancement: false,
+  imageQuality: 'fast',
+}
+
+function successfulResponse(outputText: string): Response {
+  return new Response(JSON.stringify({ output_text: outputText }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function readSerializedBody(init: RequestInit | undefined): Record<string, unknown> {
+  expect(typeof init?.body).toBe('string')
+  return JSON.parse(String(init?.body)) as Record<string, unknown>
+}
+
+function createClient() {
+  const clientResult = createSeedreamTextClient(testConfig)
+  expect(clientResult.success).toBe(true)
+  if (!clientResult.success) {
+    throw clientResult.error
+  }
+  return clientResult.data
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('seedreamTextClient', () => {
+  it('serializes the pinned Responses request through the installed SDK and returns exact text', async () => {
+    const enhancedPrompt = '  fixture enhanced prompt\n'
+    const transport = vi.fn<typeof fetch>().mockResolvedValue(successfulResponse(enhancedPrompt))
+    vi.stubGlobal('fetch', transport)
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+
+    const result = await createClient().generateText(PRIVATE_PROMPT, {
+      systemInstruction: 'Enhance image prompts',
+      maxTokens: 1000,
+      temperature: 0.2,
+      topP: 0.9,
+      topK: 40,
+    })
+
+    expect(result).toEqual({ success: true, data: enhancedPrompt })
+    expect(transport).toHaveBeenCalledTimes(1)
+
+    const [url, init] = transport.mock.calls[0]
+    const body = readSerializedBody(init)
+
+    expect(String(url)).toBe(`${MODELARK_BASE_URL}/responses`)
+    expect(init?.method).toBe('POST')
+    expect(new Headers(init?.headers).get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+    expect(body).toEqual({
+      model: 'seed-2-0-lite-260428',
+      input: PRIVATE_PROMPT,
+      instructions: 'Enhance image prompts',
+      max_output_tokens: 1000,
+      temperature: 0.2,
+      top_p: 0.9,
+      thinking: { type: 'disabled' },
+    })
+    expect(Object.hasOwn(body, 'extra_body')).toBe(false)
+    expect(Object.hasOwn(body, 'topK')).toBe(false)
+    expect(JSON.stringify(body)).not.toContain(DUMMY_API_KEY)
+    expect(timeoutSpy).toHaveBeenCalledWith(30000)
+  })
+
+  it('preserves multimodal TextClient input without provider-native prompt fields', async () => {
+    const transport = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(successfulResponse('enhanced edit prompt'))
+    vi.stubGlobal('fetch', transport)
+    const encodedImage = Buffer.from('fixture-image-bytes').toString('base64')
+
+    const result = await createClient().generateText(PRIVATE_PROMPT, {
+      inputImage: encodedImage,
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result).toEqual({ success: true, data: 'enhanced edit prompt' })
+    const body = readSerializedBody(transport.mock.calls[0]?.[1])
+    expect(body.input).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: PRIVATE_PROMPT },
+          {
+            type: 'input_image',
+            image_url: `data:image/png;base64,${encodedImage}`,
+            detail: 'auto',
+          },
+        ],
+      },
+    ])
+    expect(Object.hasOwn(body, 'extra_body')).toBe(false)
+  })
+
+  it('validates the local Responses connection without external I/O', async () => {
+    const transport = vi.fn<typeof fetch>()
+    vi.stubGlobal('fetch', transport)
+
+    const result = await createClient().validateConnection()
+
+    expect(result).toEqual({ success: true, data: true })
+    expect(transport).not.toHaveBeenCalled()
+  })
+
+  it('normalizes SDK status errors without disclosing secrets, prompts, or upstream bodies', async () => {
+    const rawBodyMarker = 'private-upstream-response-body'
+    const transport = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          error: {
+            message: `${rawBodyMarker} ${PRIVATE_PROMPT} ${DUMMY_API_KEY}`,
+            type: 'authentication_error',
+          },
+        }),
+        {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', transport)
+
+    const result = await createClient().generateText(PRIVATE_PROMPT)
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+
+    expect(result.error).toBeInstanceOf(ImageAPIError)
+    expect((result.error as ImageAPIError & { statusCode?: number }).statusCode).toBe(401)
+
+    const disclosed = JSON.stringify({
+      message: result.error.message,
+      suggestion: result.error.suggestion,
+      context: result.error.context,
+    })
+    expect(disclosed).not.toContain(DUMMY_API_KEY)
+    expect(disclosed).not.toContain(PRIVATE_PROMPT)
+    expect(disclosed).not.toContain(rawBodyMarker)
+  })
+
+  it('normalizes an SDK abort as a sanitized NetworkError', async () => {
+    const transport = vi.fn<typeof fetch>().mockImplementation(
+      async (_url, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), {
+            once: true,
+          })
+        })
+    )
+    vi.stubGlobal('fetch', transport)
+
+    const result = await createClient().generateText(PRIVATE_PROMPT, { timeout: 1 })
+
+    expect(result.success).toBe(false)
+    if (result.success) return
+
+    expect(result.error).toBeInstanceOf(NetworkError)
+    const disclosed = JSON.stringify({
+      message: result.error.message,
+      suggestion: result.error.suggestion,
+      context: result.error.context,
+    })
+    expect(disclosed).not.toContain(DUMMY_API_KEY)
+    expect(disclosed).not.toContain(PRIVATE_PROMPT)
+  })
+})

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -7,7 +7,7 @@ import { isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
 const SEEDREAM_IMAGE_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
-const SEEDREAM_IMAGE_TIMEOUT_MS = 180000
+const SEEDREAM_IMAGE_TIMEOUT_MS = 300000
 const MAX_RESPONSE_BYTES = 48 * 1024 * 1024
 const MAX_DECODED_BYTES = 32 * 1024 * 1024
 const PNG_MIME_TYPE = 'image/png'
@@ -34,30 +34,30 @@ const SUPPORTED_INPUT_MIME_TYPES = ['image/png', 'image/jpeg'] as const
 
 const SEEDREAM_ROUTES = {
   fast: {
-    model: 'seedream-5-0-260128',
-    defaultResolution: '2K',
-    allowedResolutions: ['2K', '4K'],
-    sequentialImageGeneration: true,
+    model: 'dola-seedream-5-0-pro-260628',
+    promptOptimizationMode: 'fast',
+    defaultResolution: '1K',
+    allowedResolutions: ['1K', '2K'],
   },
   balanced: {
     model: 'dola-seedream-5-0-pro-260628',
+    promptOptimizationMode: 'standard',
     defaultResolution: '1K',
     allowedResolutions: ['1K', '2K'],
-    sequentialImageGeneration: false,
   },
   quality: {
     model: 'dola-seedream-5-0-pro-260628',
+    promptOptimizationMode: 'standard',
     defaultResolution: '1K',
     allowedResolutions: ['1K', '2K'],
-    sequentialImageGeneration: false,
   },
 } as const satisfies Record<
   ImageQuality,
   {
     model: string
+    promptOptimizationMode: 'fast' | 'standard'
     defaultResolution: ImageSize
     allowedResolutions: readonly ImageSize[]
-    sequentialImageGeneration: boolean
   }
 >
 
@@ -75,7 +75,8 @@ type ResolvedCapabilities = Readonly<{
   route: SeedreamRoute
 }>
 
-type SeedreamImageWireRequestBase = Readonly<{
+type SeedreamImageWireRequest = Readonly<{
+  model: 'dola-seedream-5-0-pro-260628'
   prompt: string
   image?: string
   size: ImageSize
@@ -83,22 +84,8 @@ type SeedreamImageWireRequestBase = Readonly<{
   output_format: 'png'
   stream: false
   watermark: false
-  optimize_prompt_options: Readonly<{ mode: 'standard' }>
+  optimize_prompt_options: Readonly<{ mode: 'fast' | 'standard' }>
 }>
-
-type SeedreamLiteImageWireRequest = SeedreamImageWireRequestBase &
-  Readonly<{
-    model: 'seedream-5-0-260128'
-    sequential_image_generation: 'disabled'
-  }>
-
-type SeedreamProImageWireRequest = SeedreamImageWireRequestBase &
-  Readonly<{
-    model: 'dola-seedream-5-0-pro-260628'
-    sequential_image_generation?: never
-  }>
-
-type SeedreamImageWireRequest = SeedreamLiteImageWireRequest | SeedreamProImageWireRequest
 
 function capabilityError(message: string): Result<never, ImageAPIError> {
   return Err(
@@ -195,6 +182,7 @@ function buildWireRequest(
   resolved: ResolvedCapabilities
 ): SeedreamImageWireRequest {
   const base = {
+    model: resolved.route.model,
     prompt: appendAspectRatio(params.prompt, resolved.aspectRatio),
     ...(params.inputImage &&
       params.inputImageMimeType && {
@@ -205,21 +193,10 @@ function buildWireRequest(
     output_format: 'png',
     stream: false,
     watermark: false,
-    optimize_prompt_options: { mode: 'standard' },
+    optimize_prompt_options: { mode: resolved.route.promptOptimizationMode },
   } as const
 
-  if (resolved.route.sequentialImageGeneration) {
-    return {
-      ...base,
-      model: 'seedream-5-0-260128',
-      sequential_image_generation: 'disabled',
-    }
-  }
-
-  return {
-    ...base,
-    model: 'dola-seedream-5-0-pro-260628',
-  }
+  return base
 }
 
 async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
@@ -310,7 +287,8 @@ function parseImagePayload(payload: unknown): Result<Buffer, ImageAPIError> {
     imageData.length === 0 ||
     imageData.length > MAX_DECODED_BYTES ||
     !imageData.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC) ||
-    image['mime_type'] !== PNG_MIME_TYPE
+    (hasOwn(image, 'mime_type') && image['mime_type'] !== PNG_MIME_TYPE) ||
+    (hasOwn(image, 'output_format') && image['output_format'] !== 'png')
   ) {
     return Err(responseContractError())
   }

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -1,0 +1,478 @@
+import type { AspectRatio, ImageQuality, ImageSize } from '../types/mcp.js'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import type { Config } from '../utils/config.js'
+import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { isNetworkError } from './errorClassification.js'
+import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
+
+const SEEDREAM_IMAGE_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
+const SEEDREAM_IMAGE_TIMEOUT_MS = 180000
+const MAX_RESPONSE_BYTES = 48 * 1024 * 1024
+const MAX_DECODED_BYTES = 32 * 1024 * 1024
+const PNG_MIME_TYPE = 'image/png'
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+
+const ASPECT_RATIOS: readonly AspectRatio[] = [
+  '1:1',
+  '1:4',
+  '1:8',
+  '2:3',
+  '3:2',
+  '3:4',
+  '4:1',
+  '4:3',
+  '4:5',
+  '5:4',
+  '8:1',
+  '9:16',
+  '16:9',
+  '21:9',
+]
+
+const SUPPORTED_INPUT_MIME_TYPES = ['image/png', 'image/jpeg'] as const
+
+const SEEDREAM_ROUTES = {
+  fast: {
+    model: 'seedream-5-0-260128',
+    defaultResolution: '2K',
+    allowedResolutions: ['2K', '4K'],
+    sequentialImageGeneration: true,
+  },
+  balanced: {
+    model: 'dola-seedream-5-0-pro-260628',
+    defaultResolution: '1K',
+    allowedResolutions: ['1K', '2K'],
+    sequentialImageGeneration: false,
+  },
+  quality: {
+    model: 'dola-seedream-5-0-pro-260628',
+    defaultResolution: '1K',
+    allowedResolutions: ['1K', '2K'],
+    sequentialImageGeneration: false,
+  },
+} as const satisfies Record<
+  ImageQuality,
+  {
+    model: string
+    defaultResolution: ImageSize
+    allowedResolutions: readonly ImageSize[]
+    sequentialImageGeneration: boolean
+  }
+>
+
+type ProviderCapabilityInput = Pick<
+  ImageApiParams,
+  'inputImage' | 'inputImageMimeType' | 'aspectRatio' | 'imageSize' | 'useGoogleSearch' | 'quality'
+>
+
+type SeedreamRoute = (typeof SEEDREAM_ROUTES)[ImageQuality]
+
+type ResolvedCapabilities = Readonly<{
+  aspectRatio: AspectRatio
+  quality: ImageQuality
+  resolution: ImageSize
+  route: SeedreamRoute
+}>
+
+type SeedreamImageWireRequestBase = Readonly<{
+  prompt: string
+  image?: string
+  size: ImageSize
+  response_format: 'b64_json'
+  output_format: 'png'
+  stream: false
+  watermark: false
+  optimize_prompt_options: Readonly<{ mode: 'standard' }>
+}>
+
+type SeedreamLiteImageWireRequest = SeedreamImageWireRequestBase &
+  Readonly<{
+    model: 'seedream-5-0-260128'
+    sequential_image_generation: 'disabled'
+  }>
+
+type SeedreamProImageWireRequest = SeedreamImageWireRequestBase &
+  Readonly<{
+    model: 'dola-seedream-5-0-pro-260628'
+    sequential_image_generation?: never
+  }>
+
+type SeedreamImageWireRequest = SeedreamLiteImageWireRequest | SeedreamProImageWireRequest
+
+function capabilityError(message: string): Result<never, ImageAPIError> {
+  return Err(
+    new ImageAPIError(message, {
+      provider: 'seedream',
+      stage: 'capability_preflight',
+      suggestion: 'Use a supported Seedream image option without changing provider or model values',
+    })
+  )
+}
+
+function responseContractError(): ImageAPIError {
+  return new ImageAPIError('Invalid response from Seedream image provider', {
+    provider: 'seedream',
+    stage: 'image_response',
+    suggestion: 'Retry the request; the provider response did not satisfy the PNG contract',
+  })
+}
+
+function isStrictBase64(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value.length % 4 === 0 &&
+    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  )
+}
+
+function hasOwn(record: object, key: PropertyKey): boolean {
+  return Object.getOwnPropertyDescriptor(record, key) !== undefined
+}
+
+function resolveCapabilities(
+  input: ProviderCapabilityInput,
+  defaultQuality: ImageQuality
+): Result<ResolvedCapabilities, ImageAPIError> {
+  if (input.useGoogleSearch === true) {
+    return capabilityError('Google Search is not supported by the Seedream image provider')
+  }
+
+  const quality = input.quality ?? defaultQuality
+  if (!hasOwn(SEEDREAM_ROUTES, quality)) {
+    return capabilityError('Unsupported Seedream image quality')
+  }
+
+  const route = SEEDREAM_ROUTES[quality]
+  const resolution = input.imageSize ?? route.defaultResolution
+  if (!route.allowedResolutions.some((allowed) => allowed === resolution)) {
+    return capabilityError('Unsupported Seedream model and resolution combination')
+  }
+
+  const aspectRatio = input.aspectRatio ?? '1:1'
+  if (!ASPECT_RATIOS.some((allowed) => allowed === aspectRatio)) {
+    return capabilityError('Unsupported Seedream image aspect ratio')
+  }
+
+  const hasInputImage = input.inputImage !== undefined
+  const hasInputMimeType = input.inputImageMimeType !== undefined
+  if (hasInputImage !== hasInputMimeType) {
+    return capabilityError('Seedream image editing requires one image and its MIME type')
+  }
+
+  if (hasInputImage && hasInputMimeType) {
+    if (!SUPPORTED_INPUT_MIME_TYPES.some((supported) => supported === input.inputImageMimeType)) {
+      return capabilityError('Unsupported Seedream input image MIME type')
+    }
+
+    if (!isStrictBase64(input.inputImage ?? '')) {
+      return capabilityError('Invalid Seedream input image data')
+    }
+  }
+
+  return Ok({
+    aspectRatio,
+    quality,
+    resolution,
+    route,
+  })
+}
+
+export function validateSeedreamCapabilities(
+  input: ProviderCapabilityInput,
+  defaultQuality: ImageQuality
+): Result<void, ImageAPIError> {
+  const result = resolveCapabilities(input, defaultQuality)
+  return result.success ? Ok(undefined) : result
+}
+
+function appendAspectRatio(prompt: string, aspectRatio: AspectRatio): string {
+  return `${prompt}\n\nOutput aspect ratio: ${aspectRatio}.`
+}
+
+function buildWireRequest(
+  params: ImageApiParams,
+  resolved: ResolvedCapabilities
+): SeedreamImageWireRequest {
+  const base = {
+    prompt: appendAspectRatio(params.prompt, resolved.aspectRatio),
+    ...(params.inputImage &&
+      params.inputImageMimeType && {
+        image: `data:${params.inputImageMimeType};base64,${params.inputImage}`,
+      }),
+    size: resolved.resolution,
+    response_format: 'b64_json',
+    output_format: 'png',
+    stream: false,
+    watermark: false,
+    optimize_prompt_options: { mode: 'standard' },
+  } as const
+
+  if (resolved.route.sequentialImageGeneration) {
+    return {
+      ...base,
+      model: 'seedream-5-0-260128',
+      sequential_image_generation: 'disabled',
+    }
+  }
+
+  return {
+    ...base,
+    model: 'dola-seedream-5-0-pro-260628',
+  }
+}
+
+async function cancelBody(body: ReadableStream<Uint8Array> | null): Promise<void> {
+  if (body) {
+    await body.cancel()
+  }
+}
+
+async function readBoundedJson(response: Response): Promise<Result<unknown, ImageAPIError>> {
+  const contentLength = response.headers.get('content-length')
+  if (contentLength && /^\d+$/.test(contentLength) && Number(contentLength) > MAX_RESPONSE_BYTES) {
+    await cancelBody(response.body)
+    return Err(responseContractError())
+  }
+
+  if (response.headers.get('content-type')?.toLowerCase().includes('text/event-stream')) {
+    await cancelBody(response.body)
+    return Err(responseContractError())
+  }
+
+  if (!response.body) {
+    return Err(responseContractError())
+  }
+
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+
+    totalBytes += value.byteLength
+    if (totalBytes > MAX_RESPONSE_BYTES) {
+      await reader.cancel()
+      return Err(responseContractError())
+    }
+    chunks.push(value)
+  }
+
+  const bodyBytes = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    bodyBytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+
+  try {
+    return Ok(JSON.parse(new TextDecoder().decode(bodyBytes)))
+  } catch {
+    return Err(responseContractError())
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function calculateDecodedSize(base64: string): number {
+  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0
+  return (base64.length / 4) * 3 - padding
+}
+
+function parseImagePayload(payload: unknown): Result<Buffer, ImageAPIError> {
+  if (!isRecord(payload) || !Array.isArray(payload['data']) || payload['data'].length !== 1) {
+    return Err(responseContractError())
+  }
+
+  const image = payload['data'][0]
+  if (
+    !isRecord(image) ||
+    hasOwn(image, 'url') ||
+    hasOwn(image, 'stream') ||
+    typeof image['b64_json'] !== 'string' ||
+    !isStrictBase64(image['b64_json'])
+  ) {
+    return Err(responseContractError())
+  }
+
+  if (calculateDecodedSize(image['b64_json']) > MAX_DECODED_BYTES) {
+    return Err(responseContractError())
+  }
+
+  const imageData = Buffer.from(image['b64_json'], 'base64')
+  if (
+    imageData.length === 0 ||
+    imageData.length > MAX_DECODED_BYTES ||
+    !imageData.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC) ||
+    image['mime_type'] !== PNG_MIME_TYPE
+  ) {
+    return Err(responseContractError())
+  }
+
+  return Ok(imageData)
+}
+
+class SeedreamImageClientImpl implements ImageClient {
+  constructor(
+    private readonly apiKey: string,
+    private readonly defaultQuality: ImageQuality
+  ) {}
+
+  async generateImage(
+    params: ImageApiParams
+  ): Promise<Result<GeneratedImageResult, ImageAPIError | NetworkError>> {
+    const resolvedResult = resolveCapabilities(params, this.defaultQuality)
+    if (!resolvedResult.success) {
+      return resolvedResult
+    }
+
+    const request = buildWireRequest(params, resolvedResult.data)
+
+    try {
+      const response = await fetch(SEEDREAM_IMAGE_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(request),
+        signal: AbortSignal.timeout(SEEDREAM_IMAGE_TIMEOUT_MS),
+      })
+
+      if (!response.ok) {
+        await cancelBody(response.body)
+        return this.normalizeHttpError(response.status)
+      }
+
+      const payloadResult = await readBoundedJson(response)
+      if (!payloadResult.success) {
+        return payloadResult
+      }
+
+      const imageResult = parseImagePayload(payloadResult.data)
+      if (!imageResult.success) {
+        return imageResult
+      }
+
+      return Ok({
+        imageData: imageResult.data,
+        metadata: {
+          model: resolvedResult.data.route.model,
+          provider: 'seedream',
+          prompt: request.prompt,
+          mimeType: PNG_MIME_TYPE,
+          timestamp: new Date(),
+          inputImageProvided: params.inputImage !== undefined,
+        },
+      })
+    } catch (error) {
+      return this.normalizeTransportError(error)
+    }
+  }
+
+  private normalizeHttpError(statusCode: number): Result<never, ImageAPIError | NetworkError> {
+    if (statusCode >= 500) {
+      return Err(
+        new NetworkError('Seedream image provider unavailable', {
+          provider: 'seedream',
+          stage: 'image_request',
+          failureType: 'upstream',
+          upstreamStatus: statusCode,
+        })
+      )
+    }
+
+    return Err(
+      new ImageAPIError(
+        'Seedream image request was rejected',
+        {
+          provider: 'seedream',
+          stage: 'image_request',
+          upstreamStatus: statusCode,
+          suggestion:
+            statusCode === 401 || statusCode === 403
+              ? 'Check that ARK_API_KEY can access the pinned Seedream image model'
+              : 'Check the supported Seedream image request options and account quota',
+        },
+        statusCode
+      )
+    )
+  }
+
+  private normalizeTransportError(error: unknown): Result<never, ImageAPIError | NetworkError> {
+    if (this.isAbortFailure(error)) {
+      return Err(
+        new NetworkError('Timeout during Seedream image generation', {
+          provider: 'seedream',
+          stage: 'image_request',
+          failureType: 'timeout',
+        })
+      )
+    }
+
+    if (this.isNetworkFailure(error)) {
+      return Err(
+        new NetworkError('Network error during Seedream image generation', {
+          provider: 'seedream',
+          stage: 'image_request',
+          failureType: 'network',
+        })
+      )
+    }
+
+    return Err(
+      new ImageAPIError('Failed during Seedream image generation', {
+        provider: 'seedream',
+        stage: 'image_request',
+        suggestion: 'Retry the image request or check the ModelArk service status',
+      })
+    )
+  }
+
+  private isNetworkFailure(error: unknown): boolean {
+    let current = error
+
+    for (let depth = 0; depth < 4 && current instanceof Error; depth += 1) {
+      if (current instanceof TypeError || isNetworkError(current)) {
+        return true
+      }
+      current = Reflect.get(current, 'cause')
+    }
+
+    return false
+  }
+
+  private isAbortFailure(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      (error.name === 'AbortError' ||
+        error.name === 'TimeoutError' ||
+        error.message === 'Request was aborted.')
+    )
+  }
+}
+
+export function createSeedreamImageClient(config: Config): Result<ImageClient, ImageAPIError> {
+  const apiKey = config.arkApiKey.trim()
+  if (apiKey.length === 0) {
+    return Err(
+      new ImageAPIError(
+        'Failed to initialize Seedream image client',
+        'Set ARK_API_KEY to a non-empty ModelArk API key'
+      )
+    )
+  }
+
+  const capabilityResult = resolveCapabilities({}, config.imageQuality)
+  if (!capabilityResult.success) {
+    return capabilityResult
+  }
+
+  return Ok(new SeedreamImageClientImpl(apiKey, config.imageQuality))
+}

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -459,8 +459,7 @@ class SeedreamImageClientImpl implements ImageClient {
 }
 
 export function createSeedreamImageClient(config: Config): Result<ImageClient, ImageAPIError> {
-  const apiKey = config.arkApiKey.trim()
-  if (apiKey.length === 0) {
+  if (config.arkApiKey.trim().length === 0) {
     return Err(
       new ImageAPIError(
         'Failed to initialize Seedream image client',
@@ -474,5 +473,5 @@ export function createSeedreamImageClient(config: Config): Result<ImageClient, I
     return capabilityResult
   }
 
-  return Ok(new SeedreamImageClientImpl(apiKey, config.imageQuality))
+  return Ok(new SeedreamImageClientImpl(config.arkApiKey, config.imageQuality))
 }

--- a/src/api/seedreamTextClient.ts
+++ b/src/api/seedreamTextClient.ts
@@ -1,0 +1,204 @@
+import OpenAI from 'openai'
+import type { ResponseCreateParamsNonStreaming } from 'openai/resources/responses/responses'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import type { Config } from '../utils/config.js'
+import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { extractStatusCode, isNetworkError } from './errorClassification.js'
+import type { GenerationConfig, TextClient } from './textClient.js'
+
+const MODELARK_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3'
+const SEEDREAM_TEXT_MODEL = 'seed-2-0-lite-260428'
+const DEFAULT_TEXT_TIMEOUT = 30000
+
+type SeedreamTextRequest = ResponseCreateParamsNonStreaming &
+  Readonly<{
+    model: typeof SEEDREAM_TEXT_MODEL
+    thinking: Readonly<{
+      type: 'disabled'
+    }>
+  }>
+
+class SeedreamTextClientImpl implements TextClient {
+  private readonly client: OpenAI
+
+  constructor(config: Config) {
+    this.client = new OpenAI({
+      apiKey: config.arkApiKey,
+      baseURL: MODELARK_BASE_URL,
+    })
+  }
+
+  async generateText(
+    prompt: string,
+    config: GenerationConfig = {}
+  ): Promise<Result<string, ImageAPIError | NetworkError>> {
+    const validationResult = this.validatePromptInput(prompt)
+    if (!validationResult.success) {
+      return validationResult
+    }
+
+    const request: SeedreamTextRequest = {
+      model: SEEDREAM_TEXT_MODEL,
+      input: this.buildInput(prompt, config),
+      ...(config.systemInstruction && { instructions: config.systemInstruction }),
+      max_output_tokens: config.maxTokens ?? 8192,
+      temperature: config.temperature ?? 0.7,
+      top_p: config.topP ?? 0.95,
+      thinking: { type: 'disabled' },
+    }
+
+    try {
+      const response = await this.client.responses.create(request, {
+        signal: AbortSignal.timeout(config.timeout ?? DEFAULT_TEXT_TIMEOUT),
+      })
+      const responseText = response.output_text
+
+      if (!responseText || responseText.trim().length === 0) {
+        return Err(
+          new ImageAPIError(
+            'Failed during Seedream text generation',
+            'The text provider returned an empty response'
+          )
+        )
+      }
+
+      return Ok(responseText)
+    } catch (error) {
+      return this.handleError(error, 'text generation')
+    }
+  }
+
+  async validateConnection(): Promise<Result<boolean, ImageAPIError | NetworkError>> {
+    try {
+      if (!this.client.responses) {
+        return Err(
+          new ImageAPIError(
+            'Failed to access Seedream Responses API',
+            'Check your ARK_API_KEY configuration'
+          )
+        )
+      }
+
+      return Ok(true)
+    } catch (error) {
+      return this.handleError(error, 'connection validation')
+    }
+  }
+
+  private buildInput(prompt: string, config: GenerationConfig) {
+    if (!config.inputImage) {
+      return prompt
+    }
+
+    const mimeType = normalizeMimeType(config.inputImageMimeType ?? DEFAULT_MIME_TYPE)
+
+    return [
+      {
+        role: 'user' as const,
+        content: [
+          {
+            type: 'input_text' as const,
+            text: prompt,
+          },
+          {
+            type: 'input_image' as const,
+            image_url: `data:${mimeType};base64,${config.inputImage}`,
+            detail: 'auto' as const,
+          },
+        ],
+      },
+    ]
+  }
+
+  private handleError(error: unknown, stage: string): Result<never, ImageAPIError | NetworkError> {
+    if (this.isNetworkFailure(error)) {
+      const timedOut = this.isAbortFailure(error)
+      return Err(
+        new NetworkError(`${timedOut ? 'Timeout' : 'Network error'} during Seedream ${stage}`, {
+          provider: 'seedream',
+          stage,
+          failureType: timedOut ? 'timeout' : 'network',
+        })
+      )
+    }
+
+    const statusCode = extractStatusCode(error)
+    return Err(
+      new ImageAPIError(
+        `Failed during Seedream ${stage}`,
+        {
+          provider: 'seedream',
+          stage,
+          ...(statusCode !== undefined && { upstreamStatus: statusCode }),
+          suggestion: this.getAPIErrorSuggestion(statusCode),
+        },
+        statusCode
+      )
+    )
+  }
+
+  private isNetworkFailure(error: unknown): boolean {
+    let current = error
+
+    for (let depth = 0; depth < 4 && current instanceof Error; depth += 1) {
+      if (isNetworkError(current) || this.isAbortFailure(current)) {
+        return true
+      }
+      current = Reflect.get(current, 'cause')
+    }
+
+    return false
+  }
+
+  private isAbortFailure(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      (error.name === 'AbortError' ||
+        error.constructor.name === 'APIUserAbortError' ||
+        error.message === 'Request was aborted.')
+    )
+  }
+
+  private getAPIErrorSuggestion(statusCode: number | undefined): string {
+    if (statusCode === 401 || statusCode === 403) {
+      return 'Check that ARK_API_KEY is valid and can access the pinned Seedream text model'
+    }
+
+    if (statusCode === 429) {
+      return 'Wait before retrying or check the ModelArk quota for this account'
+    }
+
+    if (statusCode !== undefined && statusCode >= 500) {
+      return 'The text provider is temporarily unavailable; retry later'
+    }
+
+    return 'Check ModelArk text API configuration and try again'
+  }
+
+  private validatePromptInput(prompt: string): Result<true, ImageAPIError> {
+    if (!prompt || prompt.trim().length === 0) {
+      return Err(new ImageAPIError('Empty prompt provided', 'Please provide a non-empty prompt'))
+    }
+
+    if (prompt.length > 100000) {
+      return Err(new ImageAPIError('Prompt too long', 'Please provide a shorter prompt'))
+    }
+
+    return Ok(true)
+  }
+}
+
+export function createSeedreamTextClient(config: Config): Result<TextClient, ImageAPIError> {
+  try {
+    return Ok(new SeedreamTextClientImpl(config))
+  } catch {
+    return Err(
+      new ImageAPIError(
+        'Failed to initialize Seedream text client',
+        'Verify ARK_API_KEY and the installed OpenAI SDK configuration'
+      )
+    )
+  }
+}

--- a/src/business/__tests__/inputValidator.test.ts
+++ b/src/business/__tests__/inputValidator.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import type { AspectRatio, GenerateImageParams } from '../../types/mcp'
-import { validateBase64Image, validateGenerateImageParams, validatePrompt } from '../inputValidator'
+import {
+  MAX_IMAGE_SIZE,
+  validateBase64Image,
+  validateGenerateImageParams,
+  validatePrompt,
+} from '../inputValidator'
 
 describe('inputValidator', () => {
   describe('validatePrompt', () => {
@@ -120,9 +125,24 @@ describe('inputValidator', () => {
       }
     })
 
-    it('should return error for image data exceeding 10MB', () => {
-      // Arrange - Create a large base64 string (over 10MB when decoded)
-      const largeBinaryData = Buffer.alloc(11 * 1024 * 1024, 'a') // 11MB
+    it('should return success for image data at exactly 10MB', () => {
+      // Arrange
+      const boundaryBinaryData = Buffer.alloc(MAX_IMAGE_SIZE, 'a')
+      const boundaryBase64 = boundaryBinaryData.toString('base64')
+
+      // Act
+      const result = validateBase64Image(boundaryBase64)
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toHaveLength(MAX_IMAGE_SIZE)
+      }
+    })
+
+    it('should return error for image data exceeding 10MB by one byte', () => {
+      // Arrange
+      const largeBinaryData = Buffer.alloc(MAX_IMAGE_SIZE + 1, 'a')
       const largeBase64 = largeBinaryData.toString('base64')
 
       // Act
@@ -204,6 +224,44 @@ describe('inputValidator', () => {
       expect(result.success).toBe(true)
       if (result.success) {
         expect(result.data).toEqual(validParams)
+      }
+    })
+
+    it.each([
+      ['undefined', undefined],
+      ['true', true],
+      ['false', false],
+    ])('should accept useGoogleSearch when it is %s', (_name, useGoogleSearch) => {
+      const params: GenerateImageParams = {
+        prompt: 'Generate a beautiful landscape',
+        useGoogleSearch,
+      }
+
+      const result = validateGenerateImageParams(params)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual(params)
+      }
+    })
+
+    it.each([
+      ['string', 'true'],
+      ['number', 1],
+      ['null', null],
+      ['object', { enabled: true }],
+    ])('should reject useGoogleSearch when it is a %s', (_name, useGoogleSearch) => {
+      const params = {
+        prompt: 'Generate a beautiful landscape',
+        useGoogleSearch,
+      } as unknown as GenerateImageParams
+
+      const result = validateGenerateImageParams(params)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('INPUT_VALIDATION_ERROR')
+        expect(result.error.message).toContain('useGoogleSearch must be a boolean value')
       }
     })
   })

--- a/src/business/__tests__/structuredPromptGenerator.test.ts
+++ b/src/business/__tests__/structuredPromptGenerator.test.ts
@@ -18,9 +18,13 @@ describe('StructuredPromptGenerator', () => {
     vi.clearAllMocks()
   })
 
+  function createGenerator(maxTokens = 1000) {
+    return new StructuredPromptGeneratorImpl(mockGeminiTextClient, maxTokens)
+  }
+
   describe('generateStructuredPrompt', () => {
     it('should generate structured prompt successfully', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'A beautiful sunset'
       const structuredPrompt =
         'A beautiful sunset, dramatic cinematic lighting with golden hour warmth, shot with 85mm lens'
@@ -35,10 +39,26 @@ describe('StructuredPromptGenerator', () => {
         expect(result.data.structuredPrompt).toBe(structuredPrompt)
         expect(result.data.selectedPractices).toContain('Hyper-Specific Details')
       }
+      expect(mockGeminiTextClient.generateText).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ maxTokens: 1000 })
+      )
+    })
+
+    it('uses the configured prompt-generation token limit', async () => {
+      const generator = createGenerator(384)
+      vi.mocked(mockGeminiTextClient.generateText).mockResolvedValue(Ok('Enhanced prompt'))
+
+      await generator.generateStructuredPrompt('A rainy street')
+
+      expect(mockGeminiTextClient.generateText).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ maxTokens: 384 })
+      )
     })
 
     it('should handle feature flags correctly', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'A warrior in the forest'
       const features = {
         maintainCharacterConsistency: true,
@@ -61,7 +81,7 @@ describe('StructuredPromptGenerator', () => {
     })
 
     it('should return error for empty prompt', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
 
       const result = await generator.generateStructuredPrompt('')
 
@@ -73,7 +93,7 @@ describe('StructuredPromptGenerator', () => {
     })
 
     it('should handle Gemini API errors', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'A test prompt'
       const apiError = new GeminiAPIError('API failed')
 
@@ -88,7 +108,7 @@ describe('StructuredPromptGenerator', () => {
     })
 
     it('should infer selected practices from generated prompt', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'A portrait'
       const structuredPrompt =
         'A portrait with dramatic lighting, 85mm lens at f/1.4 aperture, maintaining facial features consistency'
@@ -108,7 +128,7 @@ describe('StructuredPromptGenerator', () => {
     })
 
     it('should include purpose context when purpose is provided', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'Delicious pasta dish'
       const purpose = 'high-end Italian restaurant menu'
 
@@ -127,7 +147,7 @@ describe('StructuredPromptGenerator', () => {
     })
 
     it('should not include purpose context when purpose is not provided', async () => {
-      const generator = new StructuredPromptGeneratorImpl(mockGeminiTextClient)
+      const generator = createGenerator()
       const userPrompt = 'A simple cat'
 
       vi.mocked(mockGeminiTextClient.generateText).mockResolvedValue(

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -15,7 +15,7 @@ import { SUPPORTED_EXTENSIONS, SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.j
 // Constants for validation limits
 const PROMPT_MIN_LENGTH = 1
 const PROMPT_MAX_LENGTH = 4000
-const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
+export const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
 const SUPPORTED_ASPECT_RATIOS: readonly AspectRatio[] = [
   '1:1',
   '1:4',
@@ -208,6 +208,16 @@ export function validateGenerateImageParams(
       new InputValidationError(
         'useWorldKnowledge must be a boolean value',
         'Use true or false for useWorldKnowledge parameter to enable/disable world knowledge integration'
+      )
+    )
+  }
+
+  // Validate useGoogleSearch parameter
+  if (params.useGoogleSearch !== undefined && typeof params.useGoogleSearch !== 'boolean') {
+    return Err(
+      new InputValidationError(
+        'useGoogleSearch must be a boolean value',
+        'Use true or false for useGoogleSearch parameter to enable/disable Google Search grounding'
       )
     )
   }

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -1,6 +1,6 @@
 /**
  * Structured Prompt Generator
- * Uses Gemini Flash to generate optimized prompts for image generation
+ * Uses the selected provider's text client to generate optimized image prompts
  * Applies 7 best practices and 3 feature perspectives through intelligent selection
  */
 
@@ -39,7 +39,6 @@ Core principles:
 - Maintain clarity while adding richness and specificity
 
 Your output should weave these elements into a single, natural flowing description - not a structured list. Make it vivid, engaging, and unambiguous.`
-
 /**
  * Additional system prompt for image editing mode (when input image is provided)
  */
@@ -85,10 +84,13 @@ export interface StructuredPromptGenerator {
 }
 
 /**
- * Implementation of StructuredPromptGenerator using Gemini Flash
+ * Provider-neutral implementation of StructuredPromptGenerator
  */
 export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator {
-  constructor(private readonly textClient: TextClient) {}
+  constructor(
+    private readonly textClient: TextClient,
+    private readonly maxTokens: number
+  ) {}
 
   async generateStructuredPrompt(
     userPrompt: string,
@@ -119,7 +121,7 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
       // Generate structured prompt via pure API call
       const config = {
         temperature: 0.7,
-        maxTokens: 1000,
+        maxTokens: this.maxTokens,
         systemInstruction,
         ...(inputImageData && { inputImage: inputImageData }),
         ...(inputImageMimeType && { inputImageMimeType }),
@@ -310,6 +312,9 @@ Now transform the user's request with similar attention to detail and creative e
 /**
  * Factory function to create StructuredPromptGenerator
  */
-export function createStructuredPromptGenerator(textClient: TextClient): StructuredPromptGenerator {
-  return new StructuredPromptGeneratorImpl(textClient)
+export function createStructuredPromptGenerator(
+  textClient: TextClient,
+  maxTokens: number
+): StructuredPromptGenerator {
+  return new StructuredPromptGeneratorImpl(textClient, maxTokens)
 }

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -1094,7 +1094,7 @@ describe('BytePlus Seedream integration', () => {
       {
         name: 'unsupported-editing-input',
         args: { inputImagePath: '__CREATE_UNSUPPORTED_INPUT__' },
-        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedCode: 'IMAGE_API_ERROR',
         expectedDecodeCalls: 0,
         expectedImageCalls: 0,
         expectedParseCalls: 0,
@@ -1417,9 +1417,34 @@ describe('BytePlus Seedream integration', () => {
       const parseCount = jsonParseSpy.mock.calls
         .slice(beforeParseCalls)
         .filter(([value]) => typeof value === 'string' && value.includes(responseSentinel)).length
+      const pngBase64 = createPngFixture(imageSentinel).toString('base64')
+      const nonPngBase64 = Buffer.from(`not-a-png:${imageSentinel}`).toString('base64')
+      const oversizedBase64Length = Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)
       const decodeCount = bufferFromSpy.mock.calls
         .slice(beforeDecodeCalls)
-        .filter(([, encoding]) => encoding === 'base64').length
+        .filter(([value, encoding]) => {
+          if (encoding !== 'base64' || typeof value !== 'string') {
+            return false
+          }
+
+          if (row.name === 'extra-images' || row.name === 'wrong-mime') {
+            return value === pngBase64
+          }
+          if (row.name === 'malformed-base64') {
+            return value === `***${imageSentinel}`
+          }
+          if (row.name === 'empty-base64') {
+            return value === ''
+          }
+          if (row.name === 'decoded-size-over-32-mib') {
+            return value.length === oversizedBase64Length && value.startsWith('A')
+          }
+          if (row.name === 'non-png-magic') {
+            return value === nonPngBase64
+          }
+
+          return false
+        }).length
       const publicResponse = parsePublicResponse(result)
       const publicError = (publicResponse.error ?? {}) as Record<string, unknown>
       const exposed = `${JSON.stringify(publicResponse)}\n${capturedLogs()}`

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -1,11 +1,19 @@
-import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
+import { constants as fsConstants } from 'node:fs'
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ImageClient } from '../../api/imageClient.js'
 import type { FileManager } from '../../business/fileManager.js'
+import { MAX_IMAGE_SIZE } from '../../business/inputValidator.js'
 import type { ResponseBuilder } from '../../business/responseBuilder.js'
 import type { StructuredPromptGenerator } from '../../business/structuredPromptGenerator.js'
 import { createMCPServer } from '../mcpServer.js'
+
+const fileSystem = vi.hoisted(() => ({
+  actualOpen: undefined as typeof import('node:fs/promises').open | undefined,
+  open: vi.fn(),
+}))
 
 const transports = vi.hoisted(() => ({
   fetch: vi.fn(),
@@ -20,6 +28,16 @@ const transports = vi.hoisted(() => ({
   openAIResponsesCreate: vi.fn(),
   toFile: vi.fn(),
 }))
+
+vi.mock('node:fs/promises', async (importActual) => {
+  const actual = await importActual<typeof import('node:fs/promises')>()
+  fileSystem.actualOpen = actual.open
+  fileSystem.open.mockImplementation(actual.open)
+  return {
+    ...actual,
+    open: fileSystem.open,
+  }
+})
 
 vi.mock('@google/genai', async (importActual) => {
   const actual = await importActual<typeof import('@google/genai')>()
@@ -112,6 +130,11 @@ let originalEnv: Partial<Record<(typeof TRACKED_ENV)[number], string>>
 const temporaryDirectories = new Set<string>()
 
 function resetTransportDoubles(): void {
+  if (!fileSystem.actualOpen) {
+    throw new Error('node:fs/promises.open test delegate is not initialized')
+  }
+  fileSystem.open.mockReset()
+  fileSystem.open.mockImplementation(fileSystem.actualOpen)
   transports.fetch.mockReset()
   transports.googleConstructor.mockReset()
   transports.googleGenerateContent.mockReset()
@@ -217,6 +240,17 @@ function configureSeedream(
   process.env.IMAGE_OUTPUT_DIR = outputDirectory
   process.env.IMAGE_QUALITY = options.imageQuality ?? 'fast'
   process.env.SKIP_PROMPT_ENHANCEMENT = String(options.skipPromptEnhancement ?? false)
+  process.env.NODE_ENV = 'test'
+}
+
+function configureGemini(outputDirectory: string): void {
+  process.env.IMAGE_PROVIDER = 'gemini'
+  process.env.GEMINI_API_KEY = 'gemini-dummy-integration-key'
+  process.env.OPENAI_API_KEY = 'openai-dummy-integration-key'
+  process.env.ARK_API_KEY = ARK_DUMMY_KEY
+  process.env.IMAGE_OUTPUT_DIR = outputDirectory
+  process.env.IMAGE_QUALITY = 'fast'
+  process.env.SKIP_PROMPT_ENHANCEMENT = 'true'
   process.env.NODE_ENV = 'test'
 }
 
@@ -1026,6 +1060,348 @@ describe('BytePlus Seedream integration', () => {
     }
   })
 
+  // AC: SEC-FILE-BOUND-01, SEC-FILE-TYPE-02, INPUT-SIZE-CONTRACT-04, RESOURCE-CLEANUP-05
+  // Behavior: file-backed input -> opened-handle bounded read -> exact-limit success or contained
+  // validation error with no base64/downstream side effect and guaranteed handle cleanup.
+  // @category: integration
+  // @lane: integration
+  // @dependency: createMCPServer, input validation, Gemini ImageClient, FileManager, ResponseBuilder
+  // @real-dependency: path sanitization and temporary filesystem
+  // @complexity: high
+  // Value Score: 110
+  // Budget justification: this task explicitly requires an independent common file-boundary proof;
+  // it is not a Seedream transport variant covered by the original three annotated integration cases.
+  it('bounds file-backed input before base64 and downstream side effects', async () => {
+    const inputDirectory = await createOutputDirectory()
+    const expectedInputOpenFlags =
+      fsConstants.O_RDONLY |
+      (typeof fsConstants.O_NONBLOCK === 'number' ? fsConstants.O_NONBLOCK : 0) |
+      (typeof fsConstants.O_NOFOLLOW === 'number' ? fsConstants.O_NOFOLLOW : 0)
+    const bufferAllocSpy = vi.spyOn(Buffer, 'alloc')
+    const bufferToStringSpy = vi.spyOn(Buffer.prototype, 'toString')
+
+    resetTransportDoubles()
+    const exactOutputDirectory = await createOutputDirectory()
+    const exactInputPath = join(inputDirectory, 'exact-limit.png')
+    await writeFile(exactInputPath, Buffer.alloc(MAX_IMAGE_SIZE, 0x61))
+    configureGemini(exactOutputDirectory)
+    let exactCloseSpy: ReturnType<typeof vi.spyOn> | undefined
+    fileSystem.open.mockImplementation(async (filePath: string, flags: string | number) => {
+      if (!fileSystem.actualOpen) {
+        throw new Error('node:fs/promises.open test delegate is not initialized')
+      }
+      const handle = await fileSystem.actualOpen(filePath, flags)
+      if (filePath.endsWith('/exact-limit.png')) {
+        exactCloseSpy = vi.spyOn(handle, 'close')
+      }
+      return handle
+    })
+    const exactServer = createMCPServer()
+    const exactInternals = readServerInternals(exactServer)
+    const exactSaveSpy = vi.spyOn(exactInternals.fileManager, 'saveImage')
+    const beforeExactAllocCalls = bufferAllocSpy.mock.calls.length
+
+    expect.soft(await readdir(exactOutputDirectory), 'exact-limit:before').toEqual([])
+    const exactResult = await exactServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'exact-limit-output.png',
+      inputImagePath: exactInputPath,
+    })
+    const exactAllocSizes = bufferAllocSpy.mock.calls
+      .slice(beforeExactAllocCalls)
+      .map(([size]) => size)
+
+    expect.soft(exactResult.isError, 'exact-limit').toBe(false)
+    expect.soft(fileSystem.open, 'exact-limit').toHaveBeenCalledTimes(1)
+    expect
+      .soft(fileSystem.open, 'exact-limit')
+      .toHaveBeenCalledWith(expect.stringMatching(/\/exact-limit\.png$/), expectedInputOpenFlags)
+    expect.soft(exactCloseSpy, 'exact-limit').toHaveBeenCalledTimes(1)
+    expect.soft(exactAllocSizes, 'exact-limit:allocation').toContain(MAX_IMAGE_SIZE + 1)
+    expect
+      .soft(
+        exactAllocSizes.every((size) => size <= MAX_IMAGE_SIZE + 1),
+        'exact-limit:ceiling'
+      )
+      .toBe(true)
+    expect.soft(transports.openAIResponsesCreate, 'exact-limit:text').not.toHaveBeenCalled()
+    expect.soft(transports.googleGenerateContent, 'exact-limit:image').toHaveBeenCalledTimes(1)
+    expect.soft(exactSaveSpy, 'exact-limit:save').toHaveBeenCalledTimes(1)
+    expect
+      .soft(await readdir(exactOutputDirectory), 'exact-limit:after')
+      .toEqual(['exact-limit-output.png'])
+
+    resetTransportDoubles()
+    const oversizedOutputDirectory = await createOutputDirectory()
+    const oversizedInputPath = join(inputDirectory, 'over-limit.png')
+    await writeFile(oversizedInputPath, Buffer.alloc(MAX_IMAGE_SIZE + 1, 0x62))
+    configureGemini(oversizedOutputDirectory)
+    let oversizedReadSpy: ReturnType<typeof vi.spyOn> | undefined
+    let oversizedCloseSpy: ReturnType<typeof vi.spyOn> | undefined
+    fileSystem.open.mockImplementation(async (filePath: string, flags: string | number) => {
+      if (!fileSystem.actualOpen) {
+        throw new Error('node:fs/promises.open test delegate is not initialized')
+      }
+      const handle = await fileSystem.actualOpen(filePath, flags)
+      if (filePath.endsWith('/over-limit.png')) {
+        oversizedReadSpy = vi.spyOn(handle, 'read')
+        oversizedCloseSpy = vi.spyOn(handle, 'close')
+      }
+      return handle
+    })
+    const oversizedServer = createMCPServer()
+    const oversizedInternals = readServerInternals(oversizedServer)
+    const oversizedSaveSpy = vi.spyOn(oversizedInternals.fileManager, 'saveImage')
+    const beforeOversizedAllocCalls = bufferAllocSpy.mock.calls.length
+    const beforeOversizedBase64Calls = bufferToStringSpy.mock.calls.length
+
+    expect.soft(await readdir(oversizedOutputDirectory), 'over-limit:before').toEqual([])
+    const oversizedResult = await oversizedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'over-limit-output.png',
+      inputImagePath: oversizedInputPath,
+    })
+    const oversizedAllocSizes = bufferAllocSpy.mock.calls
+      .slice(beforeOversizedAllocCalls)
+      .map(([size]) => size)
+    const oversizedBase64Calls = bufferToStringSpy.mock.calls
+      .slice(beforeOversizedBase64Calls)
+      .filter(([encoding]) => encoding === 'base64')
+    const oversizedError = (parsePublicResponse(oversizedResult).error ?? {}) as Record<
+      string,
+      unknown
+    >
+
+    expect.soft(oversizedResult.isError, 'over-limit').toBe(true)
+    expect.soft(oversizedError.code, 'over-limit').toBe('INPUT_VALIDATION_ERROR')
+    expect.soft(oversizedError.message, 'over-limit').toContain('10.0MB')
+    expect.soft(fileSystem.open, 'over-limit').toHaveBeenCalledTimes(1)
+    expect.soft(oversizedReadSpy, 'over-limit:read').not.toHaveBeenCalled()
+    expect.soft(oversizedCloseSpy, 'over-limit').toHaveBeenCalledTimes(1)
+    expect.soft(oversizedAllocSizes, 'over-limit:allocation').toEqual([])
+    expect.soft(oversizedBase64Calls, 'over-limit:base64').toEqual([])
+    expect.soft(transports.openAIResponsesCreate, 'over-limit:text').not.toHaveBeenCalled()
+    expect.soft(transports.googleGenerateContent, 'over-limit:image').not.toHaveBeenCalled()
+    expect.soft(oversizedSaveSpy, 'over-limit:save').not.toHaveBeenCalled()
+    expect.soft(await readdir(oversizedOutputDirectory), 'over-limit:after').toEqual([])
+
+    resetTransportDoubles()
+    const growthOutputDirectory = await createOutputDirectory()
+    const growthInputPath = join(inputDirectory, 'growth.png')
+    await writeFile(growthInputPath, Buffer.from('initial-file'))
+    const sanitizedGrowthInputPath = await realpath(growthInputPath)
+    configureGemini(growthOutputDirectory)
+    let growthObservedBytes = 0
+    let growthLargestReadEnd = 0
+    const growthClose = vi.fn(async () => undefined)
+    const growthRead = vi.fn(
+      async (buffer: Buffer, offset: number, length: number, _position: number | null) => {
+        const bytesRead = Math.min(length, MAX_IMAGE_SIZE + 1 - growthObservedBytes)
+        buffer.fill(0x63, offset, offset + bytesRead)
+        growthObservedBytes += bytesRead
+        growthLargestReadEnd = Math.max(growthLargestReadEnd, offset + length)
+        return { buffer, bytesRead }
+      }
+    )
+    const growthHandle = {
+      close: growthClose,
+      read: growthRead,
+      stat: vi.fn(async () => ({
+        isFile: () => true,
+        size: MAX_IMAGE_SIZE,
+      })),
+    }
+    // Mock-boundary rationale: simulate only the external growing-file handle/stat/read sequence;
+    // path selection, bounded reading, MCP orchestration, transports, saves, and other fs access stay real.
+    fileSystem.open.mockImplementation(async (filePath: string, flags: string | number) => {
+      if (filePath === sanitizedGrowthInputPath) {
+        return growthHandle
+      }
+      if (!fileSystem.actualOpen) {
+        throw new Error('node:fs/promises.open test delegate is not initialized')
+      }
+      return fileSystem.actualOpen(filePath, flags)
+    })
+    const growthServer = createMCPServer()
+    const growthInternals = readServerInternals(growthServer)
+    const growthSaveSpy = vi.spyOn(growthInternals.fileManager, 'saveImage')
+    const beforeGrowthAllocCalls = bufferAllocSpy.mock.calls.length
+    const beforeGrowthBase64Calls = bufferToStringSpy.mock.calls.length
+
+    expect.soft(await readdir(growthOutputDirectory), 'growth:before').toEqual([])
+    const growthResult = await growthServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'growth-output.png',
+      inputImagePath: growthInputPath,
+    })
+    const growthAllocSizes = bufferAllocSpy.mock.calls
+      .slice(beforeGrowthAllocCalls)
+      .map(([size]) => size)
+    const growthBase64Calls = bufferToStringSpy.mock.calls
+      .slice(beforeGrowthBase64Calls)
+      .filter(([encoding]) => encoding === 'base64')
+    const growthError = (parsePublicResponse(growthResult).error ?? {}) as Record<string, unknown>
+
+    expect.soft(growthResult.isError, 'growth').toBe(true)
+    expect.soft(growthError.code, 'growth').toBe('INPUT_VALIDATION_ERROR')
+    expect.soft(growthError.message, 'growth').toContain('10.0MB')
+    expect.soft(fileSystem.open, 'growth').toHaveBeenCalledTimes(1)
+    expect
+      .soft(fileSystem.open, 'growth')
+      .toHaveBeenCalledWith(sanitizedGrowthInputPath, expectedInputOpenFlags)
+    expect.soft(growthHandle.stat, 'growth:stat').toHaveBeenCalledTimes(1)
+    expect.soft(growthRead, 'growth:read').toHaveBeenCalled()
+    expect.soft(growthObservedBytes, 'growth:observed-bytes').toBe(MAX_IMAGE_SIZE + 1)
+    expect
+      .soft(growthLargestReadEnd, 'growth:allocation-ceiling')
+      .toBeLessThanOrEqual(MAX_IMAGE_SIZE + 1)
+    expect.soft(growthAllocSizes, 'growth:allocation').toContain(MAX_IMAGE_SIZE + 1)
+    expect
+      .soft(
+        growthAllocSizes.every((size) => size <= MAX_IMAGE_SIZE + 1),
+        'growth:ceiling'
+      )
+      .toBe(true)
+    expect.soft(growthClose, 'growth:close').toHaveBeenCalledTimes(1)
+    expect.soft(growthBase64Calls, 'growth:base64').toEqual([])
+    expect.soft(transports.openAIResponsesCreate, 'growth:text').not.toHaveBeenCalled()
+    expect.soft(transports.googleGenerateContent, 'growth:image').not.toHaveBeenCalled()
+    expect.soft(growthSaveSpy, 'growth:save').not.toHaveBeenCalled()
+    expect.soft(await readdir(growthOutputDirectory), 'growth:after').toEqual([])
+
+    resetTransportDoubles()
+    const nonRegularOutputDirectory = await createOutputDirectory()
+    const nonRegularInputPath = join(inputDirectory, 'non-regular.png')
+    await mkdir(nonRegularInputPath)
+    configureGemini(nonRegularOutputDirectory)
+    let nonRegularReadSpy: ReturnType<typeof vi.spyOn> | undefined
+    let nonRegularCloseSpy: ReturnType<typeof vi.spyOn> | undefined
+    fileSystem.open.mockImplementation(async (filePath: string, flags: string | number) => {
+      if (!fileSystem.actualOpen) {
+        throw new Error('node:fs/promises.open test delegate is not initialized')
+      }
+      const handle = await fileSystem.actualOpen(filePath, flags)
+      if (filePath.endsWith('/non-regular.png')) {
+        nonRegularReadSpy = vi.spyOn(handle, 'read')
+        nonRegularCloseSpy = vi.spyOn(handle, 'close')
+      }
+      return handle
+    })
+    const nonRegularServer = createMCPServer()
+    const nonRegularInternals = readServerInternals(nonRegularServer)
+    const nonRegularSaveSpy = vi.spyOn(nonRegularInternals.fileManager, 'saveImage')
+    const beforeNonRegularAllocCalls = bufferAllocSpy.mock.calls.length
+    const beforeNonRegularBase64Calls = bufferToStringSpy.mock.calls.length
+
+    expect.soft(await readdir(nonRegularOutputDirectory), 'non-regular:before').toEqual([])
+    const nonRegularResult = await nonRegularServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'non-regular-output.png',
+      inputImagePath: nonRegularInputPath,
+    })
+    const nonRegularAllocSizes = bufferAllocSpy.mock.calls
+      .slice(beforeNonRegularAllocCalls)
+      .map(([size]) => size)
+    const nonRegularBase64Calls = bufferToStringSpy.mock.calls
+      .slice(beforeNonRegularBase64Calls)
+      .filter(([encoding]) => encoding === 'base64')
+    const nonRegularError = (parsePublicResponse(nonRegularResult).error ?? {}) as Record<
+      string,
+      unknown
+    >
+
+    expect.soft(nonRegularResult.isError, 'non-regular').toBe(true)
+    expect.soft(nonRegularError.code, 'non-regular').toBe('INPUT_VALIDATION_ERROR')
+    expect.soft(fileSystem.open, 'non-regular').toHaveBeenCalledTimes(1)
+    expect.soft(nonRegularReadSpy, 'non-regular:read').not.toHaveBeenCalled()
+    expect.soft(nonRegularCloseSpy, 'non-regular:close').toHaveBeenCalledTimes(1)
+    expect.soft(nonRegularAllocSizes, 'non-regular:allocation').toEqual([])
+    expect.soft(nonRegularBase64Calls, 'non-regular:base64').toEqual([])
+    expect.soft(transports.openAIResponsesCreate, 'non-regular:text').not.toHaveBeenCalled()
+    expect.soft(transports.googleGenerateContent, 'non-regular:image').not.toHaveBeenCalled()
+    expect.soft(nonRegularSaveSpy, 'non-regular:save').not.toHaveBeenCalled()
+    expect.soft(await readdir(nonRegularOutputDirectory), 'non-regular:after').toEqual([])
+
+    // Windows does not provide POSIX named FIFOs; Unix-family CI exercises the real FIFO open.
+    if (process.platform !== 'win32') {
+      resetTransportDoubles()
+      const fifoOutputDirectory = await createOutputDirectory()
+      const fifoInputPath = join(inputDirectory, 'named-pipe.png')
+      await new Promise<void>((resolve, reject) => {
+        execFile('/usr/bin/mkfifo', [fifoInputPath], (error) => {
+          if (error) reject(error)
+          else resolve()
+        })
+      })
+      const sanitizedFifoInputPath = await realpath(fifoInputPath)
+      configureGemini(fifoOutputDirectory)
+      let fifoCloseSpy: ReturnType<typeof vi.spyOn> | undefined
+      fileSystem.open.mockImplementation(async (filePath: string, flags: string | number) => {
+        if (!fileSystem.actualOpen) {
+          throw new Error('node:fs/promises.open test delegate is not initialized')
+        }
+        const handle = await fileSystem.actualOpen(filePath, flags)
+        if (filePath === sanitizedFifoInputPath) {
+          fifoCloseSpy = vi.spyOn(handle, 'close')
+        }
+        return handle
+      })
+      const fifoServer = createMCPServer()
+      const fifoInternals = readServerInternals(fifoServer)
+      const fifoSaveSpy = vi.spyOn(fifoInternals.fileManager, 'saveImage')
+      const beforeFifoAllocCalls = bufferAllocSpy.mock.calls.length
+      const beforeFifoBase64Calls = bufferToStringSpy.mock.calls.length
+
+      expect.soft(await readdir(fifoOutputDirectory), 'fifo:before').toEqual([])
+      const fifoCall = fifoServer.callTool('generate_image', {
+        prompt: ORIGINAL_PROMPT,
+        fileName: 'fifo-output.png',
+        inputImagePath: fifoInputPath,
+      })
+      let deadlineTimer: ReturnType<typeof setTimeout> | undefined
+      const completionState = await Promise.race([
+        fifoCall.then(() => 'completed' as const),
+        new Promise<'deadline'>((resolve) => {
+          deadlineTimer = setTimeout(() => resolve('deadline'), 500)
+        }),
+      ])
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer)
+      }
+
+      if (completionState === 'deadline') {
+        await Promise.all([
+          fifoCall,
+          writeFile(fifoInputPath, Buffer.from('unblock-old-reader')).catch(() => undefined),
+        ])
+      }
+      const fifoResult = await fifoCall
+      const fifoAllocSizes = bufferAllocSpy.mock.calls
+        .slice(beforeFifoAllocCalls)
+        .map(([size]) => size)
+      const fifoBase64Calls = bufferToStringSpy.mock.calls
+        .slice(beforeFifoBase64Calls)
+        .filter(([encoding]) => encoding === 'base64')
+      const fifoError = (parsePublicResponse(fifoResult).error ?? {}) as Record<string, unknown>
+
+      expect.soft(completionState, 'fifo:deadline').toBe('completed')
+      expect.soft(fifoResult.isError, 'fifo').toBe(true)
+      expect.soft(fifoError.code, 'fifo').toBe('INPUT_VALIDATION_ERROR')
+      expect.soft(fileSystem.open, 'fifo').toHaveBeenCalledTimes(1)
+      expect
+        .soft(fileSystem.open, 'fifo')
+        .toHaveBeenCalledWith(sanitizedFifoInputPath, expectedInputOpenFlags)
+      expect.soft(fifoCloseSpy, 'fifo:close').toHaveBeenCalledTimes(1)
+      expect.soft(fifoAllocSizes, 'fifo:allocation').toEqual([])
+      expect.soft(fifoBase64Calls, 'fifo:base64').toEqual([])
+      expect.soft(transports.openAIResponsesCreate, 'fifo:text').not.toHaveBeenCalled()
+      expect.soft(transports.googleGenerateContent, 'fifo:image').not.toHaveBeenCalled()
+      expect.soft(fifoSaveSpy, 'fifo:save').not.toHaveBeenCalled()
+      expect.soft(await readdir(fifoOutputDirectory), 'fifo:after').toEqual([])
+      await rm(fifoInputPath, { force: true })
+    }
+  })
+
   it('contains Seedream failures before the next side effect without disclosure', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
     const jsonParseSpy = vi.spyOn(JSON, 'parse')
@@ -1042,6 +1418,7 @@ describe('BytePlus Seedream integration', () => {
       fetchError?: Error
       name: string
       responseFactory?: (responseSentinel: string, imageSentinel: string) => Response
+      sensitiveValues?: string[]
       skipPromptEnhancement?: boolean
     }
 
@@ -1072,6 +1449,45 @@ describe('BytePlus Seedream integration', () => {
         expectedImageCalls: 0,
         expectedParseCalls: 0,
         expectedTextCalls: 0,
+      },
+      {
+        name: 'google-search-string',
+        args: { useGoogleSearch: 'private-invalid-google-search-string' },
+        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        sensitiveValues: ['private-invalid-google-search-string'],
+      },
+      {
+        name: 'google-search-number',
+        args: { useGoogleSearch: 8675309 },
+        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        sensitiveValues: ['8675309'],
+      },
+      {
+        name: 'google-search-null',
+        args: { useGoogleSearch: null },
+        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'google-search-object',
+        args: { useGoogleSearch: { marker: 'private-invalid-google-search-object' } },
+        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        sensitiveValues: ['private-invalid-google-search-object'],
       },
       {
         name: 'lite-1k',
@@ -1519,6 +1935,7 @@ describe('BytePlus Seedream integration', () => {
         RAW_BODY_MARKER,
         responseSentinel,
         imageSentinel,
+        ...(row.sensitiveValues ?? []),
       ]) {
         expect.soft(exposed, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
       }

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -190,7 +190,8 @@ function createSuccessfulImageResponse(imageBytes: Buffer, responseSentinel: str
       data: [
         {
           b64_json: imageBytes.toString('base64'),
-          mime_type: 'image/png',
+          size: '1024x1024',
+          output_format: 'png',
         },
       ],
     }),
@@ -478,13 +479,13 @@ afterEach(async () => {
 // `thinking={type:'disabled'}` を含め、`extra_body` を含めない。"
 // AC: "AC-07 When routing すると、system は
 // `effectiveQuality=request.quality??capturedConfig.imageQuality` を先に決め、request quality を常に優先し、
-// fast→Lite standard、balanced|quality→Pro standard を選ぶ。"
+// fast→Pro fast、balanced|quality→Pro standard を選ぶ。"
 // AC: "AC-08 When image を呼ぶと、system は AP `POST /images/generations` に Bearer auth、
 // selected model/provider-local ratio suffix付きprompt/optional single image/effective resolution
 // token、`response_format=b64_json`,
-// `output_format=png`, `stream=false`, `watermark=false`,
-// `optimize_prompt_options.mode=standard` を送る。Lite では
-// `sequential_image_generation=disabled` を送り、Pro では同 field を送らない。"
+// `output_format=png`, `stream=false`, `watermark=false` とroute別の
+// `optimize_prompt_options.mode=fast|standard` を送り、
+// `sequential_image_generation` は送らない。"
 // AC: "AC-10 When 成功したら、既存 sanitized save/file URI と `structuredContent` 非存在を維持し、
 // internal `metadata.mimeType=image/png`、public metadata に prompt なしとする。"
 // AC: "AC-15 When request を解決すると、system は
@@ -538,15 +539,14 @@ afterEach(async () => {
 //   `Output aspect ratio: 1:1.` suffix.
 // - Every public aspect ratio is accepted through the same suffix rule; the request never constructs
 //   exact WxH or applies ratio-specific rounding.
-// - Fast route: select `seedream-5-0-260128`; include
-//   `sequential_image_generation='disabled'`.
-// - Pro route: omit the `sequential_image_generation` property entirely.
+// - Fast route: select `dola-seedream-5-0-pro-260628` with native fast optimization.
+// - Every route omits the `sequential_image_generation` property entirely.
 // - Every image request includes `response_format='b64_json'`, `output_format='png'`, stream=false,
-//   watermark=false, optimize_prompt_options.mode='standard', captured Bearer auth, and only the
-//   optional single-image field allowed by preflight.
+//   watermark=false, the route-specific optimize_prompt_options.mode, captured Bearer auth, and
+//   only the optional single-image field allowed by preflight.
 // - False prompt flags add no enhancement instruction; true prompt-only flags/purpose affect only
 //   the one text enhancement input and never add native image wire fields.
-// - Seedream image HTTP uses an AbortSignal derived from the provider-local fixed 180000 ms without
+// - Seedream image HTTP uses an AbortSignal derived from the provider-local fixed 300000 ms without
 //   changing existing apiTimeout=30000.
 // Verification items:
 // - Preflight occurs before any text or image transport call.
@@ -554,7 +554,8 @@ afterEach(async () => {
 // - Effective quality is selected before model, model before default resolution, and resolution
 //   before aspect/default suffix construction.
 // - Wire field values, model-specific field absence/presence, endpoint, and auth header are exact.
-// - The fixed valid response is exactly one strict base64 PNG with image/png metadata.
+// - The fixed valid response is exactly one strict base64 PNG; response format metadata is optional
+//   and must agree with PNG when present.
 // - Saved bytes equal the decoded fixture Buffer; the output path is sanitized.
 // - Public response contains the sanitized file URI and image/png MIME.
 // - Public response has no `structuredContent` property and no prompt field/value.
@@ -574,11 +575,12 @@ afterEach(async () => {
 // then preflight は enhancement 前に失敗し text/image external request count は共に 0 となる。"
 // AC: "AC-09 If exactly one `data[0].b64_json` PNG でない（missing/extra images、URL-only、
 // stream event、不正/空 base64、stream-read中にbody>48MiB、decode前にdecoded>32MiB、
-// PNG magic/`image/png`不一致）、またはtimeout/abortなら、then normalized errorを返しfileを作らない。"
+// PNG magic不一致、または存在するformat metadataがPNGと矛盾）、またはtimeout/abortなら、
+// then normalized errorを返しfileを作らない。"
 // AC: "AC-12 When 4xx/5xx/timeout/network error なら、既存 taxonomy へ秘密/prompt なしで正規化する。"
-// AC: "AC-16 When resolution がLite routeの2K/4KまたはPro routeの1K/2Kなら許可する。
-// それ以外はtext/image calls 0でrejectする。公開14 aspect ratioは全て同じMethod 1 ruleで送る。"
-// AC: "AC-19 When Seedream image requestを開始すると、systemはprovider-local固定`180000` msから
+// AC: "AC-16 When resolution が全routeでProの1K/2Kなら許可する。
+// 4Kを含むそれ以外はtext/image calls 0でrejectする。公開14 aspect ratioは同じMethod 1 ruleで送る。"
+// AC: "AC-19 When Seedream image requestを開始すると、systemはprovider-local固定`300000` msから
 // AbortSignalを構成する。timeout到達時はnormalized timeout errorを返してfileを作らない。"
 // Claim: every failure is contained at its owning stage, returns the existing normalized taxonomy,
 // and cannot create a file or expose ARK_API_KEY, Authorization, prompt, image, or raw wire bodies.
@@ -612,12 +614,12 @@ afterEach(async () => {
 // credentials, Authorization, prompt, image data, and request/response bodies.
 // Failure boundary rows:
 // - Missing and empty ARK_API_KEY -> ConfigError; text=0, image=0, save=0.
-// - useGoogleSearch=true, unsupported input-image combination, Lite+1K, and Pro+4K ->
+// - useGoogleSearch=true, unsupported input-image combination, and any quality+4K ->
 //   preflight error; text=0, image=0, save=0; no coercion/fallback.
 // - Missing data, extra images, URL-only data, stream event, malformed base64, empty base64,
 //   chunked response crossing 48 MiB, pre-decode size crossing 32 MiB, non-PNG magic, and MIME
-//   other than image/png -> normalized image contract error; save=0 for every row.
-// - Abort/timeout -> AbortSignal is derived from fixed 180000 ms; normalized timeout
+//   metadata contradicting PNG -> normalized image contract error; save=0 for every row.
+// - Abort/timeout -> AbortSignal is derived from fixed 300000 ms; normalized timeout
 //   error is returned and save=0.
 // - Representative 4xx, 5xx, and network failure -> existing ImageAPIError/NetworkError taxonomy;
 //   no provider/model/value fallback and save=0.
@@ -762,9 +764,9 @@ describe('BytePlus Seedream integration', () => {
     type SupportedRow = {
       args: Record<string, unknown>
       expectedAspectRatio: (typeof ALL_ASPECT_RATIOS)[number]
-      expectedModel: 'seedream-5-0-260128' | 'dola-seedream-5-0-pro-260628'
+      expectedModel: 'dola-seedream-5-0-pro-260628'
       expectedQuality: 'fast' | 'balanced' | 'quality'
-      expectedResolution: '1K' | '2K' | '4K'
+      expectedResolution: '1K' | '2K'
       inputImage?: boolean
       name: string
       skipPromptEnhancement?: boolean
@@ -776,9 +778,9 @@ describe('BytePlus Seedream integration', () => {
         name: 'prompt-baseline',
         args: {},
         expectedAspectRatio: '1:1',
-        expectedModel: 'seedream-5-0-260128',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
         expectedQuality: 'fast',
-        expectedResolution: '2K',
+        expectedResolution: '1K',
       },
       {
         name: 'enhancement-failure-original-fallback',
@@ -802,9 +804,9 @@ describe('BytePlus Seedream integration', () => {
         name: 'fast-route',
         args: { quality: 'fast' },
         expectedAspectRatio: '1:1',
-        expectedModel: 'seedream-5-0-260128',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
         expectedQuality: 'fast',
-        expectedResolution: '2K',
+        expectedResolution: '1K',
       },
       {
         name: 'balanced-route',
@@ -836,7 +838,7 @@ describe('BytePlus Seedream integration', () => {
           name: `aspect-${aspectRatio}`,
           args: { aspectRatio, imageSize: '2K', quality: 'fast' },
           expectedAspectRatio: aspectRatio,
-          expectedModel: 'seedream-5-0-260128',
+          expectedModel: 'dola-seedream-5-0-pro-260628',
           expectedQuality: 'fast',
           expectedResolution: '2K',
         })
@@ -851,9 +853,9 @@ describe('BytePlus Seedream integration', () => {
           name: `false-${flag}`,
           args: { [flag]: false },
           expectedAspectRatio: '1:1',
-          expectedModel: 'seedream-5-0-260128',
+          expectedModel: 'dola-seedream-5-0-pro-260628',
           expectedQuality: 'fast',
-          expectedResolution: '2K',
+          expectedResolution: '1K',
         })
       ),
       ...[
@@ -866,9 +868,9 @@ describe('BytePlus Seedream integration', () => {
           name: `prompt-only-${String(flag)}`,
           args: { [String(flag)]: value },
           expectedAspectRatio: '1:1',
-          expectedModel: 'seedream-5-0-260128',
+          expectedModel: 'dola-seedream-5-0-pro-260628',
           expectedQuality: 'fast',
-          expectedResolution: '2K',
+          expectedResolution: '1K',
         })
       ),
     ]
@@ -954,10 +956,9 @@ describe('BytePlus Seedream integration', () => {
         output_format: 'png',
         stream: false,
         watermark: false,
-        optimize_prompt_options: { mode: 'standard' },
-        ...(row.expectedModel === 'seedream-5-0-260128' && {
-          sequential_image_generation: 'disabled',
-        }),
+        optimize_prompt_options: {
+          mode: row.expectedQuality === 'fast' ? 'fast' : 'standard',
+        },
         ...(inputImageBytes && {
           image: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
         }),
@@ -975,7 +976,7 @@ describe('BytePlus Seedream integration', () => {
       expect.soft(imageRequest.headers.get('authorization'), row.name).toBe(AUTHORIZATION_VALUE)
       expect.soft(Object.keys(imageRequest.body).sort(), row.name).toEqual(expectedImageKeys)
       expect.soft(imageRequest.body, row.name).toEqual(expectedImageRequest)
-      expect.soft(rowTimeouts, row.name).toContain(180000)
+      expect.soft(rowTimeouts, row.name).toContain(300000)
       expect.soft(row.args.quality ?? 'fast', row.name).toBe(row.expectedQuality)
       expect.soft(parseCount, row.name).toBe(1)
       expect.soft(decodeCount, row.name).toBe(1)
@@ -998,7 +999,7 @@ describe('BytePlus Seedream integration', () => {
           ])
         expect.soft(textRequest.model, row.name).toBe('seed-2-0-lite-260428')
         expect.soft(textRequest.thinking, row.name).toEqual({ type: 'disabled' })
-        expect.soft(textRequest.max_output_tokens, row.name).toBe(1000)
+        expect.soft(textRequest.max_output_tokens, row.name).toBe(384)
         expect.soft(textRequest.temperature, row.name).toBe(0.7)
         expect.soft(textRequest.top_p, row.name).toBe(0.95)
         expect.soft(typeof textRequest.instructions, row.name).toBe('string')
@@ -1490,8 +1491,8 @@ describe('BytePlus Seedream integration', () => {
         sensitiveValues: ['private-invalid-google-search-object'],
       },
       {
-        name: 'lite-1k',
-        args: { imageSize: '1K', quality: 'fast' },
+        name: 'fast-pro-4k',
+        args: { imageSize: '4K', quality: 'fast' },
         expectedCode: 'IMAGE_API_ERROR',
         expectedDecodeCalls: 0,
         expectedImageCalls: 0,
@@ -1915,9 +1916,9 @@ describe('BytePlus Seedream integration', () => {
         .toEqual([])
 
       if (row.expectedImageCalls === 0) {
-        expect.soft(rowTimeouts, row.name).not.toContain(180000)
+        expect.soft(rowTimeouts, row.name).not.toContain(300000)
       } else {
-        expect.soft(rowTimeouts, row.name).toContain(180000)
+        expect.soft(rowTimeouts, row.name).toContain(300000)
       }
       if (row.name === 'url-only') {
         expect.soft(transports.fetch, row.name).toHaveBeenCalledTimes(1)

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -1,0 +1,1502 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ImageClient } from '../../api/imageClient.js'
+import type { FileManager } from '../../business/fileManager.js'
+import type { ResponseBuilder } from '../../business/responseBuilder.js'
+import type { StructuredPromptGenerator } from '../../business/structuredPromptGenerator.js'
+import { createMCPServer } from '../mcpServer.js'
+
+const transports = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  googleConstructor: vi.fn(),
+  googleEnhancedText: '',
+  googleGenerateContent: vi.fn(),
+  googleTextError: undefined as Error | undefined,
+  openAIConstructorError: undefined as Error | undefined,
+  openAIConstructorOptions: [] as unknown[],
+  openAIImageEdit: vi.fn(),
+  openAIImageGenerate: vi.fn(),
+  openAIResponsesCreate: vi.fn(),
+  toFile: vi.fn(),
+}))
+
+vi.mock('@google/genai', async (importActual) => {
+  const actual = await importActual<typeof import('@google/genai')>()
+  return {
+    ...actual,
+    GoogleGenAI: class {
+      readonly models = {
+        generateContent: transports.googleGenerateContent,
+      }
+
+      constructor(...args: unknown[]) {
+        transports.googleConstructor(...args)
+      }
+    },
+  }
+})
+
+vi.mock('openai', () => {
+  class OpenAITransportDouble {
+    readonly images = {
+      edit: transports.openAIImageEdit,
+      generate: transports.openAIImageGenerate,
+    }
+
+    readonly responses = {
+      create: transports.openAIResponsesCreate,
+    }
+
+    constructor(options: unknown) {
+      transports.openAIConstructorOptions.push(options)
+      if (transports.openAIConstructorError) {
+        throw transports.openAIConstructorError
+      }
+    }
+  }
+
+  return {
+    default: OpenAITransportDouble,
+    toFile: transports.toFile,
+  }
+})
+
+const API_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
+const ARK_DUMMY_KEY = 'ark-dummy-seedream-integration-key'
+const AUTHORIZATION_VALUE = `Bearer ${ARK_DUMMY_KEY}`
+const ORIGINAL_PROMPT = 'private-seedream-prompt-marker'
+const ENHANCED_PROMPT = 'fixture-enhanced-seedream-prompt'
+const RAW_BODY_MARKER = 'private-upstream-body-marker'
+const INPUT_IMAGE_MARKER = 'private-input-image-marker'
+const FALLBACK_PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x47, 0x45, 0x4d, 0x49, 0x4e, 0x49,
+])
+const FEATURE_INSTRUCTIONS = {
+  blendImages:
+    'MUST describe spatial and visual integration: Multiple visual elements need concrete spatial relationships. Define how elements interact: overlap, reflection, shared lighting, color echo between foreground and background. Clearly describe foreground (X% of frame), midground, and background elements with their relative scales and how they physically interact within the composition.',
+  maintainCharacterConsistency:
+    'Character consistency is CRITICAL - MUST include distinctive character features: This character needs at least 3 recognizable visual markers that would identify them across different scenes. Include specific details like "distinctive scar", "signature clothing item", "unique hairstyle", or "characteristic accessory". Use words like "signature", "distinctive", "always wears/has" to emphasize these consistent features.',
+  useWorldKnowledge:
+    'Apply accurate real-world knowledge - MUST incorporate authentic details: Apply accurate real-world knowledge about cultures, locations, or historical elements. Use specific terminology like "traditional [culture] style", "authentic [location] architecture", "typical of [region]", "historically accurate [period]". Be precise about cultural elements, geographical features, and factual details.',
+} as const
+const ALL_ASPECT_RATIOS = [
+  '1:1',
+  '1:4',
+  '1:8',
+  '2:3',
+  '3:2',
+  '3:4',
+  '4:1',
+  '4:3',
+  '4:5',
+  '5:4',
+  '8:1',
+  '9:16',
+  '16:9',
+  '21:9',
+] as const
+const TRACKED_ENV = [
+  'ARK_API_KEY',
+  'GEMINI_API_KEY',
+  'IMAGE_OUTPUT_DIR',
+  'IMAGE_PROVIDER',
+  'IMAGE_QUALITY',
+  'NODE_ENV',
+  'OPENAI_API_KEY',
+  'SKIP_PROMPT_ENHANCEMENT',
+] as const
+
+let originalEnv: Partial<Record<(typeof TRACKED_ENV)[number], string>>
+const temporaryDirectories = new Set<string>()
+
+function resetTransportDoubles(): void {
+  transports.fetch.mockReset()
+  transports.googleConstructor.mockReset()
+  transports.googleGenerateContent.mockReset()
+  transports.openAIImageEdit.mockReset()
+  transports.openAIImageGenerate.mockReset()
+  transports.openAIResponsesCreate.mockReset()
+  transports.toFile.mockReset()
+  transports.googleTextError = undefined
+  transports.googleEnhancedText = ENHANCED_PROMPT
+  transports.openAIConstructorError = undefined
+  transports.openAIConstructorOptions.length = 0
+
+  transports.googleGenerateContent.mockImplementation(async (params: { model?: string }) => {
+    if (params.model === 'gemini-2.5-flash') {
+      if (transports.googleTextError) {
+        throw transports.googleTextError
+      }
+      return { text: transports.googleEnhancedText }
+    }
+
+    return {
+      candidates: [
+        {
+          content: {
+            parts: [
+              {
+                inlineData: {
+                  data: FALLBACK_PNG_BYTES.toString('base64'),
+                  mimeType: 'image/png',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      modelVersion: 'gemini-fallback-must-not-run',
+      responseId: 'gemini-response-sentinel',
+    }
+  })
+  transports.openAIResponsesCreate.mockResolvedValue({
+    output_text: ENHANCED_PROMPT,
+  })
+  transports.toFile.mockResolvedValue({ name: 'fixture.png' })
+  transports.fetch.mockImplementation(async () =>
+    createSuccessfulImageResponse(FALLBACK_PNG_BYTES, 'default-response-sentinel')
+  )
+}
+
+function createSuccessfulImageResponse(imageBytes: Buffer, responseSentinel: string): Response {
+  return new Response(
+    JSON.stringify({
+      response_sentinel: responseSentinel,
+      data: [
+        {
+          b64_json: imageBytes.toString('base64'),
+          mime_type: 'image/png',
+        },
+      ],
+    }),
+    {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }
+  )
+}
+
+function createPngFixture(sentinel: string): Buffer {
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    Buffer.from(sentinel),
+  ])
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return value.split(needle).length - 1
+}
+
+function createJsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+async function createOutputDirectory(): Promise<string> {
+  const directory = await mkdtemp('/tmp/mcp-image-seedream-')
+  temporaryDirectories.add(directory)
+  return directory
+}
+
+function configureSeedream(
+  outputDirectory: string,
+  options: {
+    arkApiKey?: string
+    imageQuality?: 'fast' | 'balanced' | 'quality'
+    skipPromptEnhancement?: boolean
+  } = {}
+): void {
+  process.env.IMAGE_PROVIDER = 'seedream'
+  process.env.ARK_API_KEY = options.arkApiKey ?? ARK_DUMMY_KEY
+  process.env.GEMINI_API_KEY = 'gemini-dummy-integration-key'
+  process.env.OPENAI_API_KEY = 'openai-dummy-integration-key'
+  process.env.IMAGE_OUTPUT_DIR = outputDirectory
+  process.env.IMAGE_QUALITY = options.imageQuality ?? 'fast'
+  process.env.SKIP_PROMPT_ENHANCEMENT = String(options.skipPromptEnhancement ?? false)
+  process.env.NODE_ENV = 'test'
+}
+
+function parsePublicResponse(
+  result: Awaited<ReturnType<ReturnType<typeof createMCPServer>['callTool']>>
+) {
+  const firstContent = result.content.at(0)
+  if (firstContent?.type !== 'text') {
+    return {}
+  }
+
+  return JSON.parse(firstContent.text) as Record<string, unknown>
+}
+
+function readServerInternals(server: ReturnType<typeof createMCPServer>): {
+  fileManager: FileManager
+  imageClient: ImageClient | null
+  responseBuilder: ResponseBuilder
+  structuredPromptGenerator: StructuredPromptGenerator | null
+  textClient: object | null
+} {
+  return server as unknown as {
+    fileManager: FileManager
+    imageClient: ImageClient | null
+    responseBuilder: ResponseBuilder
+    structuredPromptGenerator: StructuredPromptGenerator | null
+    textClient: object | null
+  }
+}
+
+function observeLastImageRequest(): {
+  body: Record<string, unknown>
+  headers: Headers
+  init: RequestInit | undefined
+  url: string
+} {
+  const lastCall = transports.fetch.mock.calls.at(-1)
+  const url = lastCall?.[0]
+  const init = lastCall?.[1] as RequestInit | undefined
+  let body: Record<string, unknown> = {}
+
+  if (typeof init?.body === 'string') {
+    try {
+      body = JSON.parse(init.body) as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+  }
+
+  return {
+    body,
+    headers: new Headers(init?.headers),
+    init,
+    url: typeof url === 'string' ? url : '',
+  }
+}
+
+function extractTextInput(request: Record<string, unknown>): string {
+  if (typeof request.input === 'string') {
+    return request.input
+  }
+  if (!Array.isArray(request.input)) {
+    return ''
+  }
+
+  for (const item of request.input) {
+    if (!item || typeof item !== 'object') continue
+    const content = (item as { content?: unknown }).content
+    if (!Array.isArray(content)) continue
+    const textPart = content.find(
+      (part) =>
+        part && typeof part === 'object' && (part as { type?: unknown }).type === 'input_text'
+    ) as { text?: unknown } | undefined
+    if (typeof textPart?.text === 'string') {
+      return textPart.text
+    }
+  }
+
+  return ''
+}
+
+function capturedLogs(): string {
+  return vi
+    .mocked(console.error)
+    .mock.calls.flatMap((call) => call.map(String))
+    .join('\n')
+}
+
+async function assertSavedPng(
+  result: Awaited<ReturnType<ReturnType<typeof createMCPServer>['callTool']>>,
+  outputDirectory: string,
+  fileName: string,
+  expectedBytes: Buffer,
+  expectedModel: string
+): Promise<void> {
+  const files = await readdir(outputDirectory)
+  const expectedPath = join(outputDirectory, fileName)
+  const bytes = files[0] ? await readFile(expectedPath) : Buffer.alloc(0)
+  const publicResponse = parsePublicResponse(result)
+
+  expect.soft(result.isError).toBe(false)
+  expect.soft(Object.keys(result).sort()).toEqual(['content', 'isError'])
+  expect.soft(files).toEqual([fileName])
+  expect.soft(bytes).toEqual(expectedBytes)
+  expect.soft(publicResponse).toEqual({
+    type: 'resource',
+    resource: {
+      uri: `file://${expectedPath}`,
+      name: fileName,
+      mimeType: 'image/png',
+    },
+    metadata: {
+      model: expectedModel,
+      provider: 'seedream',
+      processingTime: 0,
+      contextMethod: 'structured_prompt',
+      timestamp: expect.any(String),
+    },
+  })
+  expect.soft(result).not.toHaveProperty('structuredContent')
+  expect.soft(publicResponse).not.toHaveProperty('metadata.prompt')
+  expect.soft(JSON.stringify(publicResponse)).not.toContain(ORIGINAL_PROMPT)
+  expect.soft(JSON.stringify(publicResponse)).not.toContain(ENHANCED_PROMPT)
+}
+
+beforeEach(() => {
+  originalEnv = Object.fromEntries(
+    TRACKED_ENV.flatMap((name) => {
+      const value = process.env[name]
+      return value === undefined ? [] : [[name, value]]
+    })
+  )
+  resetTransportDoubles()
+  vi.stubGlobal('fetch', transports.fetch)
+  vi.spyOn(console, 'error').mockImplementation(() => undefined)
+})
+
+afterEach(async () => {
+  for (const name of TRACKED_ENV) {
+    const value = originalEnv[name]
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+
+  await Promise.all(
+    [...temporaryDirectories].map((directory) => rm(directory, { force: true, recursive: true }))
+  )
+  temporaryDirectories.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+// BytePlus Seedream Provider Integration Test Skeleton
+// Design Doc: docs/design/byteplus-seedream-provider-design.md
+// ADR: docs/adr/ADR-0001-byteplus-modelark-provider-integration.md
+// Generated: 2026-07-28 | Budget Used: 3/3 integration, 0/3 fixture-e2e,
+// 0/2 service-integration-e2e
+// Artifact state: three executable behavior groups remain intentionally RED until the Seedream
+// implementation task supplies the missing production behavior.
+// Implementation pattern: follow the repository's function-style Vitest describe/it pattern;
+// use parameterized cases where a proof obligation names multiple boundary inputs.
+//
+// Candidate selection:
+// - Selected: additive Seedream selection through the existing lazy initialization (Value Score 110)
+// - Selected: exact supported-flow propagation to sanitized file response (Value Score 110)
+// - Selected: stage-aware failure containment without artifacts or secret leakage (Value Score 50)
+// - Merged: enhancement success/fallback/skip and route/default branches are boundary rows of
+//   the supported-flow propagation invariant, not separate tests.
+// - Merged: preflight, invalid wire response, abort, and upstream errors are boundary rows of
+//   the failure-containment invariant, not separate tests.
+// - Deduplicated: AC-11 Gemini/OpenAI public-output compatibility remains in the existing
+//   src/server/__tests__/mcpServer.test.ts and
+//   src/business/__tests__/responseBuilder.test.ts regression suites.
+//
+// Test case: existing lazy initialization selects Seedream clients
+// AC: "AC-01 When `seedream` configが有効なら、systemは既存遅延初期化branchでSeedream
+// text/image clientsを選択する。prompt enhancement skip時はtext clientを作らない。"
+// AC: "AC-13 While clientsが初期化済みなら、systemは既存cache behaviorを維持し、
+// requestごとのprovider再選択やruntime env reloadを追加しない。"
+// AC: "AC-14 If Seedream client構築が失敗したら、then 既存error pathでrequestを失敗させ、
+// 別provider/modelへのfallbackを行わない。"
+// Claim: the selected provider uses Seedream factories while preserving the existing skip/cache rules.
+// Value Score: 110 | Business Value: 10 (enables Seedream requests) |
+// User Frequency: 10 (every Seedream request uses initialization) | Legal: false |
+// Defect Detection: 10 (primary detector for wrong-provider or unnecessary text initialization)
+// Behavior: initialize Seedream clients through existing branches; exercise skip/cache/failure paths.
+// @category: integration
+// @lane: integration
+// @dependency: createMCPServer, Config, TextClient, ImageClient, Seedream capability preflight
+// @real-dependency: existing MCPServer initializeClients fields and lazy cache
+// @complexity: medium
+// Primary failure mode: Seedream selects a Gemini/OpenAI factory, initializes text while enhancement
+// is skipped, or silently falls back after a factory failure.
+// Boundary: empty existing fields -> selected lazy branch -> required Seedream clients or explicit error.
+// Observable state:
+// - Before: existing text/image client fields are empty.
+// - Action: initialize from one Seedream Config; separately fail one client construction.
+// - After: success uses required Seedream clients; skipped enhancement makes no text client; failure
+//   is explicit and does not select another provider/model.
+// Mock-boundary rationale: replace only network-touching SDK/HTTP transports with deterministic
+// test doubles. Keep Config selection, existing initialization fields, provider identity checks,
+// and request orchestration real because they are the boundary under proof.
+// Proof obligation: assert factory selection, skip/cache behavior, and explicit failure through the
+// public call boundary.
+// Verification items:
+// - Text/image Seedream factories are selected when enhancement is enabled.
+// - Enhancement skip initializes only the image client.
+// - Failed initialization returns an error without calling preflight, text, image, or file save.
+// - Initialized clients follow the existing cache behavior on the next request.
+// Expected result: successful calls use Seedream; skip/cache remain unchanged; failure has no fallback.
+// Pass criteria: every verification item is asserted through callTool-visible results, collaborator
+// call records, and client identity; no source-code inspection is accepted as proof.
+// Residual: this deterministic test does not prove the live ModelArk contract; the Phase 2 one-call
+// Method 1 probe owns the only remaining vendor unknown required by this MVP.
+//
+// Test case: supported inputs propagate exact effective values to one sanitized file response
+// AC: "AC-04 When enhancement が成功したら、system はexact enhanced promptをselected promptとし、
+// quality非依存のratio suffixを一回だけ付与したfinal promptをimage requestとmetadata.promptへ渡す。"
+// AC: "AC-05 If enhancement が失敗したら、then system はoriginal promptをselected promptとし、
+// 同じratio suffixを一回だけ付与したfinal promptを渡し、provider/model/valueは切り替えない。"
+// AC: "AC-06 While Seedream text を呼ぶとき、serialized request body の top-level に
+// `thinking={type:'disabled'}` を含め、`extra_body` を含めない。"
+// AC: "AC-07 When routing すると、system は
+// `effectiveQuality=request.quality??capturedConfig.imageQuality` を先に決め、request quality を常に優先し、
+// fast→Lite standard、balanced|quality→Pro standard を選ぶ。"
+// AC: "AC-08 When image を呼ぶと、system は AP `POST /images/generations` に Bearer auth、
+// selected model/provider-local ratio suffix付きprompt/optional single image/effective resolution
+// token、`response_format=b64_json`,
+// `output_format=png`, `stream=false`, `watermark=false`,
+// `optimize_prompt_options.mode=standard` を送る。Lite では
+// `sequential_image_generation=disabled` を送り、Pro では同 field を送らない。"
+// AC: "AC-10 When 成功したら、既存 sanitized save/file URI と `structuredContent` 非存在を維持し、
+// internal `metadata.mimeType=image/png`、public metadata に prompt なしとする。"
+// AC: "AC-15 When request を解決すると、system は
+// `quality/default → route → resolution/default → aspect/default` の順序を使う。例: captured fast +
+// request `quality=quality` + size/ratio omitted は Pro standard + `size='1K'` +
+// `Output aspect ratio: 1:1.`となる。"
+// AC: "AC-17 When `SKIP_PROMPT_ENHANCEMENT=true` なら、preflight 後 text calls 0、original
+// prompt で image calls 1 とする。"
+// AC: "AC-18 When false の prompt flags が来たら instruction を追加せず受理し、true の
+// prompt-only flags/purpose は共通 enhancement にだけ反映する。"
+// Claim: for every supported branch, one exact effective prompt and one exact route are propagated
+// once through the real provider adapter, PNG Buffer, sanitized save, and public MCP response.
+// Value Score: 110 | Business Value: 10 (core image-generation outcome) |
+// User Frequency: 10 (every successful request) | Legal: false |
+// Defect Detection: 10 (primary detector for cross-layer propagation drift)
+// Behavior: supported generate_image input -> preflight, optional single enhancement, deterministic
+// routing, direct-HTTP fixture decode, real file save/response build -> one PNG file URI response
+// with the exact effective values internally and no prompt exposed publicly.
+// @category: core-functionality
+// @lane: integration
+// @dependency: createMCPServer, existing client initialization, StructuredPromptGenerator,
+// SeedreamTextClient, SeedreamImageClient, FileManager, ResponseBuilder, temporary filesystem
+// @real-dependency: MCP validation/orchestration, client initialization/preflight, Seedream adapters,
+// prompt selection, PNG parser, FileManager, ResponseBuilder
+// @complexity: high
+// Primary failure mode: a supported request is enhanced more than once, uses the wrong provider,
+// model, size, or prompt, emits a model-invalid wire field, mutates decoded bytes, or leaks internal
+// prompt metadata through the public MCP response.
+// Boundary: validated MCP params -> preflight -> prompt selection -> route/default selection ->
+// Seedream wire request -> exactly-one PNG Buffer -> real temporary file -> public file URI response.
+// Observable state:
+// - Before: the per-case temporary output directory is empty and transport call counts are zero.
+// - Action: call generate_image with a parameterized supported-flow row.
+// - After: exactly one image request is made, its decoded PNG bytes are saved byte-for-byte, and
+//   the public response has the expected file URI/MIME allow-list with no prompt or structuredContent.
+// Mock-boundary rationale: intercept only the OpenAI Responses network transport and direct image
+// HTTP transport with fixed contract fixtures. Keep both Seedream adapters, effective-value rules,
+// prompt selection, b64/PNG parsing, FileManager, and ResponseBuilder real; mocking any of them would
+// hide the propagation boundary this test must prove.
+// Proof obligation: implement one parameterized Vitest case for the rows below. Assert exact request
+// payload presence and absence, call counts, internal metadata, saved bytes, and public response.
+// Supported-flow boundary rows:
+// - Enhancement success: one text request with top-level `thinking={type:'disabled'}`; its exact
+//   enhanced string is selected, then one ratio suffix forms the image prompt and metadata.prompt.
+// - Enhancement failure: the exact original prompt is selected before the same suffix, without
+//   switching provider/model/value.
+// - Enhancement skipped: preflight runs first, text calls remain 0, original prompt is used, and
+//   image calls equal 1.
+// - Captured fast plus request quality=quality plus omitted imageSize/aspectRatio: request wins;
+//   select `dola-seedream-5-0-pro-260628`, standard mode, `size='1K'`, and one
+//   `Output aspect ratio: 1:1.` suffix.
+// - Every public aspect ratio is accepted through the same suffix rule; the request never constructs
+//   exact WxH or applies ratio-specific rounding.
+// - Fast route: select `seedream-5-0-260128`; include
+//   `sequential_image_generation='disabled'`.
+// - Pro route: omit the `sequential_image_generation` property entirely.
+// - Every image request includes `response_format='b64_json'`, `output_format='png'`, stream=false,
+//   watermark=false, optimize_prompt_options.mode='standard', captured Bearer auth, and only the
+//   optional single-image field allowed by preflight.
+// - False prompt flags add no enhancement instruction; true prompt-only flags/purpose affect only
+//   the one text enhancement input and never add native image wire fields.
+// - Seedream image HTTP uses an AbortSignal derived from the provider-local fixed 180000 ms without
+//   changing existing apiTimeout=30000.
+// Verification items:
+// - Preflight occurs before any text or image transport call.
+// - Prompt generator call count is 0 or 1 according to the boundary row, never more than 1.
+// - Effective quality is selected before model, model before default resolution, and resolution
+//   before aspect/default suffix construction.
+// - Wire field values, model-specific field absence/presence, endpoint, and auth header are exact.
+// - The fixed valid response is exactly one strict base64 PNG with image/png metadata.
+// - Saved bytes equal the decoded fixture Buffer; the output path is sanitized.
+// - Public response contains the sanitized file URI and image/png MIME.
+// - Public response has no `structuredContent` property and no prompt field/value.
+// Expected result: each supported row returns one successful public resource response whose saved
+// PNG and internal prompt exactly match the one selected request path.
+// Pass criteria: every row asserts before/action/after state and exact propagation; assertions on
+// mock invocation alone are insufficient unless paired with saved bytes and public response checks.
+// Residual: deterministic fixtures prove repository contract construction, not current vendor
+// acceptance or visual quality; the Phase 2 one-call probe owns Method 1 acceptance and no CI test
+// owns stochastic aesthetic evaluation.
+//
+// Test case: failed Seedream requests stop before the next side effect and expose sanitized errors
+// AC: "AC-02 If `ARK_API_KEY` が欠落/空なら、then 外部 request 前に `ConfigError` を返し、
+// key 値を応答/log に含めない。"
+// AC: "AC-03 If Google Search、model/resolution combination、または input-image capability が
+// 非対応/未確認なら、
+// then preflight は enhancement 前に失敗し text/image external request count は共に 0 となる。"
+// AC: "AC-09 If exactly one `data[0].b64_json` PNG でない（missing/extra images、URL-only、
+// stream event、不正/空 base64、stream-read中にbody>48MiB、decode前にdecoded>32MiB、
+// PNG magic/`image/png`不一致）、またはtimeout/abortなら、then normalized errorを返しfileを作らない。"
+// AC: "AC-12 When 4xx/5xx/timeout/network error なら、既存 taxonomy へ秘密/prompt なしで正規化する。"
+// AC: "AC-16 When resolution がLite routeの2K/4KまたはPro routeの1K/2Kなら許可する。
+// それ以外はtext/image calls 0でrejectする。公開14 aspect ratioは全て同じMethod 1 ruleで送る。"
+// AC: "AC-19 When Seedream image requestを開始すると、systemはprovider-local固定`180000` msから
+// AbortSignalを構成する。timeout到達時はnormalized timeout errorを返してfileを作らない。"
+// Claim: every failure is contained at its owning stage, returns the existing normalized taxonomy,
+// and cannot create a file or expose ARK_API_KEY, Authorization, prompt, image, or raw wire bodies.
+// Value Score: 50 | Business Value: 10 (security and corrupt-artifact prevention) |
+// User Frequency: 4 (failure/unsupported paths) | Legal: false |
+// Defect Detection: 10 (primary cross-layer detector for side effects after failure)
+// Behavior: invalid config/capability or failed image transport/contract -> stage-specific stop and
+// normalized error -> zero durable files and no secret/prompt/raw-body disclosure.
+// @category: edge-case
+// @lane: integration
+// @dependency: Config validation, ProviderCapabilityPreflight, SeedreamImageClient,
+// error normalization, logger, FileManager, ResponseBuilder, temporary filesystem
+// @real-dependency: validation/preflight ordering, response parser and limits, error taxonomy,
+// logger sanitizer, FileManager boundary, public error response builder
+// @complexity: high
+// Primary failure mode: a rejected or failed request still calls a later external stage, saves
+// attacker-controlled/partial bytes, or returns/logs credentials, prompt, image, or raw payload.
+// Boundary: request/config validation and preflight before external I/O; after image I/O begins,
+// strict response parsing and abort/error normalization before FileManager.
+// Observable state:
+// - Before: a unique temporary output directory is empty; text/image/save counters are zero.
+// - Action: call generate_image once for each parameterized failure row below.
+// - After: the normalized public error matches the owning failure class; the directory is still
+//   empty; call counts stop at the expected stage; captured logs and response contain no secrets.
+// Mock-boundary rationale: inject deterministic failures only at config input, capability input,
+// external SDK/HTTP response, and AbortSignal boundaries. Keep ordering, response validation,
+// size limits, error classification, sanitization, file decision, and public response construction
+// real because those side-effect and disclosure boundaries are the proof target.
+// Proof obligation: assert before/action/after state for every row; verify exact stage call counts,
+// normalized error code/category, empty output directory, and negative string/property checks for
+// credentials, Authorization, prompt, image data, and request/response bodies.
+// Failure boundary rows:
+// - Missing and empty ARK_API_KEY -> ConfigError; text=0, image=0, save=0.
+// - useGoogleSearch=true, unsupported input-image combination, Lite+1K, and Pro+4K ->
+//   preflight error; text=0, image=0, save=0; no coercion/fallback.
+// - Missing data, extra images, URL-only data, stream event, malformed base64, empty base64,
+//   chunked response crossing 48 MiB, pre-decode size crossing 32 MiB, non-PNG magic, and MIME
+//   other than image/png -> normalized image contract error; save=0 for every row.
+// - Abort/timeout -> AbortSignal is derived from fixed 180000 ms; normalized timeout
+//   error is returned and save=0.
+// - Representative 4xx, 5xx, and network failure -> existing ImageAPIError/NetworkError taxonomy;
+//   no provider/model/value fallback and save=0.
+// Verification items:
+// - Preflight rejection occurs before enhancement and both external transports.
+// - Failures after image transport still occur before FileManager.saveImage.
+// - No rejected value is rounded, coerced, or rerouted to another model/provider/default.
+// - Every public error and captured log excludes the key, Authorization, prompt, input image,
+//   request body, response body, and internal metadata.prompt.
+// - Output directory remains empty after every failure row.
+// Expected result: each failure is observable as a stable normalized, sanitized error with no file
+// and no calls beyond the boundary that detected it.
+// Pass criteria: all listed rows assert stage call counts, error taxonomy, disclosure absence, and
+// filesystem absence; a returned error without the no-file/no-leak probes does not satisfy the test.
+// Residual: adapter L1 tests should still isolate parser and numeric-limit arithmetic for precise
+// diagnostics; this integration case proves those failures cannot escape into files or responses.
+
+describe('BytePlus Seedream integration', () => {
+  it('selects Seedream clients through the existing lazy initialization branches', async () => {
+    const skipOutput = await createOutputDirectory()
+    configureSeedream(skipOutput, { skipPromptEnhancement: true })
+    const skippedServer = createMCPServer()
+    const skippedBefore = readServerInternals(skippedServer)
+    const skippedSave = vi.spyOn(skippedBefore.fileManager, 'saveImage')
+    const skippedSuccess = vi.spyOn(skippedBefore.responseBuilder, 'buildSuccessResponse')
+
+    expect(await readdir(skipOutput)).toEqual([])
+    expect.soft(skippedBefore.textClient).toBeNull()
+    expect.soft(skippedBefore.imageClient).toBeNull()
+    expect.soft(skippedBefore.structuredPromptGenerator).toBeNull()
+
+    const skippedFirst = await skippedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'skip-first.png',
+    })
+    const skippedAfterFirst = readServerInternals(skippedServer)
+    const skippedSecond = await skippedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'skip-second.png',
+    })
+    const skippedAfterSecond = readServerInternals(skippedServer)
+
+    expect.soft(transports.googleConstructor).not.toHaveBeenCalled()
+    expect.soft(transports.openAIConstructorOptions).toHaveLength(0)
+    expect.soft(transports.openAIResponsesCreate).not.toHaveBeenCalled()
+    expect.soft(transports.fetch).toHaveBeenCalledTimes(2)
+    expect.soft(skippedAfterFirst.textClient).toBeNull()
+    expect.soft(skippedAfterFirst.structuredPromptGenerator).toBeNull()
+    expect.soft(skippedAfterFirst.imageClient).not.toBeNull()
+    expect.soft(skippedAfterSecond.imageClient).toBe(skippedAfterFirst.imageClient)
+    expect.soft(skippedSave).toHaveBeenCalledTimes(2)
+    expect.soft(skippedSuccess).toHaveBeenCalledTimes(2)
+    expect.soft(skippedFirst.isError).toBe(false)
+    expect.soft(skippedSecond.isError).toBe(false)
+    expect.soft(await readdir(skipOutput)).toHaveLength(2)
+
+    resetTransportDoubles()
+    const cachedOutput = await createOutputDirectory()
+    configureSeedream(cachedOutput)
+    const cachedServer = createMCPServer()
+    const cachedBefore = readServerInternals(cachedServer)
+    const cachedSave = vi.spyOn(cachedBefore.fileManager, 'saveImage')
+    const cachedSuccess = vi.spyOn(cachedBefore.responseBuilder, 'buildSuccessResponse')
+
+    expect(await readdir(cachedOutput)).toEqual([])
+    expect.soft(cachedBefore.textClient).toBeNull()
+    expect.soft(cachedBefore.imageClient).toBeNull()
+    expect.soft(cachedBefore.structuredPromptGenerator).toBeNull()
+
+    const cachedFirst = await cachedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'cache-first.png',
+    })
+    const cachedAfterFirst = readServerInternals(cachedServer)
+    const cachedSecond = await cachedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'cache-second.png',
+    })
+    const cachedAfterSecond = readServerInternals(cachedServer)
+
+    expect.soft(transports.googleConstructor).not.toHaveBeenCalled()
+    expect.soft(transports.openAIConstructorOptions).toHaveLength(1)
+    expect.soft(transports.openAIResponsesCreate).toHaveBeenCalledTimes(2)
+    expect.soft(transports.fetch).toHaveBeenCalledTimes(2)
+    expect.soft(cachedAfterFirst.textClient).not.toBeNull()
+    expect.soft(cachedAfterFirst.imageClient).not.toBeNull()
+    expect.soft(cachedAfterFirst.structuredPromptGenerator).not.toBeNull()
+    expect.soft(cachedAfterSecond.textClient).toBe(cachedAfterFirst.textClient)
+    expect.soft(cachedAfterSecond.imageClient).toBe(cachedAfterFirst.imageClient)
+    expect
+      .soft(cachedAfterSecond.structuredPromptGenerator)
+      .toBe(cachedAfterFirst.structuredPromptGenerator)
+    expect.soft(cachedSave).toHaveBeenCalledTimes(2)
+    expect.soft(cachedSuccess).toHaveBeenCalledTimes(2)
+    expect.soft(cachedFirst.isError).toBe(false)
+    expect.soft(cachedSecond.isError).toBe(false)
+    expect.soft(await readdir(cachedOutput)).toHaveLength(2)
+
+    resetTransportDoubles()
+    const failureOutput = await createOutputDirectory()
+    configureSeedream(failureOutput)
+    transports.openAIConstructorError = new Error('synthetic Seedream factory failure')
+    const failedServer = createMCPServer()
+    const failedBefore = readServerInternals(failedServer)
+    const failedSave = vi.spyOn(failedBefore.fileManager, 'saveImage')
+    const failedSuccess = vi.spyOn(failedBefore.responseBuilder, 'buildSuccessResponse')
+    const failedError = vi.spyOn(failedBefore.responseBuilder, 'buildErrorResponse')
+
+    expect(await readdir(failureOutput)).toEqual([])
+    expect.soft(failedBefore.textClient).toBeNull()
+    expect.soft(failedBefore.imageClient).toBeNull()
+    expect.soft(failedBefore.structuredPromptGenerator).toBeNull()
+
+    const failed = await failedServer.callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName: 'must-not-exist.png',
+    })
+    const failedAfter = readServerInternals(failedServer)
+    const failedPublicResponse = parsePublicResponse(failed)
+    const failureExposure = `${JSON.stringify(failedPublicResponse)}\n${capturedLogs()}`
+
+    expect.soft(failed.isError).toBe(true)
+    expect.soft(transports.googleConstructor).not.toHaveBeenCalled()
+    expect.soft(transports.openAIConstructorOptions).toHaveLength(1)
+    expect.soft(transports.openAIResponsesCreate).not.toHaveBeenCalled()
+    expect.soft(transports.fetch).not.toHaveBeenCalled()
+    expect.soft(failedAfter.textClient).toBeNull()
+    expect.soft(failedAfter.imageClient).toBeNull()
+    expect.soft(failedAfter.structuredPromptGenerator).toBeNull()
+    expect.soft(failedSave).not.toHaveBeenCalled()
+    expect.soft(failedSuccess).not.toHaveBeenCalled()
+    expect.soft(failedError).toHaveBeenCalledTimes(1)
+    expect.soft(await readdir(failureOutput)).toEqual([])
+    expect.soft(failureExposure).not.toContain(ARK_DUMMY_KEY)
+    expect.soft(failureExposure).not.toContain(ORIGINAL_PROMPT)
+  })
+
+  it('propagates supported effective values to one sanitized PNG file response', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+    const jsonParseSpy = vi.spyOn(JSON, 'parse')
+    const bufferFromSpy = vi.spyOn(Buffer, 'from')
+    type SupportedRow = {
+      args: Record<string, unknown>
+      expectedAspectRatio: (typeof ALL_ASPECT_RATIOS)[number]
+      expectedModel: 'seedream-5-0-260128' | 'dola-seedream-5-0-pro-260628'
+      expectedQuality: 'fast' | 'balanced' | 'quality'
+      expectedResolution: '1K' | '2K' | '4K'
+      inputImage?: boolean
+      name: string
+      skipPromptEnhancement?: boolean
+      textFailure?: boolean
+    }
+
+    const supportedRows: SupportedRow[] = [
+      {
+        name: 'prompt-baseline',
+        args: {},
+        expectedAspectRatio: '1:1',
+        expectedModel: 'seedream-5-0-260128',
+        expectedQuality: 'fast',
+        expectedResolution: '2K',
+      },
+      {
+        name: 'enhancement-failure-original-fallback',
+        args: { aspectRatio: '4:3', quality: 'balanced' },
+        expectedAspectRatio: '4:3',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'balanced',
+        expectedResolution: '1K',
+        textFailure: true,
+      },
+      {
+        name: 'enhancement-skip',
+        args: { aspectRatio: '9:16', imageSize: '2K', quality: 'quality' },
+        expectedAspectRatio: '9:16',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'quality',
+        expectedResolution: '2K',
+        skipPromptEnhancement: true,
+      },
+      {
+        name: 'fast-route',
+        args: { quality: 'fast' },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'seedream-5-0-260128',
+        expectedQuality: 'fast',
+        expectedResolution: '2K',
+      },
+      {
+        name: 'balanced-route',
+        args: { quality: 'balanced' },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'balanced',
+        expectedResolution: '1K',
+      },
+      {
+        name: 'quality-request-overrides-captured-fast',
+        args: { quality: 'quality' },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'quality',
+        expectedResolution: '1K',
+      },
+      {
+        name: 'single-input-image',
+        args: { quality: 'quality' },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'quality',
+        expectedResolution: '1K',
+        inputImage: true,
+      },
+      ...ALL_ASPECT_RATIOS.map(
+        (aspectRatio): SupportedRow => ({
+          name: `aspect-${aspectRatio}`,
+          args: { aspectRatio, imageSize: '2K', quality: 'fast' },
+          expectedAspectRatio: aspectRatio,
+          expectedModel: 'seedream-5-0-260128',
+          expectedQuality: 'fast',
+          expectedResolution: '2K',
+        })
+      ),
+      ...[
+        'blendImages',
+        'maintainCharacterConsistency',
+        'useWorldKnowledge',
+        'useGoogleSearch',
+      ].map(
+        (flag): SupportedRow => ({
+          name: `false-${flag}`,
+          args: { [flag]: false },
+          expectedAspectRatio: '1:1',
+          expectedModel: 'seedream-5-0-260128',
+          expectedQuality: 'fast',
+          expectedResolution: '2K',
+        })
+      ),
+      ...[
+        ['blendImages', true],
+        ['maintainCharacterConsistency', true],
+        ['useWorldKnowledge', true],
+        ['purpose', 'cookbook cover'],
+      ].map(
+        ([flag, value]): SupportedRow => ({
+          name: `prompt-only-${String(flag)}`,
+          args: { [String(flag)]: value },
+          expectedAspectRatio: '1:1',
+          expectedModel: 'seedream-5-0-260128',
+          expectedQuality: 'fast',
+          expectedResolution: '2K',
+        })
+      ),
+    ]
+
+    for (const [index, row] of supportedRows.entries()) {
+      resetTransportDoubles()
+      vi.mocked(console.error).mockClear()
+      const outputDirectory = await createOutputDirectory()
+      const fileName = `supported-${index}.png`
+      const requestPrompt = `${ORIGINAL_PROMPT}:${row.name}:request-body-sentinel`
+      const enhancedPrompt = `${ENHANCED_PROMPT}:${row.name}:image-body-sentinel`
+      const responseSentinel = `${row.name}:response-body-sentinel`
+      const imageSentinel = `${row.name}:decoded-image-sentinel`
+      const expectedImageBytes = createPngFixture(imageSentinel)
+      const expectedBase64 = expectedImageBytes.toString('base64')
+      const inputImageBytes = row.inputImage
+        ? createPngFixture(`${row.name}:input-image-sentinel`)
+        : undefined
+      const inputDirectory = row.inputImage ? await createOutputDirectory() : undefined
+      const inputImagePath =
+        inputDirectory && row.inputImage ? join(inputDirectory, `${row.name}-input.png`) : undefined
+      if (inputImagePath && inputImageBytes) {
+        await writeFile(inputImagePath, inputImageBytes)
+      }
+
+      configureSeedream(outputDirectory, {
+        imageQuality: 'fast',
+        skipPromptEnhancement: row.skipPromptEnhancement,
+      })
+      transports.googleEnhancedText = enhancedPrompt
+      transports.openAIResponsesCreate.mockResolvedValue({ output_text: enhancedPrompt })
+      transports.fetch.mockImplementation(async () =>
+        createSuccessfulImageResponse(expectedImageBytes, responseSentinel)
+      )
+
+      if (row.textFailure) {
+        const enhancementError = new Error('synthetic enhancement failure')
+        transports.openAIResponsesCreate.mockRejectedValue(enhancementError)
+        transports.googleTextError = enhancementError
+      }
+
+      const server = createMCPServer()
+      const internals = readServerInternals(server)
+      const saveSpy = vi.spyOn(internals.fileManager, 'saveImage')
+      const successSpy = vi.spyOn(internals.responseBuilder, 'buildSuccessResponse')
+      const beforeTimeoutCalls = timeoutSpy.mock.calls.length
+      const beforeParseCalls = jsonParseSpy.mock.calls.length
+      const beforeDecodeCalls = bufferFromSpy.mock.calls.length
+
+      expect.soft(await readdir(outputDirectory), row.name).toEqual([])
+
+      const result = await server.callTool('generate_image', {
+        prompt: requestPrompt,
+        fileName,
+        ...(inputImagePath && { inputImagePath }),
+        ...row.args,
+      })
+
+      const parseCount = jsonParseSpy.mock.calls
+        .slice(beforeParseCalls)
+        .filter(([value]) => typeof value === 'string' && value.includes(responseSentinel)).length
+      const decodeCount = bufferFromSpy.mock.calls
+        .slice(beforeDecodeCalls)
+        .filter(([value, encoding]) => value === expectedBase64 && encoding === 'base64').length
+      const imageRequest = observeLastImageRequest()
+      const textRequest =
+        (transports.openAIResponsesCreate.mock.calls.at(-1)?.[0] as
+          | Record<string, unknown>
+          | undefined) ?? {}
+      const selectedPrompt =
+        row.skipPromptEnhancement || row.textFailure ? requestPrompt : enhancedPrompt
+      const finalPrompt = `${selectedPrompt}\n\nOutput aspect ratio: ${row.expectedAspectRatio}.`
+      const rowTimeouts = timeoutSpy.mock.calls
+        .slice(beforeTimeoutCalls)
+        .map(([timeout]) => timeout)
+      const capturedGeneration = successSpy.mock.calls.at(0)?.[0]
+
+      const expectedImageRequest = {
+        model: row.expectedModel,
+        prompt: finalPrompt,
+        size: row.expectedResolution,
+        response_format: 'b64_json',
+        output_format: 'png',
+        stream: false,
+        watermark: false,
+        optimize_prompt_options: { mode: 'standard' },
+        ...(row.expectedModel === 'seedream-5-0-260128' && {
+          sequential_image_generation: 'disabled',
+        }),
+        ...(inputImageBytes && {
+          image: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
+        }),
+      }
+      const expectedImageKeys = Object.keys(expectedImageRequest).sort()
+      const textInput = extractTextInput(textRequest)
+
+      expect.soft(transports.googleConstructor, row.name).not.toHaveBeenCalled()
+      expect
+        .soft(transports.openAIResponsesCreate, row.name)
+        .toHaveBeenCalledTimes(row.skipPromptEnhancement ? 0 : 1)
+      expect.soft(transports.fetch, row.name).toHaveBeenCalledTimes(1)
+      expect.soft(imageRequest.url, row.name).toBe(API_ENDPOINT)
+      expect.soft(imageRequest.init?.method, row.name).toBe('POST')
+      expect.soft(imageRequest.headers.get('authorization'), row.name).toBe(AUTHORIZATION_VALUE)
+      expect.soft(Object.keys(imageRequest.body).sort(), row.name).toEqual(expectedImageKeys)
+      expect.soft(imageRequest.body, row.name).toEqual(expectedImageRequest)
+      expect.soft(rowTimeouts, row.name).toContain(180000)
+      expect.soft(row.args.quality ?? 'fast', row.name).toBe(row.expectedQuality)
+      expect.soft(parseCount, row.name).toBe(1)
+      expect.soft(decodeCount, row.name).toBe(1)
+      expect.soft(saveSpy, row.name).toHaveBeenCalledTimes(1)
+      expect.soft(successSpy, row.name).toHaveBeenCalledTimes(1)
+
+      if (row.skipPromptEnhancement) {
+        expect.soft(textRequest, row.name).toEqual({})
+      } else {
+        expect
+          .soft(Object.keys(textRequest).sort(), row.name)
+          .toEqual([
+            'input',
+            'instructions',
+            'max_output_tokens',
+            'model',
+            'temperature',
+            'thinking',
+            'top_p',
+          ])
+        expect.soft(textRequest.model, row.name).toBe('seed-2-0-lite-260428')
+        expect.soft(textRequest.thinking, row.name).toEqual({ type: 'disabled' })
+        expect.soft(textRequest.max_output_tokens, row.name).toBe(1000)
+        expect.soft(textRequest.temperature, row.name).toBe(0.7)
+        expect.soft(textRequest.top_p, row.name).toBe(0.95)
+        expect.soft(typeof textRequest.instructions, row.name).toBe('string')
+        expect.soft(countOccurrences(textInput, requestPrompt), row.name).toBe(1)
+
+        for (const [flag, instruction] of Object.entries(FEATURE_INSTRUCTIONS)) {
+          expect
+            .soft(textInput.includes(instruction), `${row.name}:${flag}`)
+            .toBe(row.args[flag] === true)
+        }
+
+        const purpose = typeof row.args.purpose === 'string' ? row.args.purpose : undefined
+        const purposeInstruction = purpose
+          ? `INTENDED USE: ${purpose}\nTailor the visual style, quality level, and details to match this purpose.`
+          : 'INTENDED USE:'
+        expect
+          .soft(textInput.includes(purposeInstruction), `${row.name}:purpose`)
+          .toBe(Boolean(purpose))
+
+        if (inputImageBytes) {
+          expect.soft(textRequest.input, row.name).toEqual([
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: textInput },
+                {
+                  type: 'input_image',
+                  image_url: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
+                  detail: 'auto',
+                },
+              ],
+            },
+          ])
+        } else {
+          expect.soft(textRequest.input, row.name).toBe(textInput)
+        }
+      }
+
+      expect.soft(capturedGeneration?.metadata.prompt, row.name).toBe(finalPrompt)
+      expect.soft(capturedGeneration?.metadata.mimeType, row.name).toBe('image/png')
+      expect.soft(capturedGeneration?.imageData, row.name).toEqual(expectedImageBytes)
+      expect
+        .soft(saveSpy, row.name)
+        .toHaveBeenCalledWith(expectedImageBytes, join(outputDirectory, fileName))
+      await assertSavedPng(result, outputDirectory, fileName, expectedImageBytes, row.expectedModel)
+
+      const publicAndLogs = `${JSON.stringify(parsePublicResponse(result))}\n${capturedLogs()}`
+      for (const sensitiveValue of [
+        ARK_DUMMY_KEY,
+        AUTHORIZATION_VALUE,
+        requestPrompt,
+        enhancedPrompt,
+        responseSentinel,
+        imageSentinel,
+        inputImageBytes?.toString('base64') ?? '',
+      ].filter(Boolean)) {
+        expect.soft(publicAndLogs, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
+      }
+    }
+  })
+
+  it('contains Seedream failures before the next side effect without disclosure', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
+    const jsonParseSpy = vi.spyOn(JSON, 'parse')
+    const bufferFromSpy = vi.spyOn(Buffer, 'from')
+    type FailureRow = {
+      args?: Record<string, unknown>
+      arkApiKey?: string
+      deleteArkApiKey?: boolean
+      expectedCode: string
+      expectedDecodeCalls: number
+      expectedImageCalls: number
+      expectedParseCalls: number
+      expectedTextCalls: number
+      fetchError?: Error
+      name: string
+      responseFactory?: (responseSentinel: string, imageSentinel: string) => Response
+      skipPromptEnhancement?: boolean
+    }
+
+    const failureRows: FailureRow[] = [
+      {
+        name: 'missing-key',
+        deleteArkApiKey: true,
+        expectedCode: 'CONFIG_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'empty-key',
+        arkApiKey: '   ',
+        expectedCode: 'CONFIG_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'google-search',
+        args: { useGoogleSearch: true },
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'lite-1k',
+        args: { imageSize: '1K', quality: 'fast' },
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'pro-4k',
+        args: { imageSize: '4K', quality: 'quality' },
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'unsupported-editing-input',
+        args: { inputImagePath: '__CREATE_UNSUPPORTED_INPUT__' },
+        expectedCode: 'INPUT_VALIDATION_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 0,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+      },
+      {
+        name: 'missing-data',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+          }),
+      },
+      {
+        name: 'extra-images',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) => {
+          const imageBytes = createPngFixture(imageSentinel)
+          return createJsonResponse({
+            response_sentinel: responseSentinel,
+            data: [
+              { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
+              { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
+            ],
+          })
+        },
+      },
+      {
+        name: 'url-only',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            data: [{ url: `https://attacker.invalid/${imageSentinel}.png` }],
+          }),
+      },
+      {
+        name: 'stream-event',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          new Response(
+            `data: ${JSON.stringify({
+              response_sentinel: responseSentinel,
+              image_sentinel: imageSentinel,
+              data: [],
+            })}\n\n`,
+            {
+              status: 200,
+              headers: { 'content-type': 'text/event-stream' },
+            }
+          ),
+      },
+      {
+        name: 'malformed-base64',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            data: [{ b64_json: `***${imageSentinel}`, mime_type: 'image/png' }],
+          }),
+      },
+      {
+        name: 'empty-base64',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            data: [{ b64_json: '', mime_type: 'image/png' }],
+          }),
+      },
+      {
+        name: 'content-length-over-48-mib',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          new Response(`${responseSentinel}:${imageSentinel}`, {
+            status: 200,
+            headers: {
+              'content-length': String(48 * 1024 * 1024 + 1),
+              'content-type': 'application/json',
+            },
+          }),
+      },
+      {
+        name: 'chunked-body-over-48-mib',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+      },
+      {
+        name: 'decoded-size-over-32-mib',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            data: [
+              {
+                b64_json: 'A'.repeat(Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)),
+                mime_type: 'image/png',
+              },
+            ],
+          }),
+      },
+      {
+        name: 'non-png-magic',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 1,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse({
+            response_sentinel: responseSentinel,
+            data: [
+              {
+                b64_json: Buffer.from(`not-a-png:${imageSentinel}`).toString('base64'),
+                mime_type: 'image/png',
+              },
+            ],
+          }),
+      },
+      {
+        name: 'wrong-mime',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 1,
+        expectedImageCalls: 1,
+        expectedParseCalls: 1,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) => {
+          const imageBytes = createPngFixture(imageSentinel)
+          return createJsonResponse({
+            response_sentinel: responseSentinel,
+            data: [{ b64_json: imageBytes.toString('base64'), mime_type: 'image/jpeg' }],
+          })
+        },
+      },
+      {
+        name: 'abort-timeout',
+        expectedCode: 'NETWORK_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        fetchError: new DOMException('synthetic timeout', 'AbortError'),
+      },
+      {
+        name: 'http-401',
+        expectedCode: 'IMAGE_API_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse(
+            {
+              response_sentinel: responseSentinel,
+              image_sentinel: imageSentinel,
+              error: { message: RAW_BODY_MARKER },
+            },
+            401
+          ),
+      },
+      {
+        name: 'http-500',
+        expectedCode: 'NETWORK_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        responseFactory: (responseSentinel, imageSentinel) =>
+          createJsonResponse(
+            {
+              response_sentinel: responseSentinel,
+              image_sentinel: imageSentinel,
+              error: { message: RAW_BODY_MARKER },
+            },
+            500
+          ),
+      },
+      {
+        name: 'network-failure',
+        expectedCode: 'NETWORK_ERROR',
+        expectedDecodeCalls: 0,
+        expectedImageCalls: 1,
+        expectedParseCalls: 0,
+        expectedTextCalls: 0,
+        skipPromptEnhancement: true,
+        fetchError: new TypeError(`fetch failed: ${RAW_BODY_MARKER}`),
+      },
+    ]
+
+    for (const [index, row] of failureRows.entries()) {
+      resetTransportDoubles()
+      vi.mocked(console.error).mockClear()
+      const outputDirectory = await createOutputDirectory()
+      const requestSentinel = `${ORIGINAL_PROMPT}:${row.name}:request-body-sentinel`
+      const responseSentinel = `${row.name}:response-body-sentinel`
+      const imageSentinel = `${row.name}:decoded-image-sentinel`
+      configureSeedream(outputDirectory, {
+        arkApiKey: row.arkApiKey,
+        skipPromptEnhancement: row.skipPromptEnhancement,
+      })
+      if (row.deleteArkApiKey) {
+        delete process.env.ARK_API_KEY
+      }
+
+      let chunkedCancel: ReturnType<typeof vi.fn> | undefined
+      if (row.name === 'chunked-body-over-48-mib') {
+        chunkedCancel = vi.fn()
+        transports.fetch.mockImplementation(async () => {
+          let emittedChunks = 0
+          const markerChunk = new TextEncoder().encode(`${responseSentinel}:${imageSentinel}`)
+          return new Response(
+            new ReadableStream<Uint8Array>({
+              cancel: chunkedCancel,
+              pull(controller) {
+                if (emittedChunks === 0) {
+                  controller.enqueue(markerChunk)
+                  emittedChunks += 1
+                } else if (emittedChunks < 50) {
+                  controller.enqueue(new Uint8Array(1024 * 1024))
+                  emittedChunks += 1
+                } else {
+                  controller.close()
+                }
+              },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        })
+      } else if (row.fetchError) {
+        const message = `${row.fetchError.message}:${responseSentinel}:${imageSentinel}`
+        const error =
+          row.fetchError instanceof DOMException
+            ? new DOMException(message, row.fetchError.name)
+            : new TypeError(message)
+        transports.fetch.mockRejectedValue(error)
+      } else if (row.responseFactory) {
+        transports.fetch.mockImplementation(async () =>
+          row.responseFactory?.(responseSentinel, imageSentinel)
+        )
+      }
+
+      let args: Record<string, unknown> = {
+        prompt: requestSentinel,
+        fileName: `failure-${index}.png`,
+        ...row.args,
+      }
+      if (row.args?.inputImagePath === '__CREATE_UNSUPPORTED_INPUT__') {
+        const unsupportedInputPath = join(outputDirectory, 'unsupported.gif')
+        await writeFile(unsupportedInputPath, `${INPUT_IMAGE_MARKER}:${row.name}`)
+        args = {
+          ...args,
+          inputImagePath: unsupportedInputPath,
+        }
+      }
+
+      const beforeFiles = await readdir(outputDirectory)
+      const beforeTimeoutCalls = timeoutSpy.mock.calls.length
+      const server = createMCPServer()
+      const internals = readServerInternals(server)
+      const saveSpy = vi.spyOn(internals.fileManager, 'saveImage')
+      const successSpy = vi.spyOn(internals.responseBuilder, 'buildSuccessResponse')
+      const errorSpy = vi.spyOn(internals.responseBuilder, 'buildErrorResponse')
+      const beforeParseCalls = jsonParseSpy.mock.calls.length
+      const beforeDecodeCalls = bufferFromSpy.mock.calls.length
+      const result = await server.callTool('generate_image', args)
+      const afterFiles = await readdir(outputDirectory)
+      const parseCount = jsonParseSpy.mock.calls
+        .slice(beforeParseCalls)
+        .filter(([value]) => typeof value === 'string' && value.includes(responseSentinel)).length
+      const decodeCount = bufferFromSpy.mock.calls
+        .slice(beforeDecodeCalls)
+        .filter(([, encoding]) => encoding === 'base64').length
+      const publicResponse = parsePublicResponse(result)
+      const publicError = (publicResponse.error ?? {}) as Record<string, unknown>
+      const exposed = `${JSON.stringify(publicResponse)}\n${capturedLogs()}`
+      const rowTimeouts = timeoutSpy.mock.calls
+        .slice(beforeTimeoutCalls)
+        .map(([timeout]) => timeout)
+
+      expect
+        .soft(
+          beforeFiles.filter((file) => file !== 'unsupported.gif'),
+          row.name
+        )
+        .toEqual([])
+      expect.soft(result.isError, row.name).toBe(true)
+      expect.soft(publicError.code, row.name).toBe(row.expectedCode)
+      expect.soft(Object.keys(result).sort(), row.name).toEqual(['content', 'isError'])
+      expect.soft(Object.keys(publicResponse), row.name).toEqual(['error'])
+      expect
+        .soft(
+          Object.keys(publicError).every((key) => {
+            return ['code', 'details', 'message', 'suggestion', 'timestamp'].includes(key)
+          }),
+          row.name
+        )
+        .toBe(true)
+      const publicDetails = publicError.details as Record<string, unknown> | undefined
+      if (publicDetails) {
+        expect
+          .soft(
+            Object.keys(publicDetails).every((key) => {
+              return ['provider', 'stage', 'statusCode', 'upstreamMessage'].includes(key)
+            }),
+            row.name
+          )
+          .toBe(true)
+      }
+      expect.soft(transports.googleConstructor, row.name).not.toHaveBeenCalled()
+      expect
+        .soft(transports.openAIResponsesCreate, row.name)
+        .toHaveBeenCalledTimes(row.expectedTextCalls)
+      expect.soft(transports.fetch, row.name).toHaveBeenCalledTimes(row.expectedImageCalls)
+      expect.soft(parseCount, row.name).toBe(row.expectedParseCalls)
+      expect.soft(decodeCount, row.name).toBe(row.expectedDecodeCalls)
+      expect.soft(saveSpy, row.name).not.toHaveBeenCalled()
+      expect.soft(successSpy, row.name).not.toHaveBeenCalled()
+      expect.soft(errorSpy, row.name).toHaveBeenCalledTimes(1)
+      expect
+        .soft(
+          afterFiles.filter((file) => file !== 'unsupported.gif'),
+          row.name
+        )
+        .toEqual([])
+
+      if (row.expectedImageCalls === 0) {
+        expect.soft(rowTimeouts, row.name).not.toContain(180000)
+      } else {
+        expect.soft(rowTimeouts, row.name).toContain(180000)
+      }
+      if (row.name === 'url-only') {
+        expect.soft(transports.fetch, row.name).toHaveBeenCalledTimes(1)
+      }
+      if (row.name === 'chunked-body-over-48-mib') {
+        expect.soft(chunkedCancel, row.name).toBeDefined()
+        expect.soft(chunkedCancel?.mock.calls.length ?? 0, row.name).toBe(1)
+      }
+
+      for (const sensitiveValue of [
+        ARK_DUMMY_KEY,
+        AUTHORIZATION_VALUE,
+        requestSentinel,
+        INPUT_IMAGE_MARKER,
+        RAW_BODY_MARKER,
+        responseSentinel,
+        imageSentinel,
+      ]) {
+        expect.soft(exposed, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
+      }
+    }
+  })
+})

--- a/src/server/imageProviderRegistry.ts
+++ b/src/server/imageProviderRegistry.ts
@@ -1,0 +1,57 @@
+import { createGeminiClient } from '../api/geminiClient.js'
+import { createGeminiTextClient } from '../api/geminiTextClient.js'
+import type { ImageApiParams, ImageClient } from '../api/imageClient.js'
+import { createOpenAIImageClient } from '../api/openaiImageClient.js'
+import { createOpenAITextClient } from '../api/openaiTextClient.js'
+import {
+  createSeedreamImageClient,
+  validateSeedreamCapabilities,
+} from '../api/seedreamImageClient.js'
+import { createSeedreamTextClient } from '../api/seedreamTextClient.js'
+import type { TextClient } from '../api/textClient.js'
+import type { ImageProvider } from '../types/mcp.js'
+import type { Result } from '../types/result.js'
+import type { Config } from '../utils/config.js'
+
+type ImageOptions = Omit<ImageApiParams, 'prompt'>
+
+export interface ImageProviderDefinition {
+  readonly promptGeneration: Readonly<{
+    maxTokens: number
+  }>
+  createTextClient(config: Config): TextClient
+  createImageClient(config: Config): ImageClient
+  validateImageOptions?(options: ImageOptions, config: Config): void
+}
+
+function unwrap<T, E extends Error>(result: Result<T, E>): T {
+  if (!result.success) {
+    throw result.error
+  }
+  return result.data
+}
+
+const IMAGE_PROVIDERS = {
+  gemini: {
+    promptGeneration: { maxTokens: 1000 },
+    createTextClient: (config) => unwrap(createGeminiTextClient(config)),
+    createImageClient: (config) => unwrap(createGeminiClient(config)),
+  },
+  openai: {
+    promptGeneration: { maxTokens: 1000 },
+    createTextClient: (config) => unwrap(createOpenAITextClient(config)),
+    createImageClient: (config) => unwrap(createOpenAIImageClient(config)),
+  },
+  seedream: {
+    promptGeneration: { maxTokens: 384 },
+    createTextClient: (config) => unwrap(createSeedreamTextClient(config)),
+    createImageClient: (config) => unwrap(createSeedreamImageClient(config)),
+    validateImageOptions: (options, config) => {
+      unwrap(validateSeedreamCapabilities(options, config.imageQuality))
+    },
+  },
+} satisfies Record<ImageProvider, ImageProviderDefinition>
+
+export function getImageProviderDefinition(provider: ImageProvider): ImageProviderDefinition {
+  return IMAGE_PROVIDERS[provider]
+}

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -3,6 +3,7 @@
  * Simplified architecture with direct Gemini integration
  */
 
+import { constants as fsConstants } from 'node:fs'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
@@ -26,7 +27,7 @@ import { createSeedreamTextClient } from '../api/seedreamTextClient.js'
 import type { TextClient } from '../api/textClient.js'
 // Business logic
 import { createFileManager, type FileManager } from '../business/fileManager.js'
-import { validateGenerateImageParams } from '../business/inputValidator.js'
+import { MAX_IMAGE_SIZE, validateGenerateImageParams } from '../business/inputValidator.js'
 import { createResponseBuilder, type ResponseBuilder } from '../business/responseBuilder.js'
 import {
   createStructuredPromptGenerator,
@@ -38,6 +39,7 @@ import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
 
 // Utilities
 import { getConfig } from '../utils/config.js'
+import { InputValidationError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
 import { ensureExtension, getMimeTypeFromExtension } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
@@ -50,6 +52,57 @@ const DEFAULT_CONFIG: MCPServerConfig = {
   name: 'mcp-image-server',
   version: '0.1.0',
   defaultOutputDir: './output',
+}
+
+const INPUT_IMAGE_OPEN_FLAGS =
+  fsConstants.O_RDONLY |
+  (typeof fsConstants.O_NONBLOCK === 'number' ? fsConstants.O_NONBLOCK : 0) |
+  (typeof fsConstants.O_NOFOLLOW === 'number' ? fsConstants.O_NOFOLLOW : 0)
+
+function createInputImageSizeError(actualSize: number): InputValidationError {
+  const sizeInMB = (actualSize / (1024 * 1024)).toFixed(1)
+  const limitInMB = (MAX_IMAGE_SIZE / (1024 * 1024)).toFixed(1)
+  return new InputValidationError(
+    `Image size exceeds ${limitInMB}MB limit. Current size: ${sizeInMB}MB`,
+    `Please compress your image or reduce its resolution to stay below ${limitInMB}MB`
+  )
+}
+
+async function readInputImageWithinLimit(filePath: string): Promise<Buffer> {
+  const fileHandle = await fs.open(filePath, INPUT_IMAGE_OPEN_FLAGS)
+
+  try {
+    const stats = await fileHandle.stat()
+    if (!stats.isFile()) {
+      throw new InputValidationError(
+        'Input image must be a regular file',
+        'Please provide a path to a regular PNG, JPEG, or WebP image file'
+      )
+    }
+    if (stats.size > MAX_IMAGE_SIZE) {
+      throw createInputImageSizeError(stats.size)
+    }
+
+    const boundedBuffer = Buffer.alloc(MAX_IMAGE_SIZE + 1)
+    let observedBytes = 0
+
+    while (observedBytes < boundedBuffer.length) {
+      const readLength = Math.min(64 * 1024, boundedBuffer.length - observedBytes)
+      const { bytesRead } = await fileHandle.read(boundedBuffer, observedBytes, readLength, null)
+      if (bytesRead === 0) {
+        break
+      }
+
+      observedBytes += bytesRead
+      if (observedBytes > MAX_IMAGE_SIZE) {
+        throw createInputImageSizeError(observedBytes)
+      }
+    }
+
+    return boundedBuffer.subarray(0, observedBytes)
+  } finally {
+    await fileHandle.close()
+  }
 }
 
 /**
@@ -276,7 +329,7 @@ export class MCPServerImpl {
         if (!extensionCheck.success) {
           throw extensionCheck.error
         }
-        const imageBuffer = await fs.readFile(sanitizedInputPath.data)
+        const imageBuffer = await readInputImageWithinLimit(sanitizedInputPath.data)
         inputImageData = imageBuffer.toString('base64')
         inputImageMimeType = getMimeTypeFromExtension(path.extname(sanitizedInputPath.data))
       }

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -13,17 +13,7 @@ import {
   ListToolsRequestSchema,
   type ListToolsResult,
 } from '@modelcontextprotocol/sdk/types.js'
-// API clients
-import { createGeminiClient } from '../api/geminiClient.js'
-import { createGeminiTextClient } from '../api/geminiTextClient.js'
 import type { ImageApiParams, ImageClient } from '../api/imageClient.js'
-import { createOpenAIImageClient } from '../api/openaiImageClient.js'
-import { createOpenAITextClient } from '../api/openaiTextClient.js'
-import {
-  createSeedreamImageClient,
-  validateSeedreamCapabilities,
-} from '../api/seedreamImageClient.js'
-import { createSeedreamTextClient } from '../api/seedreamTextClient.js'
 import type { TextClient } from '../api/textClient.js'
 // Business logic
 import { createFileManager, type FileManager } from '../business/fileManager.js'
@@ -38,12 +28,16 @@ import {
 import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
 
 // Utilities
-import { getConfig } from '../utils/config.js'
+import { type Config, getConfig } from '../utils/config.js'
 import { InputValidationError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
 import { ensureExtension, getMimeTypeFromExtension } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
 import { ErrorHandler } from './errorHandler.js'
+import {
+  getImageProviderDefinition,
+  type ImageProviderDefinition,
+} from './imageProviderRegistry.js'
 
 /**
  * Default MCP server configuration
@@ -247,48 +241,30 @@ export class MCPServerImpl {
   /**
    * Initialize provider clients lazily.
    */
-  private async initializeClients(): Promise<void> {
-    const configResult = getConfig()
-    if (!configResult.success) {
-      throw configResult.error
-    }
-    const config = configResult.data
-
+  private async initializeClients(
+    config: Config,
+    provider: ImageProviderDefinition
+  ): Promise<void> {
     if (this.imageClient && (config.skipPromptEnhancement || this.structuredPromptGenerator)) {
       return
     }
 
     // Initialize Text Client for prompt generation when enhancement is enabled.
     if (!config.skipPromptEnhancement && !this.textClient) {
-      const textClientResult =
-        config.imageProvider === 'openai'
-          ? createOpenAITextClient(config)
-          : config.imageProvider === 'seedream'
-            ? createSeedreamTextClient(config)
-            : createGeminiTextClient(config)
-      if (!textClientResult.success) {
-        throw textClientResult.error
-      }
-      this.textClient = textClientResult.data
+      this.textClient = provider.createTextClient(config)
     }
 
     // Initialize Structured Prompt Generator
     if (!config.skipPromptEnhancement && this.textClient && !this.structuredPromptGenerator) {
-      this.structuredPromptGenerator = createStructuredPromptGenerator(this.textClient)
+      this.structuredPromptGenerator = createStructuredPromptGenerator(
+        this.textClient,
+        provider.promptGeneration.maxTokens
+      )
     }
 
     // Initialize image generation client.
     if (!this.imageClient) {
-      const clientResult =
-        config.imageProvider === 'openai'
-          ? createOpenAIImageClient(config)
-          : config.imageProvider === 'seedream'
-            ? createSeedreamImageClient(config)
-            : createGeminiClient(config)
-      if (!clientResult.success) {
-        throw clientResult.error
-      }
-      this.imageClient = clientResult.data
+      this.imageClient = provider.createImageClient(config)
     }
 
     this.logger.info('mcp-server', 'Image provider clients initialized', {
@@ -313,9 +289,11 @@ export class MCPServerImpl {
       if (!configResult.success) {
         throw configResult.error
       }
+      const config = configResult.data
+      const provider = getImageProviderDefinition(config.imageProvider)
 
       // Initialize clients
-      await this.initializeClients()
+      await this.initializeClients(config, provider)
 
       // Handle input image if provided
       let inputImageData: string | undefined
@@ -345,19 +323,11 @@ export class MCPServerImpl {
         ...(params.quality !== undefined && { quality: params.quality }),
       } satisfies Omit<ImageApiParams, 'prompt'>
 
-      if (configResult.data.imageProvider === 'seedream') {
-        const capabilityResult = validateSeedreamCapabilities(
-          imageOptions,
-          configResult.data.imageQuality
-        )
-        if (!capabilityResult.success) {
-          throw capabilityResult.error
-        }
-      }
+      provider.validateImageOptions?.(imageOptions, config)
 
       // Generate structured prompt (unless skipped)
       let structuredPrompt = params.prompt
-      if (!configResult.data.skipPromptEnhancement && this.structuredPromptGenerator) {
+      if (!config.skipPromptEnhancement && this.structuredPromptGenerator) {
         const features: FeatureFlags = {}
         if (params.maintainCharacterConsistency !== undefined) {
           features.maintainCharacterConsistency = params.maintainCharacterConsistency
@@ -393,7 +363,7 @@ export class MCPServerImpl {
             error: promptResult.error.message,
           })
         }
-      } else if (configResult.data.skipPromptEnhancement) {
+      } else if (config.skipPromptEnhancement) {
         this.logger.info('mcp-server', 'Prompt enhancement skipped (SKIP_PROMPT_ENHANCEMENT=true)')
       }
 
@@ -417,7 +387,7 @@ export class MCPServerImpl {
         ? this.securityManager.sanitizeFilename(params.fileName)
         : this.fileManager.generateFileName(mimeType)
       const fileName = params.fileName ? ensureExtension(rawFileName, mimeType) : rawFileName
-      const outputPath = path.join(configResult.data.imageOutputDir, fileName)
+      const outputPath = path.join(config.imageOutputDir, fileName)
 
       const sanitizedPath = this.securityManager.sanitizeFilePath(outputPath)
       if (!sanitizedPath.success) {

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -15,9 +15,14 @@ import {
 // API clients
 import { createGeminiClient } from '../api/geminiClient.js'
 import { createGeminiTextClient } from '../api/geminiTextClient.js'
-import type { ImageClient } from '../api/imageClient.js'
+import type { ImageApiParams, ImageClient } from '../api/imageClient.js'
 import { createOpenAIImageClient } from '../api/openaiImageClient.js'
 import { createOpenAITextClient } from '../api/openaiTextClient.js'
+import {
+  createSeedreamImageClient,
+  validateSeedreamCapabilities,
+} from '../api/seedreamImageClient.js'
+import { createSeedreamTextClient } from '../api/seedreamTextClient.js'
 import type { TextClient } from '../api/textClient.js'
 // Business logic
 import { createFileManager, type FileManager } from '../business/fileManager.js'
@@ -205,7 +210,9 @@ export class MCPServerImpl {
       const textClientResult =
         config.imageProvider === 'openai'
           ? createOpenAITextClient(config)
-          : createGeminiTextClient(config)
+          : config.imageProvider === 'seedream'
+            ? createSeedreamTextClient(config)
+            : createGeminiTextClient(config)
       if (!textClientResult.success) {
         throw textClientResult.error
       }
@@ -222,7 +229,9 @@ export class MCPServerImpl {
       const clientResult =
         config.imageProvider === 'openai'
           ? createOpenAIImageClient(config)
-          : createGeminiClient(config)
+          : config.imageProvider === 'seedream'
+            ? createSeedreamImageClient(config)
+            : createGeminiClient(config)
       if (!clientResult.success) {
         throw clientResult.error
       }
@@ -270,6 +279,27 @@ export class MCPServerImpl {
         const imageBuffer = await fs.readFile(sanitizedInputPath.data)
         inputImageData = imageBuffer.toString('base64')
         inputImageMimeType = getMimeTypeFromExtension(path.extname(sanitizedInputPath.data))
+      }
+
+      const imageOptions = {
+        ...(inputImageData && { inputImage: inputImageData }),
+        ...(inputImageMimeType && { inputImageMimeType }),
+        ...(params.aspectRatio && { aspectRatio: params.aspectRatio }),
+        ...(params.imageSize && { imageSize: params.imageSize }),
+        ...(params.useGoogleSearch !== undefined && {
+          useGoogleSearch: params.useGoogleSearch,
+        }),
+        ...(params.quality !== undefined && { quality: params.quality }),
+      } satisfies Omit<ImageApiParams, 'prompt'>
+
+      if (configResult.data.imageProvider === 'seedream') {
+        const capabilityResult = validateSeedreamCapabilities(
+          imageOptions,
+          configResult.data.imageQuality
+        )
+        if (!capabilityResult.success) {
+          throw capabilityResult.error
+        }
       }
 
       // Generate structured prompt (unless skipped)
@@ -321,12 +351,7 @@ export class MCPServerImpl {
 
       const generationResult = await this.imageClient.generateImage({
         prompt: structuredPrompt,
-        ...(inputImageData && { inputImage: inputImageData }),
-        ...(inputImageMimeType && { inputImageMimeType }),
-        ...(params.aspectRatio && { aspectRatio: params.aspectRatio }),
-        ...(params.imageSize && { imageSize: params.imageSize }),
-        ...(params.useGoogleSearch !== undefined && { useGoogleSearch: params.useGoogleSearch }),
-        ...(params.quality !== undefined && { quality: params.quality }),
+        ...imageOptions,
       })
 
       if (!generationResult.success) {

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -43,8 +43,9 @@ export type ImageQuality = 'fast' | 'balanced' | 'quality'
  * Supported image providers.
  * - 'gemini': Google Gemini/Nano Banana models (default)
  * - 'openai': OpenAI GPT Image models such as gpt-image-2
+ * - 'seedream': BytePlus Seedream models through ModelArk
  */
-export type ImageProvider = 'gemini' | 'openai'
+export type ImageProvider = 'gemini' | 'openai' | 'seedream'
 
 /**
  * Supported quality preset values
@@ -58,7 +59,11 @@ export const IMAGE_QUALITY_VALUES: readonly ImageQuality[] = [
 /**
  * Supported image provider values.
  */
-export const IMAGE_PROVIDER_VALUES: readonly ImageProvider[] = ['gemini', 'openai'] as const
+export const IMAGE_PROVIDER_VALUES: readonly ImageProvider[] = [
+  'gemini',
+  'openai',
+  'seedream',
+] as const
 
 /**
  * Gemini image generation model identifiers

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -11,6 +11,7 @@ describe('config', () => {
     process.env.IMAGE_PROVIDER = undefined
     process.env.GEMINI_API_KEY = undefined
     process.env.OPENAI_API_KEY = undefined
+    process.env.ARK_API_KEY = undefined
     process.env.IMAGE_OUTPUT_DIR = undefined
     process.env.IMAGE_QUALITY = undefined
   })
@@ -27,6 +28,7 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: '',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -51,6 +53,7 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'short',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -74,6 +77,7 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: -1000, // Invalid negative timeout
         skipPromptEnhancement: false,
@@ -101,6 +105,7 @@ describe('config', () => {
           imageProvider: 'gemini' as const,
           geminiApiKey: 'valid-api-key-12345',
           openaiApiKey: '',
+          arkApiKey: '',
           imageOutputDir: './output',
           apiTimeout: 30000,
           skipPromptEnhancement: false,
@@ -121,6 +126,7 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -147,6 +153,7 @@ describe('config', () => {
         imageProvider: 'gemini' as const,
         geminiApiKey: 'valid-api-key-12345',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -169,6 +176,7 @@ describe('config', () => {
         imageProvider: 'openai' as const,
         geminiApiKey: '',
         openaiApiKey: 'test-openai-api-key-12345',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -188,6 +196,7 @@ describe('config', () => {
         imageProvider: 'openai' as const,
         geminiApiKey: '',
         openaiApiKey: '',
+        arkApiKey: '',
         imageOutputDir: './output',
         apiTimeout: 30000,
         skipPromptEnhancement: false,
@@ -203,6 +212,56 @@ describe('config', () => {
         expect(result.error).toBeInstanceOf(ConfigError)
         expect(result.error.message).toContain('OPENAI_API_KEY')
       }
+    })
+
+    it.each(['', '   '])(
+      'should require a trimmed non-empty ARK_API_KEY for the Seedream provider',
+      (arkApiKey) => {
+        // Arrange
+        const config = {
+          imageProvider: 'seedream' as const,
+          geminiApiKey: '',
+          openaiApiKey: '',
+          arkApiKey,
+          imageOutputDir: './output',
+          apiTimeout: 30000,
+          skipPromptEnhancement: false,
+          imageQuality: 'fast' as const,
+        }
+
+        // Act
+        const result = validateConfig(config)
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toBeInstanceOf(ConfigError)
+          expect(result.error.message).toContain('ARK_API_KEY')
+          if (arkApiKey.length > 0) {
+            expect(result.error.message).not.toContain(arkApiKey)
+          }
+        }
+      }
+    )
+
+    it('should accept a trimmed non-empty ARK_API_KEY without other provider keys', () => {
+      // Arrange
+      const config = {
+        imageProvider: 'seedream' as const,
+        geminiApiKey: '',
+        openaiApiKey: '',
+        arkApiKey: '  test-ark-key  ',
+        imageOutputDir: './output',
+        apiTimeout: 30000,
+        skipPromptEnhancement: false,
+        imageQuality: 'fast' as const,
+      }
+
+      // Act
+      const result = validateConfig(config)
+
+      // Assert
+      expect(result.success).toBe(true)
     })
   })
 
@@ -251,6 +310,23 @@ describe('config', () => {
       if (result.success) {
         expect(result.data.imageProvider).toBe('openai')
         expect(result.data.openaiApiKey).toBe('test-openai-api-key-12345')
+      }
+    })
+
+    it('should load the exact Seedream provider and ARK_API_KEY from environment', () => {
+      // Arrange
+      process.env.IMAGE_PROVIDER = 'seedream'
+      process.env.ARK_API_KEY = 'test-ark-api-key'
+
+      // Act
+      const result = getConfig()
+
+      // Assert
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.imageProvider).toBe('seedream')
+        expect(result.data.arkApiKey).toBe('test-ark-api-key')
+        expect(result.data.apiTimeout).toBe(30000)
       }
     })
 

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -198,6 +198,41 @@ describe('Logger', () => {
       )
     })
 
+    it('should redact Seedream credentials and sensitive request data', () => {
+      // Arrange
+      const sensitiveValues = {
+        arkApiKey: 'ark-dummy-key',
+        authorization: 'bearer-dummy-token',
+        prompt: 'private prompt value',
+        image: 'private-image-value',
+        requestBody: 'private-request-body',
+        responseBody: 'private-response-body',
+      }
+      const message = [
+        `ARK_API_KEY=${sensitiveValues.arkApiKey}`,
+        `Authorization: Bearer ${sensitiveValues.authorization}`,
+        `prompt="${sensitiveValues.prompt}"`,
+        `image="${sensitiveValues.image}"`,
+        `request_body="${sensitiveValues.requestBody}"`,
+      ].join(' ')
+      const error = new Error(`response_body="${sensitiveValues.responseBody}"`)
+
+      // Act
+      logger.error('seedream', message, error, {
+        prompt: sensitiveValues.prompt,
+        image: sensitiveValues.image,
+        rawBody: sensitiveValues.requestBody,
+        authorization: `Bearer ${sensitiveValues.authorization}`,
+      })
+
+      // Assert
+      const logOutput = mockConsoleError.mock.calls[0][0]
+      expect(logOutput).toContain('[REDACTED]')
+      for (const sensitiveValue of Object.values(sensitiveValues)) {
+        expect(logOutput).not.toContain(sensitiveValue)
+      }
+    })
+
     it('should redact URLs in log messages', () => {
       // Arrange
       const message = 'Fetching data from https://api.example.com/v1/data?key=secret'

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -155,7 +155,7 @@ export function getConfig(): Result<Config, ConfigError> {
     imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
     geminiApiKey: readEnv('GEMINI_API_KEY') || '',
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
-    arkApiKey: readEnv('ARK_API_KEY') || '',
+    arkApiKey: (readEnv('ARK_API_KEY') || '').trim(),
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     apiTimeout: DEFAULT_CONFIG.apiTimeout,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,6 +16,7 @@ export interface Config {
   imageProvider: ImageProvider
   geminiApiKey: string
   openaiApiKey: string
+  arkApiKey: string
   imageOutputDir: string
   apiTimeout: number
   skipPromptEnhancement: boolean // Skip prompt enhancement for direct control
@@ -99,6 +100,19 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
+  // Seedream only requires a trimmed non-empty key; no vendor-specific length heuristic is defined.
+  if (
+    config.imageProvider === 'seedream' &&
+    (!config.arkApiKey || config.arkApiKey.trim().length === 0)
+  ) {
+    return Err(
+      new ConfigError(
+        'ARK_API_KEY is required but not provided',
+        'Set ARK_API_KEY environment variable with your BytePlus ModelArk API key'
+      )
+    )
+  }
+
   // Validate apiTimeout
   if (config.apiTimeout <= 0) {
     return Err(
@@ -141,6 +155,7 @@ export function getConfig(): Result<Config, ConfigError> {
     imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
     geminiApiKey: readEnv('GEMINI_API_KEY') || '',
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
+    arkApiKey: readEnv('ARK_API_KEY') || '',
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     apiTimeout: DEFAULT_CONFIG.apiTimeout,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,12 +21,15 @@ interface StructuredLogEntry {
 const SENSITIVE_PATTERNS = [
   /GEMINI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /OPENAI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
+  /ARK_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /api[_-]?key[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /password[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /bearer\s+([a-zA-Z0-9\-._~+/]+=*)/gi,
   /secret[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /token[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /(sk-(?:proj-)?[A-Za-z0-9_-]{16,})/g,
+  /\b(?:prompt|(?:input[_-]?)?image(?:[_-]?(?:data|body|content|base64))?|(?:raw|request|response)[_-]?body)['"]?\s*[:=]\s*"([^"]*)"/gi,
+  /\b(?:prompt|(?:input[_-]?)?image(?:[_-]?(?:data|body|content|base64))?|(?:raw|request|response)[_-]?body)['"]?\s*[:=]\s*'([^']*)'/gi,
 ]
 
 const URL_PATTERNS = [
@@ -82,6 +85,9 @@ export class Logger {
     /token/i,
     /credential/i,
     /bearer/i,
+    /^prompt(?:$|[_-]?(?:text|body|data)$)/i,
+    /^(?:input[_-]?)?image(?:$|[_-]?(?:data|body|content|base64)$)/i,
+    /^(?:raw|request|response)[_-]?body$/i,
   ]
 
   private currentTraceId?: string


### PR DESCRIPTION
## Summary

- Add `IMAGE_PROVIDER=seedream` using BytePlus ModelArk Responses for prompt enhancement and the direct image generation endpoint.
- Keep the public MCP request, `TextClient`/`ImageClient`, file-save, and file-URI response contracts provider-neutral.
- Centralize provider factories, prompt-generation limits, and capability validation in a typed provider registry.
- Map Seedream quality presets to the live-validated Pro routes:
  - `fast`: Seedream 5.0 Pro with native `fast` optimization
  - `balanced` / `quality`: Seedream 5.0 Pro with native `standard` optimization
  - all presets accept `1K` and `2K`, default to `1K`, and reject `4K`
- Apply aspect ratios through BytePlus Method 1 and reject unsupported Google Search before external calls.
- Enforce bounded response reading, strict base64 and PNG validation, optional non-contradictory response format metadata, and a Seedream-local 300-second timeout.
- Use a Seedream-specific 384-token prompt-generation limit while preserving the existing 1000-token limit for Gemini and OpenAI.

## Validation

- `npm run check:all`
  - 19 test files passed
  - 303 tests passed
- One no-retry live call through the production MCP code path succeeded with prompt enhancement enabled, Pro/native `fast`, omitted `imageSize` (default `1K`), and a saved PNG response.

## Scope

- This PR keeps image requests fixed to PNG.
- Provider-wide output format selection and filename/extension reconciliation will be handled in a follow-up PR.
- The package version is intentionally unchanged; the follow-up format work and this provider integration will be included in the same minor release.
