### PR TITLE
feat: add PNG and JPEG output selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The prompt optimizer uses a **Subject–Context–Style** framework (powered by 
   - World knowledge for photorealistic depictions of historical figures, landmarks, and factual scenarios
   - Prompt-level blending guidance for composite scenes
   - Purpose-aware generation (e.g., "cookbook cover" produces different results than "social media post")
-- **Multiple Output Formats**: PNG, JPEG, and WebP support where the selected provider supports them; Seedream output is PNG.
+- **Multiple Output Formats**: OpenAI and Seedream support PNG/JPEG selection through the output filename.
 
 ## Agent Skill: Image Generation Prompt Guide
 
@@ -359,7 +359,7 @@ The server uses a two-stage process with separate models for each stage:
 | `prompt` | string | ✅ | Text description or editing instruction |
 | `quality` | string | - | Quality preset: `fast` (default), `balanced`, `quality`. Overrides `IMAGE_QUALITY` env var for this request |
 | `inputImagePath` | string | - | Absolute path to input image for image-to-image editing |
-| `fileName` | string | - | Custom filename for output (auto-generated if not specified) |
+| `fileName` | string | - | `.png`, `.jpg`, or `.jpeg` output filename. OpenAI/Seedream use its extension as the output format; no extension defaults to PNG |
 | `aspectRatio` | string | - | `1:1` (default), `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `1:8`, `4:1`, `8:1` |
 | `imageSize` | string | - | `1K`, `2K`, `4K`. Leave unspecified for standard quality |
 | `blendImages` | boolean | - | Enable multi-image blending for combining multiple visual elements naturally |

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Seedream quality routing is fixed:
 
 All supported aspect ratios use BytePlus Method 1, so final pixel dimensions are model-selected.
 Seedream rejects `imageSize: "4K"` and `useGoogleSearch: true`. Image requests have a fixed
-300-second timeout.
+300-second timeout. Seedream image editing accepts PNG and JPEG input images only.
 
 ### Using the OpenAI provider
 
@@ -359,7 +359,7 @@ The server uses a two-stage process with separate models for each stage:
 | `prompt` | string | ✅ | Text description or editing instruction |
 | `quality` | string | - | Quality preset: `fast` (default), `balanced`, `quality`. Overrides `IMAGE_QUALITY` env var for this request |
 | `inputImagePath` | string | - | Absolute path to input image for image-to-image editing |
-| `fileName` | string | - | `.png`, `.jpg`, or `.jpeg` output filename. OpenAI/Seedream use its extension as the output format; no extension defaults to PNG |
+| `fileName` | string | - | `.png`, `.jpg`, or `.jpeg` selects that output format for OpenAI/Seedream. Other or absent suffixes use the provider default, and the saved name is corrected to the actual image extension |
 | `aspectRatio` | string | - | `1:1` (default), `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `1:8`, `4:1`, `8:1` |
 | `imageSize` | string | - | `1K`, `2K`, `4K`. Leave unspecified for standard quality |
 | `blendImages` | boolean | - | Enable multi-image blending for combining multiple visual elements naturally |

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -7,6 +7,8 @@ const mockGenerate = vi.fn()
 const mockEdit = vi.fn()
 const mockOpenAI = vi.fn()
 const mockToFile = vi.fn()
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01])
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x01])
 
 vi.mock('openai', () => ({
   default: class {
@@ -66,7 +68,7 @@ describe('openaiImageClient', () => {
       mockGenerate.mockResolvedValue({
         data: [
           {
-            b64_json: Buffer.from('mock-openai-image-data').toString('base64'),
+            b64_json: PNG_BYTES.toString('base64'),
           },
         ],
       })
@@ -89,7 +91,7 @@ describe('openaiImageClient', () => {
         size: '1024x1024',
       })
       if (result.success) {
-        expect(result.data.imageData).toEqual(Buffer.from('mock-openai-image-data'))
+        expect(result.data.imageData).toEqual(PNG_BYTES)
         expect(result.data.metadata.model).toBe('gpt-image-2')
         expect(result.data.metadata.provider).toBe('openai')
         expect(result.data.metadata.prompt).toBe('Generate a beautiful landscape')
@@ -101,7 +103,7 @@ describe('openaiImageClient', () => {
       mockEdit.mockResolvedValue({
         data: [
           {
-            b64_json: Buffer.from('mock-openai-edited-image-data').toString('base64'),
+            b64_json: PNG_BYTES.toString('base64'),
           },
         ],
       })
@@ -134,7 +136,7 @@ describe('openaiImageClient', () => {
 
     it('should map balanced quality to medium OpenAI quality', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)
@@ -155,7 +157,7 @@ describe('openaiImageClient', () => {
 
     it('should map quality preset to high OpenAI quality', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)
@@ -176,7 +178,7 @@ describe('openaiImageClient', () => {
 
     it('should map aspect ratio to closest OpenAI size', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)
@@ -197,7 +199,7 @@ describe('openaiImageClient', () => {
 
     it('should fall back to square size when aspect ratio is malformed', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)
@@ -257,9 +259,66 @@ describe('openaiImageClient', () => {
       }
     })
 
+    it('should request and validate JPEG output for generation', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: JPEG_BYTES.toString('base64') }],
+      })
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Generate a JPEG image',
+        preferredOutputFormat: 'jpeg',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ output_format: 'jpeg' }))
+      if (result.success) {
+        expect(result.data.imageData).toEqual(JPEG_BYTES)
+        expect(result.data.metadata.mimeType).toBe('image/jpeg')
+      }
+    })
+
+    it('should request JPEG output for editing', async () => {
+      mockEdit.mockResolvedValue({
+        data: [{ b64_json: JPEG_BYTES.toString('base64') }],
+      })
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({
+        prompt: 'Edit as JPEG',
+        inputImage: Buffer.from('input-image-data').toString('base64'),
+        inputImageMimeType: 'image/png',
+        preferredOutputFormat: 'jpeg',
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockEdit).toHaveBeenCalledWith(expect.objectContaining({ output_format: 'jpeg' }))
+    })
+
+    it('should reject bytes that contradict the requested format', async () => {
+      mockGenerate.mockResolvedValue({
+        data: [{ b64_json: JPEG_BYTES.toString('base64') }],
+      })
+      const clientResult = createOpenAIImageClient(testConfig)
+      expect(clientResult.success).toBe(true)
+      if (!clientResult.success) return
+
+      const result = await clientResult.data.generateImage({ prompt: 'Generate PNG' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ImageAPIError)
+        expect(result.error.context).toMatchObject({ stage: 'image_response' })
+      }
+    })
+
     it('should map 2K imageSize with landscape aspect ratio to a GPT Image 2 size', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)
@@ -282,7 +341,7 @@ describe('openaiImageClient', () => {
 
     it('should map 4K imageSize with portrait aspect ratio to a GPT Image 2 size', async () => {
       mockGenerate.mockResolvedValue({
-        data: [{ b64_json: Buffer.from('mock-openai-image-data').toString('base64') }],
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
 
       const clientResult = createOpenAIImageClient(testConfig)

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -125,6 +125,28 @@ describe('openaiTextClient', () => {
     }
   })
 
+  it('should reject a partial prompt when Responses reports max-output-token truncation', async () => {
+    mockResponsesCreate.mockResolvedValue({
+      output_text: 'partial enhanced prompt',
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+    })
+
+    const clientResult = createOpenAITextClient(testConfig)
+    expect(clientResult.success).toBe(true)
+    if (!clientResult.success) return
+
+    const result = await clientResult.data.generateText('make a product photo', {
+      maxTokens: 1000,
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(result.error.message).toContain('incomplete')
+    }
+  })
+
   it('should reject prompts that exceed the 100k character cap', async () => {
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -422,7 +422,7 @@ describe('seedreamImageClient', () => {
 
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.imageData).toEqual(largePng)
+      expect(Buffer.compare(result.data.imageData, largePng)).toBe(0)
     }
   })
 

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -408,6 +408,40 @@ describe('seedreamImageClient', () => {
     expect(rejected.success).toBe(false)
   })
 
+  it('accepts a valid 4 MiB PNG response without overflowing the validation stack', async () => {
+    // Keep this above the former regex stack-overflow threshold (~3.2 MiB decoded on Node 22).
+    const largePng = Buffer.alloc(4 * MIB)
+    PNG_BYTES.copy(largePng)
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ b64_json: largePng.toString('base64'), mime_type: 'image/png' }],
+      })
+    )
+
+    const result = await createClient().generateImage({ prompt: PRIVATE_PROMPT })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.imageData).toEqual(largePng)
+    }
+  })
+
+  it('accepts a valid 4 MiB PNG editing input without overflowing the validation stack', async () => {
+    // Keep this above the former regex stack-overflow threshold (~3.2 MiB decoded on Node 22).
+    const largePng = Buffer.alloc(4 * MIB)
+    PNG_BYTES.copy(largePng)
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: largePng.toString('base64'),
+      inputImageMimeType: 'image/png',
+    })
+
+    expect(result.success).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(readRequest().body.image).toBe(`data:image/png;base64,${largePng.toString('base64')}`)
+  })
+
   it.each([
     {
       name: 'missing data',
@@ -454,8 +488,18 @@ describe('seedreamImageClient', () => {
         }),
     },
     {
-      name: 'malformed base64',
-      response: () => jsonResponse({ data: [{ b64_json: '***', mime_type: 'image/png' }] }),
+      name: 'invalid base64 character after a valid PNG signature',
+      response: () => {
+        const validBase64 = PNG_BYTES.toString('base64')
+        return jsonResponse({
+          data: [
+            {
+              b64_json: `${validBase64.slice(0, -1)}*`,
+              mime_type: 'image/png',
+            },
+          ],
+        })
+      },
     },
     {
       name: 'empty base64',
@@ -641,6 +685,7 @@ describe('seedreamImageClient', () => {
     expect(timeoutSpy).toHaveBeenCalledWith(300000)
     expect(timeoutSpy).not.toHaveBeenCalledWith(1)
     expect(timeoutSpy).not.toHaveBeenCalledWith(30000)
+    expect(readRequest().init.signal).toBe(timeoutSpy.mock.results[0]?.value)
   })
 
   it('rejects missing or whitespace auth during factory preflight', () => {

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -15,6 +15,7 @@ const MAX_DECODED_BYTES = 32 * MIB
 const PNG_BYTES = Buffer.from([
   0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x66, 0x69, 0x78, 0x74, 0x75, 0x72, 0x65,
 ])
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x66, 0x69, 0x78, 0x74, 0x75, 0x72, 0x65])
 const PRIVATE_INPUT_IMAGE = PNG_BYTES.toString('base64')
 const ALL_ASPECT_RATIOS = [
   '1:1',
@@ -284,6 +285,53 @@ describe('seedreamImageClient', () => {
     if (result.success) {
       expect(result.data.metadata.inputImageProvided).toBe(true)
     }
+  })
+
+  it('requests and validates JPEG output for generation', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          {
+            b64_json: JPEG_BYTES.toString('base64'),
+            mime_type: 'image/jpeg',
+            output_format: 'jpeg',
+          },
+        ],
+      })
+    )
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      preferredOutputFormat: 'jpeg',
+    })
+
+    expect(result.success).toBe(true)
+    expect(readRequest().body.output_format).toBe('jpeg')
+    if (result.success) {
+      expect(result.data.imageData).toEqual(JPEG_BYTES)
+      expect(result.data.metadata.mimeType).toBe('image/jpeg')
+    }
+  })
+
+  it('requests JPEG output for editing', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: [{ b64_json: JPEG_BYTES.toString('base64') }],
+      })
+    )
+
+    const result = await createClient().generateImage({
+      prompt: PRIVATE_PROMPT,
+      inputImage: PRIVATE_INPUT_IMAGE,
+      inputImageMimeType: 'image/png',
+      preferredOutputFormat: 'jpeg',
+    })
+
+    expect(result.success).toBe(true)
+    expect(readRequest().body).toMatchObject({
+      output_format: 'jpeg',
+      image: `data:image/png;base64,${PRIVATE_INPUT_IMAGE}`,
+    })
   })
 
   it.each([

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -99,7 +99,7 @@ describe('seedreamTextClient', () => {
       topK: 40,
     })
 
-    expect(result).toEqual({ success: true, data: enhancedPrompt })
+    expect(result).toEqual({ success: true, data: enhancedPrompt.trim() })
     expect(transport).toHaveBeenCalledTimes(1)
 
     const [url, init] = transport.mock.calls[0]
@@ -121,6 +121,31 @@ describe('seedreamTextClient', () => {
     expect(Object.hasOwn(body, 'topK')).toBe(false)
     expect(JSON.stringify(body)).not.toContain(DUMMY_API_KEY)
     expect(timeoutSpy).toHaveBeenCalledWith(30000)
+  })
+
+  it('rejects a partial prompt when Responses reports max-output-token truncation', async () => {
+    const transport = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          output_text: 'partial enhanced prompt',
+          status: 'incomplete',
+          incomplete_details: { reason: 'max_output_tokens' },
+        }),
+        {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }
+      )
+    )
+    vi.stubGlobal('fetch', transport)
+
+    const result = await createClient().generateText(PRIVATE_PROMPT, { maxTokens: 384 })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBeInstanceOf(ImageAPIError)
+      expect(result.error.message).toContain('incomplete')
+    }
   })
 
   it('preserves multimodal TextClient input without provider-native prompt fields', async () => {

--- a/src/api/imageClient.ts
+++ b/src/api/imageClient.ts
@@ -1,4 +1,4 @@
-import type { AspectRatio, ImageQuality, ImageSize } from '../types/mcp.js'
+import type { AspectRatio, ImageOutputFormat, ImageQuality, ImageSize } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import type { GeminiAPIError, ImageAPIError, NetworkError } from '../utils/errors.js'
 
@@ -27,6 +27,7 @@ export interface ImageApiParams {
   aspectRatio?: AspectRatio
   imageSize?: ImageSize
   useGoogleSearch?: boolean
+  preferredOutputFormat?: ImageOutputFormat
   quality?: ImageQuality
 }
 

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -8,12 +8,17 @@ import type {
   ImageGenerateParamsNonStreaming,
   ImagesResponse,
 } from 'openai/resources/images'
-import type { ImageQuality } from '../types/mcp.js'
+import type { ImageOutputFormat, ImageQuality } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
-import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import {
+  DEFAULT_MIME_TYPE,
+  getMimeTypeForOutputFormat,
+  matchesImageDataMimeType,
+  normalizeMimeType,
+} from '../utils/mimeUtils.js'
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
@@ -28,7 +33,6 @@ type OpenAIImageSize =
   | '3840x2160'
   | '2160x3840'
 type OpenAIImageQuality = 'low' | 'medium' | 'high'
-type OpenAIOutputFormat = 'png'
 // The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
 // enumerate the older fixed GPT image sizes. Keep the request cast local to this file.
 type OpenAIImageGenerateRequest = ImageGenerateParamsNonStreaming
@@ -128,7 +132,6 @@ function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIErr
 }
 
 class OpenAIImageClientImpl implements ImageClient {
-  private readonly outputFormat: OpenAIOutputFormat = 'png'
   private readonly modelName = OPENAI_IMAGE_MODEL
 
   constructor(
@@ -147,10 +150,11 @@ class OpenAIImageClientImpl implements ImageClient {
 
       const quality = mapQuality(params.quality ?? this.defaultQuality)
       const size = mapSize(params)
+      const outputFormat: ImageOutputFormat = params.preferredOutputFormat ?? 'png'
 
       const response = hasInputImage(params)
-        ? await this.editImage(params, quality, size)
-        : await this.createImage(params, quality, size)
+        ? await this.editImage(params, quality, size, outputFormat)
+        : await this.createImage(params, quality, size, outputFormat)
 
       const firstImage = response.data?.[0]
       if (!firstImage?.b64_json) {
@@ -165,13 +169,26 @@ class OpenAIImageClientImpl implements ImageClient {
         )
       }
 
+      const imageData = Buffer.from(firstImage.b64_json, 'base64')
+      const mimeType = getMimeTypeForOutputFormat(outputFormat)
+      if (!matchesImageDataMimeType(imageData, mimeType)) {
+        return Err(
+          new ImageAPIError('OpenAI image response did not match the requested output format', {
+            provider: 'openai',
+            model: this.modelName,
+            stage: 'image_response',
+            suggestion: 'Retry the request; the provider returned unexpected image bytes',
+          })
+        )
+      }
+
       return Ok({
-        imageData: Buffer.from(firstImage.b64_json, 'base64'),
+        imageData,
         metadata: {
           model: this.modelName,
           provider: 'openai',
           prompt: params.prompt,
-          mimeType: `image/${this.outputFormat}`,
+          mimeType,
           timestamp: new Date(),
           inputImageProvided: !!params.inputImage,
           ...(firstImage.revised_prompt && { revisedPrompt: firstImage.revised_prompt }),
@@ -185,13 +202,14 @@ class OpenAIImageClientImpl implements ImageClient {
   private async createImage(
     params: ImageApiParams,
     quality: OpenAIImageQuality,
-    size: OpenAIImageSize
+    size: OpenAIImageSize,
+    outputFormat: ImageOutputFormat
   ): Promise<ImagesResponse> {
     const request = {
       model: this.modelName,
       prompt: params.prompt,
       n: 1,
-      output_format: this.outputFormat,
+      output_format: outputFormat,
       quality,
       size,
     }
@@ -202,7 +220,8 @@ class OpenAIImageClientImpl implements ImageClient {
   private async editImage(
     params: ImageEditApiParams,
     quality: OpenAIImageQuality,
-    size: OpenAIImageSize
+    size: OpenAIImageSize,
+    outputFormat: ImageOutputFormat
   ): Promise<ImagesResponse> {
     const mimeType = normalizeMimeType(params.inputImageMimeType ?? DEFAULT_MIME_TYPE)
     const inputFile = await toFile(
@@ -216,7 +235,7 @@ class OpenAIImageClientImpl implements ImageClient {
       prompt: params.prompt,
       image: inputFile,
       n: 1,
-      output_format: this.outputFormat,
+      output_format: outputFormat,
       quality,
       size,
     }

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -13,6 +13,10 @@ import type { GenerationConfig, TextClient } from './textClient.js'
 
 interface OpenAITextResponse {
   output_text?: string
+  status?: 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete'
+  incomplete_details?: {
+    reason?: 'max_output_tokens' | 'content_filter'
+  } | null
   output?: Array<{
     content?: Array<{
       type?: string
@@ -56,6 +60,17 @@ class OpenAITextClientImpl implements TextClient {
         },
         { signal: AbortSignal.timeout(timeout) }
       )) as OpenAITextResponse
+
+      if (response.status === 'incomplete') {
+        const reason = response.incomplete_details?.reason ?? 'unknown reason'
+        return Err(
+          new ImageAPIError(`OpenAI text generation response was incomplete: ${reason}`, {
+            provider: 'openai',
+            stage: 'text generation',
+            suggestion: 'Use the original prompt or increase the prompt generation token limit',
+          })
+        )
+      }
 
       const responseText = this.extractResponseText(response)
       if (!responseText || responseText.trim().length === 0) {

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -106,11 +106,33 @@ function responseContractError(): ImageAPIError {
 }
 
 function isStrictBase64(value: string): boolean {
-  return (
-    value.length > 0 &&
-    value.length % 4 === 0 &&
-    /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
-  )
+  if (value.length === 0 || value.length % 4 !== 0) {
+    return false
+  }
+
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
+  const contentLength = value.length - padding
+
+  for (let index = 0; index < contentLength; index += 1) {
+    const code = value.charCodeAt(index)
+    const isBase64Character =
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code === 0x2b ||
+      code === 0x2f
+    if (!isBase64Character) {
+      return false
+    }
+  }
+
+  for (let index = contentLength; index < value.length; index += 1) {
+    if (value.charCodeAt(index) !== 0x3d) {
+      return false
+    }
+  }
+
+  return true
 }
 
 function hasOwn(record: object, key: PropertyKey): boolean {
@@ -275,17 +297,17 @@ function parseImagePayload(
     !isRecord(image) ||
     hasOwn(image, 'url') ||
     hasOwn(image, 'stream') ||
-    typeof image['b64_json'] !== 'string' ||
-    !isStrictBase64(image['b64_json'])
+    typeof image['b64_json'] !== 'string'
   ) {
     return Err(responseContractError())
   }
 
-  if (calculateDecodedSize(image['b64_json']) > MAX_DECODED_BYTES) {
+  const base64Image = image['b64_json']
+  if (calculateDecodedSize(base64Image) > MAX_DECODED_BYTES || !isStrictBase64(base64Image)) {
     return Err(responseContractError())
   }
 
-  const imageData = Buffer.from(image['b64_json'], 'base64')
+  const imageData = Buffer.from(base64Image, 'base64')
   const expectedMimeType = getMimeTypeForOutputFormat(outputFormat)
   if (
     imageData.length === 0 ||

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -1,8 +1,9 @@
-import type { AspectRatio, ImageQuality, ImageSize } from '../types/mcp.js'
+import type { AspectRatio, ImageOutputFormat, ImageQuality, ImageSize } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { getMimeTypeForOutputFormat, matchesImageDataMimeType } from '../utils/mimeUtils.js'
 import { isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
@@ -10,8 +11,6 @@ const SEEDREAM_IMAGE_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/
 const SEEDREAM_IMAGE_TIMEOUT_MS = 300000
 const MAX_RESPONSE_BYTES = 48 * 1024 * 1024
 const MAX_DECODED_BYTES = 32 * 1024 * 1024
-const PNG_MIME_TYPE = 'image/png'
-const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
 
 const ASPECT_RATIOS: readonly AspectRatio[] = [
   '1:1',
@@ -81,7 +80,7 @@ type SeedreamImageWireRequest = Readonly<{
   image?: string
   size: ImageSize
   response_format: 'b64_json'
-  output_format: 'png'
+  output_format: ImageOutputFormat
   stream: false
   watermark: false
   optimize_prompt_options: Readonly<{ mode: 'fast' | 'standard' }>
@@ -101,7 +100,8 @@ function responseContractError(): ImageAPIError {
   return new ImageAPIError('Invalid response from Seedream image provider', {
     provider: 'seedream',
     stage: 'image_response',
-    suggestion: 'Retry the request; the provider response did not satisfy the PNG contract',
+    suggestion:
+      'Retry the request; the provider response did not satisfy the requested image format',
   })
 }
 
@@ -190,7 +190,7 @@ function buildWireRequest(
       }),
     size: resolved.resolution,
     response_format: 'b64_json',
-    output_format: 'png',
+    output_format: params.preferredOutputFormat ?? 'png',
     stream: false,
     watermark: false,
     optimize_prompt_options: { mode: resolved.route.promptOptimizationMode },
@@ -262,7 +262,10 @@ function calculateDecodedSize(base64: string): number {
   return (base64.length / 4) * 3 - padding
 }
 
-function parseImagePayload(payload: unknown): Result<Buffer, ImageAPIError> {
+function parseImagePayload(
+  payload: unknown,
+  outputFormat: ImageOutputFormat
+): Result<Buffer, ImageAPIError> {
   if (!isRecord(payload) || !Array.isArray(payload['data']) || payload['data'].length !== 1) {
     return Err(responseContractError())
   }
@@ -283,12 +286,13 @@ function parseImagePayload(payload: unknown): Result<Buffer, ImageAPIError> {
   }
 
   const imageData = Buffer.from(image['b64_json'], 'base64')
+  const expectedMimeType = getMimeTypeForOutputFormat(outputFormat)
   if (
     imageData.length === 0 ||
     imageData.length > MAX_DECODED_BYTES ||
-    !imageData.subarray(0, PNG_MAGIC.length).equals(PNG_MAGIC) ||
-    (hasOwn(image, 'mime_type') && image['mime_type'] !== PNG_MIME_TYPE) ||
-    (hasOwn(image, 'output_format') && image['output_format'] !== 'png')
+    !matchesImageDataMimeType(imageData, expectedMimeType) ||
+    (hasOwn(image, 'mime_type') && image['mime_type'] !== expectedMimeType) ||
+    (hasOwn(image, 'output_format') && image['output_format'] !== outputFormat)
   ) {
     return Err(responseContractError())
   }
@@ -333,7 +337,7 @@ class SeedreamImageClientImpl implements ImageClient {
         return payloadResult
       }
 
-      const imageResult = parseImagePayload(payloadResult.data)
+      const imageResult = parseImagePayload(payloadResult.data, request.output_format)
       if (!imageResult.success) {
         return imageResult
       }
@@ -344,7 +348,7 @@ class SeedreamImageClientImpl implements ImageClient {
           model: resolvedResult.data.route.model,
           provider: 'seedream',
           prompt: request.prompt,
-          mimeType: PNG_MIME_TYPE,
+          mimeType: getMimeTypeForOutputFormat(request.output_format),
           timestamp: new Date(),
           inputImageProvided: params.inputImage !== undefined,
         },

--- a/src/api/seedreamTextClient.ts
+++ b/src/api/seedreamTextClient.ts
@@ -4,6 +4,7 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
+import { sanitizeText } from '../utils/logger.js'
 import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
@@ -55,6 +56,17 @@ class SeedreamTextClientImpl implements TextClient {
       })
       const responseText = response.output_text
 
+      if (response.status === 'incomplete') {
+        const reason = response.incomplete_details?.reason ?? 'unknown reason'
+        return Err(
+          new ImageAPIError(`Seedream text generation response was incomplete: ${reason}`, {
+            provider: 'seedream',
+            stage: 'text generation',
+            suggestion: 'Use the original prompt or increase the prompt generation token limit',
+          })
+        )
+      }
+
       if (!responseText || responseText.trim().length === 0) {
         return Err(
           new ImageAPIError(
@@ -64,7 +76,7 @@ class SeedreamTextClientImpl implements TextClient {
         )
       }
 
-      return Ok(responseText)
+      return Ok(responseText.trim())
     } catch (error) {
       return this.handleError(error, 'text generation')
     }
@@ -193,10 +205,11 @@ class SeedreamTextClientImpl implements TextClient {
 export function createSeedreamTextClient(config: Config): Result<TextClient, ImageAPIError> {
   try {
     return Ok(new SeedreamTextClientImpl(config))
-  } catch {
+  } catch (error) {
+    const errorMessage = sanitizeText(error instanceof Error ? error.message : 'Unknown error')
     return Err(
       new ImageAPIError(
-        'Failed to initialize Seedream text client',
+        `Failed to initialize Seedream text client: ${errorMessage}`,
         'Verify ARK_API_KEY and the installed OpenAI SDK configuration'
       )
     )

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -209,6 +209,10 @@ function createPngFixture(sentinel: string): Buffer {
   ])
 }
 
+function createJpegFixture(sentinel: string): Buffer {
+  return Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.from(sentinel)])
+}
+
 function countOccurrences(value: string, needle: string): number {
   return value.split(needle).length - 1
 }
@@ -483,7 +487,7 @@ afterEach(async () => {
 // AC: "AC-08 When image を呼ぶと、system は AP `POST /images/generations` に Bearer auth、
 // selected model/provider-local ratio suffix付きprompt/optional single image/effective resolution
 // token、`response_format=b64_json`,
-// `output_format=png`, `stream=false`, `watermark=false` とroute別の
+// default `output_format=png`, `stream=false`, `watermark=false` とroute別の
 // `optimize_prompt_options.mode=fast|standard` を送り、
 // `sequential_image_generation` は送らない。"
 // AC: "AC-10 When 成功したら、既存 sanitized save/file URI と `structuredContent` 非存在を維持し、
@@ -541,7 +545,7 @@ afterEach(async () => {
 //   exact WxH or applies ratio-specific rounding.
 // - Fast route: select `dola-seedream-5-0-pro-260628` with native fast optimization.
 // - Every route omits the `sequential_image_generation` property entirely.
-// - Every image request includes `response_format='b64_json'`, `output_format='png'`, stream=false,
+// - Every PNG matrix request includes `response_format='b64_json'`, `output_format='png'`, stream=false,
 //   watermark=false, the route-specific optimize_prompt_options.mode, captured Bearer auth, and
 //   only the optional single-image field allowed by preflight.
 // - False prompt flags add no enhancement instruction; true prompt-only flags/purpose affect only
@@ -1059,6 +1063,48 @@ describe('BytePlus Seedream integration', () => {
         expect.soft(publicAndLogs, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
       }
     }
+  })
+
+  it('propagates .jpg through Seedream JPEG wire, bytes, save, and public resource', async () => {
+    resetTransportDoubles()
+    const outputDirectory = await createOutputDirectory()
+    const fileName = 'seedream-native-output.jpg'
+    const expectedBytes = createJpegFixture('seedream-jpeg-integration')
+    configureSeedream(outputDirectory, { skipPromptEnhancement: true })
+    transports.fetch.mockResolvedValue(
+      createJsonResponse({
+        data: [
+          {
+            b64_json: expectedBytes.toString('base64'),
+            mime_type: 'image/jpeg',
+            output_format: 'jpeg',
+          },
+        ],
+      })
+    )
+
+    const result = await createMCPServer().callTool('generate_image', {
+      prompt: ORIGINAL_PROMPT,
+      fileName,
+      quality: 'fast',
+    })
+
+    expect.soft(result.isError).toBe(false)
+    expect.soft(observeLastImageRequest().body).toMatchObject({
+      output_format: 'jpeg',
+      response_format: 'b64_json',
+    })
+    expect.soft(await readFile(join(outputDirectory, fileName))).toEqual(expectedBytes)
+    expect.soft(parsePublicResponse(result)).toMatchObject({
+      type: 'resource',
+      resource: {
+        name: fileName,
+        mimeType: 'image/jpeg',
+      },
+      metadata: {
+        provider: 'seedream',
+      },
+    })
   })
 
   // AC: SEC-FILE-BOUND-01, SEC-FILE-TYPE-02, INPUT-SIZE-CONTRACT-04, RESOURCE-CLEANUP-05

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -1,13 +1,10 @@
 import { execFile } from 'node:child_process'
 import { constants as fsConstants } from 'node:fs'
 import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { ImageClient } from '../../api/imageClient.js'
-import type { FileManager } from '../../business/fileManager.js'
 import { MAX_IMAGE_SIZE } from '../../business/inputValidator.js'
-import type { ResponseBuilder } from '../../business/responseBuilder.js'
-import type { StructuredPromptGenerator } from '../../business/structuredPromptGenerator.js'
 import { createMCPServer } from '../mcpServer.js'
 
 const fileSystem = vi.hoisted(() => ({
@@ -225,7 +222,7 @@ function createJsonResponse(payload: unknown, status = 200): Response {
 }
 
 async function createOutputDirectory(): Promise<string> {
-  const directory = await mkdtemp('/tmp/mcp-image-seedream-')
+  const directory = await mkdtemp(join(tmpdir(), 'mcp-image-seedream-'))
   temporaryDirectories.add(directory)
   return directory
 }
@@ -268,22 +265,6 @@ function parsePublicResponse(
   }
 
   return JSON.parse(firstContent.text) as Record<string, unknown>
-}
-
-function readServerInternals(server: ReturnType<typeof createMCPServer>): {
-  fileManager: FileManager
-  imageClient: ImageClient | null
-  responseBuilder: ResponseBuilder
-  structuredPromptGenerator: StructuredPromptGenerator | null
-  textClient: object | null
-} {
-  return server as unknown as {
-    fileManager: FileManager
-    imageClient: ImageClient | null
-    responseBuilder: ResponseBuilder
-    structuredPromptGenerator: StructuredPromptGenerator | null
-    textClient: object | null
-  }
 }
 
 function observeLastImageRequest(): {
@@ -642,106 +623,73 @@ afterEach(async () => {
 // diagnostics; this integration case proves those failures cannot escape into files or responses.
 
 describe('BytePlus Seedream integration', () => {
-  it('selects Seedream clients through the existing lazy initialization branches', async () => {
+  it('routes Seedream requests and reuses the prompt client through public effects', async () => {
     const skipOutput = await createOutputDirectory()
     configureSeedream(skipOutput, { skipPromptEnhancement: true })
     const skippedServer = createMCPServer()
-    const skippedBefore = readServerInternals(skippedServer)
-    const skippedSave = vi.spyOn(skippedBefore.fileManager, 'saveImage')
-    const skippedSuccess = vi.spyOn(skippedBefore.responseBuilder, 'buildSuccessResponse')
 
     expect(await readdir(skipOutput)).toEqual([])
-    expect.soft(skippedBefore.textClient).toBeNull()
-    expect.soft(skippedBefore.imageClient).toBeNull()
-    expect.soft(skippedBefore.structuredPromptGenerator).toBeNull()
 
     const skippedFirst = await skippedServer.callTool('generate_image', {
       prompt: ORIGINAL_PROMPT,
       fileName: 'skip-first.png',
     })
-    const skippedAfterFirst = readServerInternals(skippedServer)
     const skippedSecond = await skippedServer.callTool('generate_image', {
       prompt: ORIGINAL_PROMPT,
       fileName: 'skip-second.png',
     })
-    const skippedAfterSecond = readServerInternals(skippedServer)
 
     expect.soft(transports.googleConstructor).not.toHaveBeenCalled()
     expect.soft(transports.openAIConstructorOptions).toHaveLength(0)
     expect.soft(transports.openAIResponsesCreate).not.toHaveBeenCalled()
     expect.soft(transports.fetch).toHaveBeenCalledTimes(2)
-    expect.soft(skippedAfterFirst.textClient).toBeNull()
-    expect.soft(skippedAfterFirst.structuredPromptGenerator).toBeNull()
-    expect.soft(skippedAfterFirst.imageClient).not.toBeNull()
-    expect.soft(skippedAfterSecond.imageClient).toBe(skippedAfterFirst.imageClient)
-    expect.soft(skippedSave).toHaveBeenCalledTimes(2)
-    expect.soft(skippedSuccess).toHaveBeenCalledTimes(2)
     expect.soft(skippedFirst.isError).toBe(false)
     expect.soft(skippedSecond.isError).toBe(false)
-    expect.soft(await readdir(skipOutput)).toHaveLength(2)
+    expect.soft((await readdir(skipOutput)).sort()).toEqual(['skip-first.png', 'skip-second.png'])
 
     resetTransportDoubles()
     const cachedOutput = await createOutputDirectory()
     configureSeedream(cachedOutput)
     const cachedServer = createMCPServer()
-    const cachedBefore = readServerInternals(cachedServer)
-    const cachedSave = vi.spyOn(cachedBefore.fileManager, 'saveImage')
-    const cachedSuccess = vi.spyOn(cachedBefore.responseBuilder, 'buildSuccessResponse')
 
     expect(await readdir(cachedOutput)).toEqual([])
-    expect.soft(cachedBefore.textClient).toBeNull()
-    expect.soft(cachedBefore.imageClient).toBeNull()
-    expect.soft(cachedBefore.structuredPromptGenerator).toBeNull()
 
     const cachedFirst = await cachedServer.callTool('generate_image', {
       prompt: ORIGINAL_PROMPT,
       fileName: 'cache-first.png',
     })
-    const cachedAfterFirst = readServerInternals(cachedServer)
     const cachedSecond = await cachedServer.callTool('generate_image', {
       prompt: ORIGINAL_PROMPT,
       fileName: 'cache-second.png',
     })
-    const cachedAfterSecond = readServerInternals(cachedServer)
 
     expect.soft(transports.googleConstructor).not.toHaveBeenCalled()
-    expect.soft(transports.openAIConstructorOptions).toHaveLength(1)
+    expect.soft(transports.openAIConstructorOptions).toEqual([
+      {
+        apiKey: ARK_DUMMY_KEY,
+        baseURL: 'https://ark.ap-southeast.bytepluses.com/api/v3',
+      },
+    ])
     expect.soft(transports.openAIResponsesCreate).toHaveBeenCalledTimes(2)
     expect.soft(transports.fetch).toHaveBeenCalledTimes(2)
-    expect.soft(cachedAfterFirst.textClient).not.toBeNull()
-    expect.soft(cachedAfterFirst.imageClient).not.toBeNull()
-    expect.soft(cachedAfterFirst.structuredPromptGenerator).not.toBeNull()
-    expect.soft(cachedAfterSecond.textClient).toBe(cachedAfterFirst.textClient)
-    expect.soft(cachedAfterSecond.imageClient).toBe(cachedAfterFirst.imageClient)
-    expect
-      .soft(cachedAfterSecond.structuredPromptGenerator)
-      .toBe(cachedAfterFirst.structuredPromptGenerator)
-    expect.soft(cachedSave).toHaveBeenCalledTimes(2)
-    expect.soft(cachedSuccess).toHaveBeenCalledTimes(2)
     expect.soft(cachedFirst.isError).toBe(false)
     expect.soft(cachedSecond.isError).toBe(false)
-    expect.soft(await readdir(cachedOutput)).toHaveLength(2)
+    expect
+      .soft((await readdir(cachedOutput)).sort())
+      .toEqual(['cache-first.png', 'cache-second.png'])
 
     resetTransportDoubles()
     const failureOutput = await createOutputDirectory()
     configureSeedream(failureOutput)
     transports.openAIConstructorError = new Error('synthetic Seedream factory failure')
     const failedServer = createMCPServer()
-    const failedBefore = readServerInternals(failedServer)
-    const failedSave = vi.spyOn(failedBefore.fileManager, 'saveImage')
-    const failedSuccess = vi.spyOn(failedBefore.responseBuilder, 'buildSuccessResponse')
-    const failedError = vi.spyOn(failedBefore.responseBuilder, 'buildErrorResponse')
 
     expect(await readdir(failureOutput)).toEqual([])
-    expect.soft(failedBefore.textClient).toBeNull()
-    expect.soft(failedBefore.imageClient).toBeNull()
-    expect.soft(failedBefore.structuredPromptGenerator).toBeNull()
 
     const failed = await failedServer.callTool('generate_image', {
       prompt: ORIGINAL_PROMPT,
       fileName: 'must-not-exist.png',
     })
-    const failedAfter = readServerInternals(failedServer)
     const failedPublicResponse = parsePublicResponse(failed)
     const failureExposure = `${JSON.stringify(failedPublicResponse)}\n${capturedLogs()}`
 
@@ -750,12 +698,9 @@ describe('BytePlus Seedream integration', () => {
     expect.soft(transports.openAIConstructorOptions).toHaveLength(1)
     expect.soft(transports.openAIResponsesCreate).not.toHaveBeenCalled()
     expect.soft(transports.fetch).not.toHaveBeenCalled()
-    expect.soft(failedAfter.textClient).toBeNull()
-    expect.soft(failedAfter.imageClient).toBeNull()
-    expect.soft(failedAfter.structuredPromptGenerator).toBeNull()
-    expect.soft(failedSave).not.toHaveBeenCalled()
-    expect.soft(failedSuccess).not.toHaveBeenCalled()
-    expect.soft(failedError).toHaveBeenCalledTimes(1)
+    expect
+      .soft((failedPublicResponse.error as { message?: string } | undefined)?.message)
+      .toContain('synthetic Seedream factory failure')
     expect.soft(await readdir(failureOutput)).toEqual([])
     expect.soft(failureExposure).not.toContain(ARK_DUMMY_KEY)
     expect.soft(failureExposure).not.toContain(ORIGINAL_PROMPT)
@@ -917,9 +862,6 @@ describe('BytePlus Seedream integration', () => {
       }
 
       const server = createMCPServer()
-      const internals = readServerInternals(server)
-      const saveSpy = vi.spyOn(internals.fileManager, 'saveImage')
-      const successSpy = vi.spyOn(internals.responseBuilder, 'buildSuccessResponse')
       const beforeTimeoutCalls = timeoutSpy.mock.calls.length
       const beforeParseCalls = jsonParseSpy.mock.calls.length
       const beforeDecodeCalls = bufferFromSpy.mock.calls.length
@@ -950,8 +892,6 @@ describe('BytePlus Seedream integration', () => {
       const rowTimeouts = timeoutSpy.mock.calls
         .slice(beforeTimeoutCalls)
         .map(([timeout]) => timeout)
-      const capturedGeneration = successSpy.mock.calls.at(0)?.[0]
-
       const expectedImageRequest = {
         model: row.expectedModel,
         prompt: finalPrompt,
@@ -981,11 +921,8 @@ describe('BytePlus Seedream integration', () => {
       expect.soft(Object.keys(imageRequest.body).sort(), row.name).toEqual(expectedImageKeys)
       expect.soft(imageRequest.body, row.name).toEqual(expectedImageRequest)
       expect.soft(rowTimeouts, row.name).toContain(300000)
-      expect.soft(row.args.quality ?? 'fast', row.name).toBe(row.expectedQuality)
       expect.soft(parseCount, row.name).toBe(1)
       expect.soft(decodeCount, row.name).toBe(1)
-      expect.soft(saveSpy, row.name).toHaveBeenCalledTimes(1)
-      expect.soft(successSpy, row.name).toHaveBeenCalledTimes(1)
 
       if (row.skipPromptEnhancement) {
         expect.soft(textRequest, row.name).toEqual({})
@@ -1042,12 +979,6 @@ describe('BytePlus Seedream integration', () => {
         }
       }
 
-      expect.soft(capturedGeneration?.metadata.prompt, row.name).toBe(finalPrompt)
-      expect.soft(capturedGeneration?.metadata.mimeType, row.name).toBe('image/png')
-      expect.soft(capturedGeneration?.imageData, row.name).toEqual(expectedImageBytes)
-      expect
-        .soft(saveSpy, row.name)
-        .toHaveBeenCalledWith(expectedImageBytes, join(outputDirectory, fileName))
       await assertSavedPng(result, outputDirectory, fileName, expectedImageBytes, row.expectedModel)
 
       const publicAndLogs = `${JSON.stringify(parsePublicResponse(result))}\n${capturedLogs()}`
@@ -1144,8 +1075,6 @@ describe('BytePlus Seedream integration', () => {
       return handle
     })
     const exactServer = createMCPServer()
-    const exactInternals = readServerInternals(exactServer)
-    const exactSaveSpy = vi.spyOn(exactInternals.fileManager, 'saveImage')
     const beforeExactAllocCalls = bufferAllocSpy.mock.calls.length
 
     expect.soft(await readdir(exactOutputDirectory), 'exact-limit:before').toEqual([])
@@ -1173,7 +1102,6 @@ describe('BytePlus Seedream integration', () => {
       .toBe(true)
     expect.soft(transports.openAIResponsesCreate, 'exact-limit:text').not.toHaveBeenCalled()
     expect.soft(transports.googleGenerateContent, 'exact-limit:image').toHaveBeenCalledTimes(1)
-    expect.soft(exactSaveSpy, 'exact-limit:save').toHaveBeenCalledTimes(1)
     expect
       .soft(await readdir(exactOutputDirectory), 'exact-limit:after')
       .toEqual(['exact-limit-output.png'])
@@ -1197,8 +1125,6 @@ describe('BytePlus Seedream integration', () => {
       return handle
     })
     const oversizedServer = createMCPServer()
-    const oversizedInternals = readServerInternals(oversizedServer)
-    const oversizedSaveSpy = vi.spyOn(oversizedInternals.fileManager, 'saveImage')
     const beforeOversizedAllocCalls = bufferAllocSpy.mock.calls.length
     const beforeOversizedBase64Calls = bufferToStringSpy.mock.calls.length
 
@@ -1229,7 +1155,6 @@ describe('BytePlus Seedream integration', () => {
     expect.soft(oversizedBase64Calls, 'over-limit:base64').toEqual([])
     expect.soft(transports.openAIResponsesCreate, 'over-limit:text').not.toHaveBeenCalled()
     expect.soft(transports.googleGenerateContent, 'over-limit:image').not.toHaveBeenCalled()
-    expect.soft(oversizedSaveSpy, 'over-limit:save').not.toHaveBeenCalled()
     expect.soft(await readdir(oversizedOutputDirectory), 'over-limit:after').toEqual([])
 
     resetTransportDoubles()
@@ -1270,8 +1195,6 @@ describe('BytePlus Seedream integration', () => {
       return fileSystem.actualOpen(filePath, flags)
     })
     const growthServer = createMCPServer()
-    const growthInternals = readServerInternals(growthServer)
-    const growthSaveSpy = vi.spyOn(growthInternals.fileManager, 'saveImage')
     const beforeGrowthAllocCalls = bufferAllocSpy.mock.calls.length
     const beforeGrowthBase64Calls = bufferToStringSpy.mock.calls.length
 
@@ -1313,7 +1236,6 @@ describe('BytePlus Seedream integration', () => {
     expect.soft(growthBase64Calls, 'growth:base64').toEqual([])
     expect.soft(transports.openAIResponsesCreate, 'growth:text').not.toHaveBeenCalled()
     expect.soft(transports.googleGenerateContent, 'growth:image').not.toHaveBeenCalled()
-    expect.soft(growthSaveSpy, 'growth:save').not.toHaveBeenCalled()
     expect.soft(await readdir(growthOutputDirectory), 'growth:after').toEqual([])
 
     resetTransportDoubles()
@@ -1335,8 +1257,6 @@ describe('BytePlus Seedream integration', () => {
       return handle
     })
     const nonRegularServer = createMCPServer()
-    const nonRegularInternals = readServerInternals(nonRegularServer)
-    const nonRegularSaveSpy = vi.spyOn(nonRegularInternals.fileManager, 'saveImage')
     const beforeNonRegularAllocCalls = bufferAllocSpy.mock.calls.length
     const beforeNonRegularBase64Calls = bufferToStringSpy.mock.calls.length
 
@@ -1366,7 +1286,6 @@ describe('BytePlus Seedream integration', () => {
     expect.soft(nonRegularBase64Calls, 'non-regular:base64').toEqual([])
     expect.soft(transports.openAIResponsesCreate, 'non-regular:text').not.toHaveBeenCalled()
     expect.soft(transports.googleGenerateContent, 'non-regular:image').not.toHaveBeenCalled()
-    expect.soft(nonRegularSaveSpy, 'non-regular:save').not.toHaveBeenCalled()
     expect.soft(await readdir(nonRegularOutputDirectory), 'non-regular:after').toEqual([])
 
     // Windows does not provide POSIX named FIFOs; Unix-family CI exercises the real FIFO open.
@@ -1394,8 +1313,6 @@ describe('BytePlus Seedream integration', () => {
         return handle
       })
       const fifoServer = createMCPServer()
-      const fifoInternals = readServerInternals(fifoServer)
-      const fifoSaveSpy = vi.spyOn(fifoInternals.fileManager, 'saveImage')
       const beforeFifoAllocCalls = bufferAllocSpy.mock.calls.length
       const beforeFifoBase64Calls = bufferToStringSpy.mock.calls.length
 
@@ -1443,7 +1360,6 @@ describe('BytePlus Seedream integration', () => {
       expect.soft(fifoBase64Calls, 'fifo:base64').toEqual([])
       expect.soft(transports.openAIResponsesCreate, 'fifo:text').not.toHaveBeenCalled()
       expect.soft(transports.googleGenerateContent, 'fifo:image').not.toHaveBeenCalled()
-      expect.soft(fifoSaveSpy, 'fifo:save').not.toHaveBeenCalled()
       expect.soft(await readdir(fifoOutputDirectory), 'fifo:after').toEqual([])
       await rm(fifoInputPath, { force: true })
     }
@@ -1640,11 +1556,18 @@ describe('BytePlus Seedream integration', () => {
         expectedParseCalls: 1,
         expectedTextCalls: 0,
         skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
+        responseFactory: (responseSentinel, imageSentinel) => {
+          const validBase64 = createPngFixture(imageSentinel).toString('base64')
+          return createJsonResponse({
             response_sentinel: responseSentinel,
-            data: [{ b64_json: `***${imageSentinel}`, mime_type: 'image/png' }],
-          }),
+            data: [
+              {
+                b64_json: `${validBase64.slice(0, -1)}*`,
+                mime_type: 'image/png',
+              },
+            ],
+          })
+        },
       },
       {
         name: 'empty-base64',
@@ -1869,10 +1792,6 @@ describe('BytePlus Seedream integration', () => {
       const beforeFiles = await readdir(outputDirectory)
       const beforeTimeoutCalls = timeoutSpy.mock.calls.length
       const server = createMCPServer()
-      const internals = readServerInternals(server)
-      const saveSpy = vi.spyOn(internals.fileManager, 'saveImage')
-      const successSpy = vi.spyOn(internals.responseBuilder, 'buildSuccessResponse')
-      const errorSpy = vi.spyOn(internals.responseBuilder, 'buildErrorResponse')
       const beforeParseCalls = jsonParseSpy.mock.calls.length
       const beforeDecodeCalls = bufferFromSpy.mock.calls.length
       const result = await server.callTool('generate_image', args)
@@ -1881,6 +1800,7 @@ describe('BytePlus Seedream integration', () => {
         .slice(beforeParseCalls)
         .filter(([value]) => typeof value === 'string' && value.includes(responseSentinel)).length
       const pngBase64 = createPngFixture(imageSentinel).toString('base64')
+      const malformedBase64 = `${pngBase64.slice(0, -1)}*`
       const nonPngBase64 = Buffer.from(`not-a-png:${imageSentinel}`).toString('base64')
       const oversizedBase64Length = Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)
       const decodeCount = bufferFromSpy.mock.calls
@@ -1894,7 +1814,7 @@ describe('BytePlus Seedream integration', () => {
             return value === pngBase64
           }
           if (row.name === 'malformed-base64') {
-            return value === `***${imageSentinel}`
+            return value === malformedBase64
           }
           if (row.name === 'empty-base64') {
             return value === ''
@@ -1951,9 +1871,6 @@ describe('BytePlus Seedream integration', () => {
       expect.soft(transports.fetch, row.name).toHaveBeenCalledTimes(row.expectedImageCalls)
       expect.soft(parseCount, row.name).toBe(row.expectedParseCalls)
       expect.soft(decodeCount, row.name).toBe(row.expectedDecodeCalls)
-      expect.soft(saveSpy, row.name).not.toHaveBeenCalled()
-      expect.soft(successSpy, row.name).not.toHaveBeenCalled()
-      expect.soft(errorSpy, row.name).toHaveBeenCalledTimes(1)
       expect
         .soft(
           afterFiles.filter((file) => file !== 'unsupported.gif'),

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -31,19 +31,22 @@ vi.mock('../../api/openaiImageClient', () => {
   return {
     createOpenAIImageClient: vi.fn().mockImplementation(() => {
       const mockClient = {
-        generateImage: vi.fn().mockResolvedValue({
-          success: true,
-          data: {
-            imageData: Buffer.from('mock-openai-image-data', 'utf-8'),
-            metadata: {
-              model: 'gpt-image-2',
-              provider: 'openai',
-              prompt: 'test prompt',
-              mimeType: 'image/png',
-              timestamp: new Date(),
-              inputImageProvided: false,
+        generateImage: vi.fn().mockImplementation((params) => {
+          const mimeType = params.preferredOutputFormat === 'jpeg' ? 'image/jpeg' : 'image/png'
+          return Promise.resolve({
+            success: true,
+            data: {
+              imageData: Buffer.from('mock-openai-image-data', 'utf-8'),
+              metadata: {
+                model: 'gpt-image-2',
+                provider: 'openai',
+                prompt: 'test prompt',
+                mimeType,
+                timestamp: new Date(),
+                inputImageProvided: false,
+              },
             },
-          },
+          })
         }),
       }
       return { success: true, data: mockClient }
@@ -268,7 +271,8 @@ describe('MCP Server', () => {
     expect(schema.properties).toHaveProperty('fileName')
     expect(schema.properties?.fileName).toEqual({
       type: 'string',
-      description: 'Custom file name for the output image. Auto-generated if not specified.',
+      description:
+        'Custom .png, .jpg, or .jpeg output filename. OpenAI and Seedream use its extension as the output format; no extension defaults to PNG.',
     })
     expect(schema.required).toContain('prompt')
   })
@@ -474,6 +478,44 @@ describe('MCP Server', () => {
       })
     )
     expect(createOpenAITextClient).toHaveBeenCalled()
+  })
+
+  it('should pass JPEG preference from fileName to the selected provider', async () => {
+    process.env.IMAGE_PROVIDER = 'openai'
+    process.env.GEMINI_API_KEY = undefined
+    process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
+    const mcpServer = createMCPServer()
+
+    const result = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      fileName: 'requested.JPEG',
+    })
+
+    expect(result.isError).toBe(false)
+    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+    const imageClient = (createOpenAIImageClient as ReturnType<typeof vi.fn>).mock.results[0].value
+      .data
+    expect(imageClient.generateImage).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredOutputFormat: 'jpeg' })
+    )
+  })
+
+  it('should reject unsupported output extensions before provider initialization', async () => {
+    const mcpServer = createMCPServer()
+
+    const result = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      fileName: 'requested.webp',
+    })
+
+    expect(result.isError).toBe(true)
+    const responseData = JSON.parse(result.content[0].text)
+    expect(responseData.error).toMatchObject({
+      code: 'INPUT_VALIDATION_ERROR',
+      message: 'Unsupported output image format',
+    })
+    const { createGeminiClient } = await import('../../api/geminiClient')
+    expect(createGeminiClient).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -1,4 +1,7 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Logger } from '../../utils/logger.js'
 import { createMCPServer, MCPServerImpl } from '../mcpServer'
 
 // Mock the Gemini client for unit tests
@@ -207,18 +210,24 @@ vi.mock('../../business/inputValidator', async () => {
 // Basic tests for MCP server startup and tool registration
 describe('MCP Server', () => {
   let originalApiKey: string | undefined
+  let originalArkApiKey: string | undefined
   let originalImageProvider: string | undefined
   let originalOpenAIApiKey: string | undefined
+  let originalSkipPromptEnhancement: string | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
     // Set up environment for testing
     originalApiKey = process.env.GEMINI_API_KEY
+    originalArkApiKey = process.env.ARK_API_KEY
     originalImageProvider = process.env.IMAGE_PROVIDER
     originalOpenAIApiKey = process.env.OPENAI_API_KEY
-    process.env.IMAGE_PROVIDER = undefined
+    originalSkipPromptEnhancement = process.env.SKIP_PROMPT_ENHANCEMENT
+    delete process.env.IMAGE_PROVIDER
     process.env.GEMINI_API_KEY = 'test-api-key-unit-tests'
-    process.env.OPENAI_API_KEY = undefined
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ARK_API_KEY
+    delete process.env.SKIP_PROMPT_ENHANCEMENT
     process.env.IMAGE_OUTPUT_DIR = './test-output'
   })
 
@@ -227,10 +236,28 @@ describe('MCP Server', () => {
     if (originalApiKey !== undefined) {
       process.env.GEMINI_API_KEY = originalApiKey
     } else {
-      process.env.GEMINI_API_KEY = undefined
+      delete process.env.GEMINI_API_KEY
     }
-    process.env.IMAGE_PROVIDER = originalImageProvider
-    process.env.OPENAI_API_KEY = originalOpenAIApiKey
+    if (originalImageProvider !== undefined) {
+      process.env.IMAGE_PROVIDER = originalImageProvider
+    } else {
+      delete process.env.IMAGE_PROVIDER
+    }
+    if (originalOpenAIApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalOpenAIApiKey
+    } else {
+      delete process.env.OPENAI_API_KEY
+    }
+    if (originalArkApiKey !== undefined) {
+      process.env.ARK_API_KEY = originalArkApiKey
+    } else {
+      delete process.env.ARK_API_KEY
+    }
+    if (originalSkipPromptEnhancement !== undefined) {
+      process.env.SKIP_PROMPT_ENHANCEMENT = originalSkipPromptEnhancement
+    } else {
+      delete process.env.SKIP_PROMPT_ENHANCEMENT
+    }
   })
   it('should create MCP server instance', async () => {
     // Arrange & Act
@@ -256,24 +283,54 @@ describe('MCP Server', () => {
     // Assert: Verify that generate_image tool is registered
     expect(toolsList.tools).toHaveLength(1)
     expect(toolsList.tools[0].name).toBe('generate_image')
-    expect(toolsList.tools[0].description).toContain('Generate image with specified prompt')
+    expect(toolsList.tools[0].description).toMatch(/generate a new image/i)
+    expect(toolsList.tools[0].description).toMatch(/edit an existing image/i)
+    expect(toolsList.tools[0].description).toContain('inputImagePath')
+    expect(toolsList.tools[0].description).toMatch(/file resource/i)
     expect(toolsList.tools[0].inputSchema).toBeDefined()
 
     // Verify basic schema structure
     const schema = toolsList.tools[0].inputSchema
     expect(schema.type).toBe('object')
     expect(schema.properties).toHaveProperty('prompt')
-    expect(schema.properties?.prompt).toEqual({
-      type: 'string',
-      description:
-        'The prompt for image generation (English recommended for optimal structured prompt enhancement)',
-    })
+    expect(schema.properties?.prompt?.type).toBe('string')
+    expect(schema.properties?.prompt?.description).toMatch(/generate|edit/i)
+    expect(schema.properties?.prompt?.description).toMatch(/subject/i)
+    expect(schema.properties?.prompt?.description).toMatch(/context/i)
+    expect(schema.properties?.prompt?.description).toMatch(/visual style/i)
     expect(schema.properties).toHaveProperty('fileName')
-    expect(schema.properties?.fileName).toEqual({
-      type: 'string',
-      description:
-        'Custom .png, .jpg, or .jpeg output filename. OpenAI and Seedream use its extension as the output format; no extension defaults to PNG.',
-    })
+    const fileNameDescription = schema.properties?.fileName?.description
+    expect(fileNameDescription).toContain('.png')
+    expect(fileNameDescription).toContain('.jpg')
+    expect(fileNameDescription).toContain('.jpeg')
+    expect(fileNameDescription).toMatch(/OpenAI/)
+    expect(fileNameDescription).toMatch(/Seedream/)
+    expect(fileNameDescription).toMatch(/output format/i)
+    expect(fileNameDescription).toMatch(/omit|default/i)
+
+    const googleSearchDescription = schema.properties?.useGoogleSearch?.description
+    expect(googleSearchDescription).toMatch(/Gemini/)
+    expect(googleSearchDescription).toMatch(/OpenAI/)
+    expect(googleSearchDescription).toMatch(/Seedream/)
+    expect(googleSearchDescription).toMatch(/current|time-sensitive/i)
+    expect(googleSearchDescription).toMatch(/omit|false/i)
+
+    const imageSizeDescription = schema.properties?.imageSize?.description
+    expect(imageSizeDescription).toMatch(/1K/)
+    expect(imageSizeDescription).toMatch(/2K/)
+    expect(imageSizeDescription).toMatch(/4K/)
+    expect(imageSizeDescription).toMatch(/default/i)
+    expect(imageSizeDescription).toMatch(/Seedream/)
+
+    const qualityDescription = schema.properties?.quality?.description
+    expect(qualityDescription).toMatch(/user requests/i)
+    expect(qualityDescription).toMatch(/omit|default/i)
+    expect(qualityDescription).toMatch(/fast/)
+    expect(qualityDescription).toMatch(/balanced/)
+    expect(qualityDescription).toMatch(/quality/)
+    expect(qualityDescription).toMatch(/speed/)
+    expect(qualityDescription).toMatch(/detail/)
+    expect(qualityDescription).toMatch(/fidelity/)
     expect(schema.required).toContain('prompt')
   })
 
@@ -368,7 +425,7 @@ describe('MCP Server', () => {
     expect(fileManagerInstance.generateFileName).toHaveBeenCalledWith('image/png')
   })
 
-  it('should append extension to user-provided filename without extension via ensureExtension', async () => {
+  it('should append extension to user-provided filename without extension', async () => {
     // Arrange
     const mcpServer = createMCPServer()
 
@@ -378,7 +435,7 @@ describe('MCP Server', () => {
       fileName: 'my-photo',
     })
 
-    // Assert: saveImage should be called with a path ending in .png (ensureExtension adds it)
+    // Assert: saveImage should be called with a path ending in .png
     const { createFileManager } = await import('../../business/fileManager')
     const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
       .value
@@ -387,8 +444,11 @@ describe('MCP Server', () => {
     expect(savedPath).toMatch(/my-photo\.png$/)
   })
 
-  it('should preserve user-provided filename with existing extension', async () => {
+  it('should preserve a user-provided extension when it matches the actual MIME type', async () => {
     // Arrange
+    process.env.IMAGE_PROVIDER = 'openai'
+    delete process.env.GEMINI_API_KEY
+    process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
     const mcpServer = createMCPServer()
 
     // Act
@@ -406,7 +466,37 @@ describe('MCP Server', () => {
     expect(savedPath).toMatch(/my-photo\.jpg$/)
   })
 
-  it('should sanitize filename before applying ensureExtension', async () => {
+  it('should correct a recognized extension when it differs from the actual MIME type', async () => {
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn')
+
+    try {
+      const mcpServer = createMCPServer()
+
+      await mcpServer.callTool('generate_image', {
+        prompt: 'test prompt',
+        fileName: 'my-photo.jpg',
+      })
+
+      const { createFileManager } = await import('../../business/fileManager')
+      const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
+        .value
+      const savedPath = fileManagerInstance.saveImage.mock.calls[0][1] as string
+      expect(savedPath).toMatch(/my-photo\.png$/)
+      expect(warnSpy).toHaveBeenCalledWith(
+        'mcp-server',
+        'Output filename extension corrected to match generated MIME type',
+        {
+          requestedExtension: '.jpg',
+          savedExtension: '.png',
+          mimeType: 'image/png',
+        }
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('should sanitize filename before reconciling its extension', async () => {
     // Arrange
     const mcpServer = createMCPServer()
 
@@ -417,13 +507,13 @@ describe('MCP Server', () => {
     })
 
     // Assert: sanitizeFilename runs first (strips leading dots, null bytes),
-    // then ensureExtension adds .png
+    // then extension reconciliation adds .png
     const { createFileManager } = await import('../../business/fileManager')
     const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results[0]
       .value
     const saveImageCall = fileManagerInstance.saveImage.mock.calls[0]
     const savedPath = saveImageCall[1] as string
-    // After sanitize: 'my-photo', after ensureExtension: 'my-photo.png'
+    // After sanitize: 'my-photo', after reconciliation: 'my-photo.png'
     expect(savedPath).toMatch(/my-photo\.png$/)
   })
 
@@ -453,7 +543,7 @@ describe('MCP Server', () => {
   it('should route image generation through OpenAI provider when configured', async () => {
     // Arrange
     process.env.IMAGE_PROVIDER = 'openai'
-    process.env.GEMINI_API_KEY = undefined
+    delete process.env.GEMINI_API_KEY
     process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
     const mcpServer = createMCPServer()
 
@@ -482,7 +572,7 @@ describe('MCP Server', () => {
 
   it('should pass JPEG preference from fileName to the selected provider', async () => {
     process.env.IMAGE_PROVIDER = 'openai'
-    process.env.GEMINI_API_KEY = undefined
+    delete process.env.GEMINI_API_KEY
     process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
     const mcpServer = createMCPServer()
 
@@ -500,22 +590,77 @@ describe('MCP Server', () => {
     )
   })
 
-  it('should reject unsupported output extensions before provider initialization', async () => {
+  it.each([
+    ['banner.v2', 'banner.v2.png'],
+    ['my.photo', 'my.photo.png'],
+    ['2026.07.29-banner', '2026.07.29-banner.png'],
+    ['requested.webp', 'requested.png'],
+  ])(
+    'should use the provider default for a suffix that cannot select an output format: %s',
+    async (fileName, expectedSavedName) => {
+      const mcpServer = createMCPServer()
+
+      const result = await mcpServer.callTool('generate_image', {
+        prompt: 'test prompt',
+        fileName,
+      })
+
+      expect(result.isError).toBe(false)
+      const { createGeminiClient } = await import('../../api/geminiClient')
+      const imageClient = (createGeminiClient as ReturnType<typeof vi.fn>).mock.results.at(-1)
+        ?.value.data
+      const imageParams = imageClient.generateImage.mock.calls[0][0]
+      expect(imageParams).not.toHaveProperty('preferredOutputFormat')
+
+      const { createFileManager } = await import('../../business/fileManager')
+      const fileManagerInstance = (createFileManager as ReturnType<typeof vi.fn>).mock.results.at(
+        -1
+      )?.value
+      const savedPath = fileManagerInstance.saveImage.mock.calls[0][1] as string
+      expect(savedPath.endsWith(expectedSavedName)).toBe(true)
+    }
+  )
+
+  it('should omit the format hint when fileName has no extension', async () => {
     const mcpServer = createMCPServer()
 
     const result = await mcpServer.callTool('generate_image', {
       prompt: 'test prompt',
-      fileName: 'requested.webp',
+      fileName: 'requested',
     })
 
-    expect(result.isError).toBe(true)
-    const responseData = JSON.parse(result.content[0].text)
-    expect(responseData.error).toMatchObject({
-      code: 'INPUT_VALIDATION_ERROR',
-      message: 'Unsupported output image format',
-    })
     const { createGeminiClient } = await import('../../api/geminiClient')
-    expect(createGeminiClient).not.toHaveBeenCalled()
+    const imageClient = (createGeminiClient as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
+      .data
+    expect(result.isError).toBe(false)
+    expect(imageClient.generateImage.mock.calls[0][0]).not.toHaveProperty('preferredOutputFormat')
+  })
+
+  it('should preserve tool execution errors across the MCP transport boundary', async () => {
+    process.env.IMAGE_PROVIDER = 'seedream'
+    process.env.ARK_API_KEY = 'test-seedream-api-key'
+    process.env.SKIP_PROMPT_ENHANCEMENT = 'true'
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    const server = createMCPServer().initialize()
+    const client = new Client({ name: 'mcp-image-test-client', version: '1.0.0' })
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+    try {
+      const result = await client.callTool({
+        name: 'generate_image',
+        arguments: {
+          prompt: 'test prompt',
+          fileName: 'seedream-error.png',
+          useGoogleSearch: true,
+        },
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content).toHaveLength(1)
+    } finally {
+      await client.close()
+      await server.close()
+    }
   })
 })
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -31,7 +31,11 @@ import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
 import { type Config, getConfig } from '../utils/config.js'
 import { InputValidationError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
-import { ensureExtension, getMimeTypeFromExtension } from '../utils/mimeUtils.js'
+import {
+  ensureExtension,
+  getMimeTypeFromExtension,
+  resolvePreferredOutputFormat,
+} from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
 import { ErrorHandler } from './errorHandler.js'
 import {
@@ -151,7 +155,7 @@ export class MCPServerImpl {
               fileName: {
                 type: 'string' as const,
                 description:
-                  'Custom file name for the output image. Auto-generated if not specified.',
+                  'Custom .png, .jpg, or .jpeg output filename. OpenAI and Seedream use its extension as the output format; no extension defaults to PNG.',
               },
               inputImagePath: {
                 type: 'string' as const,
@@ -284,6 +288,17 @@ export class MCPServerImpl {
         throw validationResult.error
       }
 
+      const sanitizedFileName = params.fileName
+        ? this.securityManager.sanitizeFilename(params.fileName)
+        : undefined
+      const preferredOutputFormat = resolvePreferredOutputFormat(sanitizedFileName)
+      if (!preferredOutputFormat) {
+        throw new InputValidationError(
+          'Unsupported output image format',
+          'Use a .png, .jpg, or .jpeg file name, or omit the extension for PNG output'
+        )
+      }
+
       // Get configuration
       const configResult = getConfig()
       if (!configResult.success) {
@@ -320,6 +335,7 @@ export class MCPServerImpl {
         ...(params.useGoogleSearch !== undefined && {
           useGoogleSearch: params.useGoogleSearch,
         }),
+        preferredOutputFormat,
         ...(params.quality !== undefined && { quality: params.quality }),
       } satisfies Omit<ImageApiParams, 'prompt'>
 
@@ -383,9 +399,7 @@ export class MCPServerImpl {
 
       // Save image file
       const mimeType = generationResult.data.metadata.mimeType
-      const rawFileName = params.fileName
-        ? this.securityManager.sanitizeFilename(params.fileName)
-        : this.fileManager.generateFileName(mimeType)
+      const rawFileName = sanitizedFileName ?? this.fileManager.generateFileName(mimeType)
       const fileName = params.fileName ? ensureExtension(rawFileName, mimeType) : rawFileName
       const outputPath = path.join(config.imageOutputDir, fileName)
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -32,9 +32,10 @@ import { type Config, getConfig } from '../utils/config.js'
 import { InputValidationError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
 import {
-  ensureExtension,
   getMimeTypeFromExtension,
+  reconcileFileNameExtension,
   resolvePreferredOutputFormat,
+  SUPPORTED_EXTENSIONS,
 } from '../utils/mimeUtils.js'
 import { SecurityManager } from '../utils/security.js'
 import { ErrorHandler } from './errorHandler.js'
@@ -143,48 +144,50 @@ export class MCPServerImpl {
       tools: [
         {
           name: 'generate_image',
-          description: 'Generate image with specified prompt and optional parameters',
+          description:
+            'Generate a new image from a text prompt or edit an existing image using inputImagePath. Saves the result and returns a file resource.',
           inputSchema: {
             type: 'object' as const,
             properties: {
               prompt: {
                 type: 'string' as const,
                 description:
-                  'The prompt for image generation (English recommended for optimal structured prompt enhancement)',
+                  'Describe the image to generate or the edit to apply. Include the subject, context, and visual style; English is recommended for prompt enhancement.',
               },
               fileName: {
                 type: 'string' as const,
                 description:
-                  'Custom .png, .jpg, or .jpeg output filename. OpenAI and Seedream use its extension as the output format; no extension defaults to PNG.',
+                  'Use .png, .jpg, or .jpeg to request that output format from OpenAI or Seedream. Other or absent suffixes use the provider default; the saved filename is corrected to the actual image extension.',
               },
               inputImagePath: {
                 type: 'string' as const,
                 description:
-                  'Optional absolute path to source image for image-to-image generation. Use when generating variations, style transfers, or similar images based on an existing image (must be an absolute path)',
+                  'Provide an absolute path to a source image when editing, creating a variation, or transferring style.',
               },
               blendImages: {
                 type: 'boolean' as const,
                 description:
-                  'Enable multi-image blending for combining multiple visual elements naturally. Use when prompt mentions multiple subjects or composite scenes',
+                  'Enable when the prompt combines multiple visual elements that need coherent spatial relationships, lighting, or composition.',
               },
               maintainCharacterConsistency: {
                 type: 'boolean' as const,
                 description:
-                  'Maintain character appearance consistency. Enable when generating same character in different poses/scenes',
+                  'Enable when the same character must retain a recognizable appearance across poses or scenes.',
               },
               useWorldKnowledge: {
                 type: 'boolean' as const,
                 description:
-                  'Use real-world knowledge for accurate context. Enable for historical figures, landmarks, or factual scenarios',
+                  'Enable when accurate real-world details matter, such as historical figures, landmarks, cultures, or factual settings.',
               },
               useGoogleSearch: {
                 type: 'boolean' as const,
                 description:
-                  "Enable Google Search grounding to access real-time web information for factually accurate image generation. Use when prompt requires current or time-sensitive data that may have changed since the model's knowledge cutoff. Leave disabled for creative, fictional, historical, or timeless content.",
+                  'Enable when using Gemini and the image requires current or time-sensitive web information. With OpenAI or Seedream, omit this option or set it to false.',
               },
               aspectRatio: {
                 type: 'string' as const,
-                description: 'Aspect ratio for the generated image',
+                description:
+                  'Set the requested output aspect ratio. Omit to use the provider default.',
                 enum: [
                   '1:1',
                   '1:4',
@@ -205,18 +208,18 @@ export class MCPServerImpl {
               imageSize: {
                 type: 'string' as const,
                 description:
-                  'Image resolution for high-quality output. Specify "1K", "2K", or "4K" when you need specific resolution. Leave unspecified for standard quality.',
+                  "Set the requested output size to 1K, 2K, or 4K. Omit to use the selected provider and quality preset's default. With Seedream, use 1K or 2K.",
                 enum: ['1K', '2K', '4K'],
               },
               purpose: {
                 type: 'string' as const,
                 description:
-                  'Intended use for the image (e.g., cookbook cover, social media post, presentation slide). Influences lighting, composition, and detail level to match the context.',
+                  "Describe the image's intended use, such as a cookbook cover, social media post, or presentation slide, so prompt enhancement can adapt composition and detail.",
               },
               quality: {
                 type: 'string' as const,
                 description:
-                  'Quality preset controlling speed/fidelity tradeoff. Only specify when the user explicitly requests a specific quality level; omit to use the server\'s configured default. "fast": best for drafts and rapid iteration. "balanced": better detail and coherence, moderate latency. "quality": highest fidelity, use for final deliverables where quality matters most.',
+                  'Set only when the user requests a quality level; otherwise omit to use the server default. fast prioritizes speed, balanced trades speed for detail, and quality prioritizes fidelity.',
                 enum: ['fast', 'balanced', 'quality'],
               },
             },
@@ -292,12 +295,6 @@ export class MCPServerImpl {
         ? this.securityManager.sanitizeFilename(params.fileName)
         : undefined
       const preferredOutputFormat = resolvePreferredOutputFormat(sanitizedFileName)
-      if (!preferredOutputFormat) {
-        throw new InputValidationError(
-          'Unsupported output image format',
-          'Use a .png, .jpg, or .jpeg file name, or omit the extension for PNG output'
-        )
-      }
 
       // Get configuration
       const configResult = getConfig()
@@ -335,7 +332,7 @@ export class MCPServerImpl {
         ...(params.useGoogleSearch !== undefined && {
           useGoogleSearch: params.useGoogleSearch,
         }),
-        preferredOutputFormat,
+        ...(preferredOutputFormat && { preferredOutputFormat }),
         ...(params.quality !== undefined && { quality: params.quality }),
       } satisfies Omit<ImageApiParams, 'prompt'>
 
@@ -400,7 +397,25 @@ export class MCPServerImpl {
       // Save image file
       const mimeType = generationResult.data.metadata.mimeType
       const rawFileName = sanitizedFileName ?? this.fileManager.generateFileName(mimeType)
-      const fileName = params.fileName ? ensureExtension(rawFileName, mimeType) : rawFileName
+      const fileName = params.fileName
+        ? reconcileFileNameExtension(rawFileName, mimeType)
+        : rawFileName
+      const requestedExtension = path.extname(rawFileName)
+      if (
+        sanitizedFileName &&
+        fileName !== rawFileName &&
+        SUPPORTED_EXTENSIONS.includes(requestedExtension.toLowerCase())
+      ) {
+        this.logger.warn(
+          'mcp-server',
+          'Output filename extension corrected to match generated MIME type',
+          {
+            requestedExtension,
+            savedExtension: path.extname(fileName),
+            mimeType,
+          }
+        )
+      }
       const outputPath = path.join(config.imageOutputDir, fileName)
 
       const sanitizedPath = this.securityManager.sanitizeFilePath(outputPath)
@@ -470,6 +485,7 @@ export class MCPServerImpl {
         const result = await this.callTool(name, args)
         const response: CallToolResult = {
           content: result.content,
+          isError: result.isError,
         }
         if (result.structuredContent) {
           response.structuredContent = result.structuredContent as { [x: string]: unknown }

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -32,6 +32,11 @@ export type AspectRatio =
 export type ImageSize = '1K' | '2K' | '4K'
 
 /**
+ * Provider-neutral output formats supported by OpenAI and Seedream.
+ */
+export type ImageOutputFormat = 'png' | 'jpeg'
+
+/**
  * Quality presets for image generation
  * - 'fast': Nano Banana 2, fastest generation (default)
  * - 'balanced': Nano Banana 2 with enhanced thinking, better quality

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -8,12 +8,12 @@ describe('config', () => {
   beforeEach(() => {
     // Mock process.env for each test
     process.env = { ...originalEnv }
-    process.env.IMAGE_PROVIDER = undefined
-    process.env.GEMINI_API_KEY = undefined
-    process.env.OPENAI_API_KEY = undefined
-    process.env.ARK_API_KEY = undefined
-    process.env.IMAGE_OUTPUT_DIR = undefined
-    process.env.IMAGE_QUALITY = undefined
+    delete process.env.IMAGE_PROVIDER
+    delete process.env.GEMINI_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.ARK_API_KEY
+    delete process.env.IMAGE_OUTPUT_DIR
+    delete process.env.IMAGE_QUALITY
   })
 
   afterEach(() => {
@@ -327,6 +327,18 @@ describe('config', () => {
         expect(result.data.imageProvider).toBe('seedream')
         expect(result.data.arkApiKey).toBe('test-ark-api-key')
         expect(result.data.apiTimeout).toBe(30000)
+      }
+    })
+
+    it('should trim ARK_API_KEY while loading Seedream environment config', () => {
+      process.env.IMAGE_PROVIDER = 'seedream'
+      process.env.ARK_API_KEY = ' \ttest-ark-api-key\n '
+
+      const result = getConfig()
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.arkApiKey).toBe('test-ark-api-key')
       }
     })
 

--- a/src/utils/__tests__/mimeUtils.test.ts
+++ b/src/utils/__tests__/mimeUtils.test.ts
@@ -8,8 +8,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ensureExtension,
   getExtensionFromMimeType,
+  getMimeTypeForOutputFormat,
   getMimeTypeFromExtension,
+  matchesImageDataMimeType,
   normalizeMimeType,
+  resolvePreferredOutputFormat,
   SUPPORTED_EXTENSIONS,
   SUPPORTED_MIME_TYPES,
 } from '../mimeUtils'
@@ -209,6 +212,36 @@ describe('mimeUtils', () => {
 
       // Assert
       expect(result).toBe('artwork.webp')
+    })
+  })
+
+  describe('output format preference', () => {
+    it.each([
+      [undefined, 'png'],
+      ['', 'png'],
+      ['photo', 'png'],
+      ['photo.png', 'png'],
+      ['photo.PNG', 'png'],
+      ['photo.jpg', 'jpeg'],
+      ['photo.JPEG', 'jpeg'],
+      ['photo.webp', undefined],
+    ] as const)('resolves %s to %s', (fileName, expected) => {
+      expect(resolvePreferredOutputFormat(fileName)).toBe(expected)
+    })
+
+    it('maps output formats to their exact MIME types', () => {
+      expect(getMimeTypeForOutputFormat('png')).toBe('image/png')
+      expect(getMimeTypeForOutputFormat('jpeg')).toBe('image/jpeg')
+    })
+
+    it('matches PNG and JPEG signatures', () => {
+      const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0])
+
+      expect(matchesImageDataMimeType(png, 'image/png')).toBe(true)
+      expect(matchesImageDataMimeType(jpeg, 'image/jpeg')).toBe(true)
+      expect(matchesImageDataMimeType(png, 'image/jpeg')).toBe(false)
+      expect(matchesImageDataMimeType(Buffer.from('not-an-image'), 'image/png')).toBe(false)
     })
   })
 

--- a/src/utils/__tests__/mimeUtils.test.ts
+++ b/src/utils/__tests__/mimeUtils.test.ts
@@ -6,12 +6,12 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  ensureExtension,
   getExtensionFromMimeType,
   getMimeTypeForOutputFormat,
   getMimeTypeFromExtension,
   matchesImageDataMimeType,
   normalizeMimeType,
+  reconcileFileNameExtension,
   resolvePreferredOutputFormat,
   SUPPORTED_EXTENSIONS,
   SUPPORTED_MIME_TYPES,
@@ -173,10 +173,10 @@ describe('mimeUtils', () => {
     })
   })
 
-  describe('ensureExtension', () => {
+  describe('reconcileFileNameExtension', () => {
     it('should add extension when filename has none', () => {
       // Act
-      const result = ensureExtension('photo', 'image/jpeg')
+      const result = reconcileFileNameExtension('photo', 'image/jpeg')
 
       // Assert
       expect(result).toBe('photo.jpg')
@@ -184,23 +184,32 @@ describe('mimeUtils', () => {
 
     it('should preserve existing correct extension', () => {
       // Act
-      const result = ensureExtension('photo.jpg', 'image/jpeg')
+      const result = reconcileFileNameExtension('photo.jpg', 'image/jpeg')
 
       // Assert
       expect(result).toBe('photo.jpg')
     })
 
-    it('should preserve existing extension even if different from MIME type', () => {
+    it('should replace a recognized extension when it does not match the actual MIME type', () => {
       // Act
-      const result = ensureExtension('photo.png', 'image/jpeg')
+      const result = reconcileFileNameExtension('photo.png', 'image/jpeg')
 
       // Assert
-      expect(result).toBe('photo.png')
+      expect(result).toBe('photo.jpg')
+    })
+
+    it('should treat an unrecognized dotted suffix as part of the basename', () => {
+      expect(reconcileFileNameExtension('banner.v2', 'image/png')).toBe('banner.v2.png')
+    })
+
+    it('should preserve or replace uppercase extensions based on the actual MIME type', () => {
+      expect(reconcileFileNameExtension('photo.JPG', 'image/jpeg')).toBe('photo.JPG')
+      expect(reconcileFileNameExtension('photo.PNG', 'image/jpeg')).toBe('photo.jpg')
     })
 
     it('should add extension for image/png when filename has no extension', () => {
       // Act
-      const result = ensureExtension('screenshot', 'image/png')
+      const result = reconcileFileNameExtension('screenshot', 'image/png')
 
       // Assert
       expect(result).toBe('screenshot.png')
@@ -208,7 +217,7 @@ describe('mimeUtils', () => {
 
     it('should add extension for image/webp when filename has no extension', () => {
       // Act
-      const result = ensureExtension('artwork', 'image/webp')
+      const result = reconcileFileNameExtension('artwork', 'image/webp')
 
       // Assert
       expect(result).toBe('artwork.webp')
@@ -217,9 +226,12 @@ describe('mimeUtils', () => {
 
   describe('output format preference', () => {
     it.each([
-      [undefined, 'png'],
-      ['', 'png'],
-      ['photo', 'png'],
+      [undefined, undefined],
+      ['', undefined],
+      ['photo', undefined],
+      ['banner.v2', undefined],
+      ['my.photo', undefined],
+      ['2026.07.29-banner', undefined],
       ['photo.png', 'png'],
       ['photo.PNG', 'png'],
       ['photo.jpg', 'jpeg'],

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,7 +21,6 @@ interface StructuredLogEntry {
 const SENSITIVE_PATTERNS = [
   /GEMINI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /OPENAI_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
-  /ARK_API_KEY['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /api[_-]?key[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /password[^\s]*['"]?\s*[:=]\s*['"]?([^\s'"]+)/gi,
   /bearer\s+([a-zA-Z0-9\-._~+/]+=*)/gi,

--- a/src/utils/mimeUtils.ts
+++ b/src/utils/mimeUtils.ts
@@ -98,11 +98,11 @@ export function normalizeMimeType(mimeType: string): string {
 
 export function resolvePreferredOutputFormat(fileName?: string): ImageOutputFormat | undefined {
   if (!fileName) {
-    return 'png'
+    return undefined
   }
 
   const extension = path.extname(fileName).toLowerCase()
-  if (!extension || extension === '.png') {
+  if (extension === '.png') {
     return 'png'
   }
   if (extension === '.jpg' || extension === '.jpeg') {
@@ -128,19 +128,25 @@ export function matchesImageDataMimeType(
 
 /**
  * Ensure a filename has an appropriate file extension based on MIME type.
- * - If the filename already has an extension (any extension), it is preserved as-is.
- * - If the filename has no extension, one is appended based on the MIME type.
+ * - A recognized extension is preserved only when it matches the actual MIME type.
+ * - A recognized mismatched extension is replaced with the actual canonical extension.
+ * - Missing or unrecognized extensions are completed without discarding the caller's basename.
  *
  * @param fileName - The filename, with or without extension
- * @param mimeType - The MIME type to derive the extension from
+ * @param mimeType - The actual MIME type to derive the extension from
  * @returns The filename with an appropriate extension
  */
-export function ensureExtension(fileName: string, mimeType: string): string {
-  const ext = path.extname(fileName)
-  if (ext) {
+export function reconcileFileNameExtension(fileName: string, mimeType: string): string {
+  const originalExtension = path.extname(fileName)
+  const normalizedExtension = originalExtension.toLowerCase()
+  const extensionMimeType = EXTENSION_TO_MIME.get(normalizedExtension)
+  if (extensionMimeType === mimeType) {
     return fileName
   }
 
   const newExt = getExtensionFromMimeType(mimeType)
+  if (extensionMimeType) {
+    return `${fileName.slice(0, -originalExtension.length)}${newExt}`
+  }
   return `${fileName}${newExt}`
 }

--- a/src/utils/mimeUtils.ts
+++ b/src/utils/mimeUtils.ts
@@ -4,6 +4,7 @@
  */
 
 import * as path from 'node:path'
+import type { ImageOutputFormat } from '../types/mcp.js'
 import { Logger } from './logger.js'
 
 const logger = new Logger()
@@ -35,6 +36,8 @@ const EXTENSION_TO_MIME: ReadonlyMap<string, string> = new Map([
 
 export const DEFAULT_MIME_TYPE = 'image/png'
 const DEFAULT_EXTENSION = '.png'
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+const JPEG_SIGNATURE = Buffer.from([0xff, 0xd8, 0xff])
 
 /**
  * All supported MIME types for image processing.
@@ -91,6 +94,36 @@ export function normalizeMimeType(mimeType: string): string {
   }
   logger.warn('mimeUtils', `Unknown MIME type, normalizing to ${DEFAULT_MIME_TYPE}`, { mimeType })
   return DEFAULT_MIME_TYPE
+}
+
+export function resolvePreferredOutputFormat(fileName?: string): ImageOutputFormat | undefined {
+  if (!fileName) {
+    return 'png'
+  }
+
+  const extension = path.extname(fileName).toLowerCase()
+  if (!extension || extension === '.png') {
+    return 'png'
+  }
+  if (extension === '.jpg' || extension === '.jpeg') {
+    return 'jpeg'
+  }
+  return undefined
+}
+
+export function getMimeTypeForOutputFormat(format: ImageOutputFormat): 'image/png' | 'image/jpeg' {
+  return format === 'jpeg' ? 'image/jpeg' : 'image/png'
+}
+
+export function matchesImageDataMimeType(
+  imageData: Buffer,
+  mimeType: 'image/png' | 'image/jpeg'
+): boolean {
+  const signature = mimeType === 'image/png' ? PNG_SIGNATURE : JPEG_SIGNATURE
+  return (
+    imageData.length >= signature.length &&
+    imageData.subarray(0, signature.length).equals(signature)
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

- add filename-based PNG/JPEG output selection for OpenAI and BytePlus Seedream
- validate returned image bytes and reconcile saved filenames with the actual MIME type
- harden Seedream response parsing, MCP error propagation, and prompt-enhancement truncation handling
- improve provider integration tests, tool descriptions, and Seedream input-format documentation

## Verification

- `npm run check:all`
- 19 test suites passed
- 337 tests passed
