### PR TITLE
chore: normalize npm publish metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "mcp-image": "./dist/index.js"
+    "mcp-image": "dist/index.js"
   },
   "keywords": [
     "mcp",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/shinpr/mcp-image.git"
+    "url": "git+https://github.com/shinpr/mcp-image.git"
   },
   "files": [
     "dist/**/*",


### PR DESCRIPTION
## Summary

- Normalize the `bin.mcp-image` path to `dist/index.js`.
- Use the canonical `git+https` repository URL in `package.json`.
- Prevent npm from auto-correcting package metadata when publishing `0.12.2`.

## Verification

- `npm run check:all`
- `npm audit --omit=dev --json` — 0 vulnerabilities
- `npm publish --dry-run --json` — passed without package metadata correction warnings
- 337 tests passed

This PR should be merged before publishing `0.12.2`; move the `v0.12.2` tag to the merge commit afterward.
