### PR TITLE
chore: prepare release 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.11.4",
+  "version": "0.12.0",
   "description": "MCP server for AI image generation",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.11.4",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- bump the npm package version to `0.12.0`
- update the package lockfile to `0.12.0`
- update the MCP Registry server and package metadata to `0.12.0`

## Verification

- `npm run check:all`
- 19 test suites passed
- 337 tests passed
