### PR TITLE
Refactor shared maintenance logic

### DIFF
--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -33,7 +33,6 @@ describe('geminiClient', () => {
     geminiApiKey: 'test-api-key-12345',
     openaiApiKey: '',
     imageOutputDir: './output',
-    apiTimeout: 30000,
     skipPromptEnhancement: false,
     imageQuality: 'fast',
   }

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -60,7 +60,6 @@ describe('GeminiTextClient', () => {
       geminiApiKey: 'test-api-key',
       openaiApiKey: '',
       imageOutputDir: './test-output',
-      apiTimeout: 30000,
       skipPromptEnhancement: false,
       imageQuality: 'fast',
     }

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -30,7 +30,6 @@ describe('openaiImageClient', () => {
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
     imageOutputDir: './output',
-    apiTimeout: 30000,
     skipPromptEnhancement: false,
     imageQuality: 'fast',
   }

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -24,7 +24,6 @@ describe('openaiTextClient', () => {
     geminiApiKey: '',
     openaiApiKey: 'test-openai-api-key-12345',
     imageOutputDir: './output',
-    apiTimeout: 30000,
     skipPromptEnhancement: false,
     imageQuality: 'fast',
   }

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -40,7 +40,6 @@ const testConfig: Config = {
   openaiApiKey: '',
   arkApiKey: DUMMY_API_KEY,
   imageOutputDir: './output',
-  apiTimeout: 30000,
   skipPromptEnhancement: false,
   imageQuality: 'fast',
 }
@@ -675,10 +674,7 @@ describe('seedreamImageClient', () => {
   it('constructs the image AbortSignal from the fixed 300000 ms timeout only', async () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
 
-    const result = await createClient({
-      ...testConfig,
-      apiTimeout: 1,
-    }).generateImage({ prompt: PRIVATE_PROMPT })
+    const result = await createClient(testConfig).generateImage({ prompt: PRIVATE_PROMPT })
 
     expect(result.success).toBe(true)
     expect(timeoutSpy).toHaveBeenCalledTimes(1)

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -14,7 +14,6 @@ const testConfig: Config = {
   openaiApiKey: '',
   arkApiKey: DUMMY_API_KEY,
   imageOutputDir: './output',
-  apiTimeout: 30000,
   skipPromptEnhancement: false,
   imageQuality: 'fast',
 }

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -11,7 +11,7 @@ import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
 import { DEFAULT_MIME_TYPE } from '../utils/mimeUtils.js'
 import { isNetworkError } from './errorClassification.js'
-import type { GenerationConfig, TextClient } from './textClient.js'
+import { type GenerationConfig, MAX_TEXT_PROMPT_LENGTH, type TextClient } from './textClient.js'
 
 /**
  * Options for text generation
@@ -279,11 +279,11 @@ class GeminiTextClientImpl implements GeminiTextClient {
       )
     }
 
-    if (prompt.length > 100000) {
+    if (prompt.length > MAX_TEXT_PROMPT_LENGTH) {
       return Err(
         new GeminiAPIError(
           'Prompt too long',
-          'Please provide a shorter prompt (under 100,000 characters)'
+          `Please provide a shorter prompt (under ${MAX_TEXT_PROMPT_LENGTH.toLocaleString('en-US')} characters)`
         )
       )
     }

--- a/src/api/openaiCompatibleText.ts
+++ b/src/api/openaiCompatibleText.ts
@@ -1,0 +1,48 @@
+import type { ResponseCreateParamsNonStreaming } from 'openai/resources/responses/responses'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import { ImageAPIError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { type GenerationConfig, MAX_TEXT_PROMPT_LENGTH } from './textClient.js'
+
+type OpenAICompatibleInput = NonNullable<ResponseCreateParamsNonStreaming['input']>
+
+export function buildOpenAICompatibleInput(
+  prompt: string,
+  config: GenerationConfig
+): OpenAICompatibleInput {
+  if (!config.inputImage) {
+    return prompt
+  }
+
+  const mimeType = normalizeMimeType(config.inputImageMimeType ?? DEFAULT_MIME_TYPE)
+
+  return [
+    {
+      role: 'user' as const,
+      content: [
+        {
+          type: 'input_text' as const,
+          text: prompt,
+        },
+        {
+          type: 'input_image' as const,
+          image_url: `data:${mimeType};base64,${config.inputImage}`,
+          detail: 'auto' as const,
+        },
+      ],
+    },
+  ]
+}
+
+export function validateOpenAICompatiblePrompt(prompt: string): Result<true, ImageAPIError> {
+  if (!prompt || prompt.trim().length === 0) {
+    return Err(new ImageAPIError('Empty prompt provided', 'Please provide a non-empty prompt'))
+  }
+
+  if (prompt.length > MAX_TEXT_PROMPT_LENGTH) {
+    return Err(new ImageAPIError('Prompt too long', 'Please provide a shorter prompt'))
+  }
+
+  return Ok(true)
+}

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -7,8 +7,11 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
-import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
+import {
+  buildOpenAICompatibleInput,
+  validateOpenAICompatiblePrompt,
+} from './openaiCompatibleText.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
 
 interface OpenAITextResponse {
@@ -41,7 +44,7 @@ class OpenAITextClientImpl implements TextClient {
     prompt: string,
     config: GenerationConfig = {}
   ): Promise<Result<string, ImageAPIError | NetworkError>> {
-    const validationResult = this.validatePromptInput(prompt)
+    const validationResult = validateOpenAICompatiblePrompt(prompt)
     if (!validationResult.success) {
       return validationResult
     }
@@ -52,7 +55,7 @@ class OpenAITextClientImpl implements TextClient {
       const response = (await this.client.responses.create(
         {
           model: this.modelName,
-          input: this.buildInput(prompt, config),
+          input: buildOpenAICompatibleInput(prompt, config),
           ...(config.systemInstruction && { instructions: config.systemInstruction }),
           max_output_tokens: config.maxTokens ?? 8192,
           temperature: config.temperature ?? 0.7,
@@ -97,31 +100,6 @@ class OpenAITextClientImpl implements TextClient {
     } catch (error) {
       return this.handleError(error, 'connection validation')
     }
-  }
-
-  private buildInput(prompt: string, config: GenerationConfig) {
-    if (!config.inputImage) {
-      return prompt
-    }
-
-    const mimeType = normalizeMimeType(config.inputImageMimeType ?? DEFAULT_MIME_TYPE)
-
-    return [
-      {
-        role: 'user' as const,
-        content: [
-          {
-            type: 'input_text' as const,
-            text: prompt,
-          },
-          {
-            type: 'input_image' as const,
-            image_url: `data:${mimeType};base64,${config.inputImage}`,
-            detail: 'auto' as const,
-          },
-        ],
-      },
-    ]
   }
 
   private extractResponseText(response: OpenAITextResponse): string {
@@ -184,18 +162,6 @@ class OpenAITextClientImpl implements TextClient {
     }
 
     return 'Check OpenAI API configuration and try again'
-  }
-
-  private validatePromptInput(prompt: string): Result<true, ImageAPIError> {
-    if (!prompt || prompt.trim().length === 0) {
-      return Err(new ImageAPIError('Empty prompt provided', 'Please provide a non-empty prompt'))
-    }
-
-    if (prompt.length > 100000) {
-      return Err(new ImageAPIError('Prompt too long', 'Please provide a shorter prompt'))
-    }
-
-    return Ok(true)
   }
 }
 

--- a/src/api/seedreamTextClient.ts
+++ b/src/api/seedreamTextClient.ts
@@ -5,8 +5,11 @@ import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { ImageAPIError, NetworkError } from '../utils/errors.js'
 import { sanitizeText } from '../utils/logger.js'
-import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
+import {
+  buildOpenAICompatibleInput,
+  validateOpenAICompatiblePrompt,
+} from './openaiCompatibleText.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
 
 const MODELARK_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3'
@@ -35,14 +38,14 @@ class SeedreamTextClientImpl implements TextClient {
     prompt: string,
     config: GenerationConfig = {}
   ): Promise<Result<string, ImageAPIError | NetworkError>> {
-    const validationResult = this.validatePromptInput(prompt)
+    const validationResult = validateOpenAICompatiblePrompt(prompt)
     if (!validationResult.success) {
       return validationResult
     }
 
     const request: SeedreamTextRequest = {
       model: SEEDREAM_TEXT_MODEL,
-      input: this.buildInput(prompt, config),
+      input: buildOpenAICompatibleInput(prompt, config),
       ...(config.systemInstruction && { instructions: config.systemInstruction }),
       max_output_tokens: config.maxTokens ?? 8192,
       temperature: config.temperature ?? 0.7,
@@ -97,31 +100,6 @@ class SeedreamTextClientImpl implements TextClient {
     } catch (error) {
       return this.handleError(error, 'connection validation')
     }
-  }
-
-  private buildInput(prompt: string, config: GenerationConfig) {
-    if (!config.inputImage) {
-      return prompt
-    }
-
-    const mimeType = normalizeMimeType(config.inputImageMimeType ?? DEFAULT_MIME_TYPE)
-
-    return [
-      {
-        role: 'user' as const,
-        content: [
-          {
-            type: 'input_text' as const,
-            text: prompt,
-          },
-          {
-            type: 'input_image' as const,
-            image_url: `data:${mimeType};base64,${config.inputImage}`,
-            detail: 'auto' as const,
-          },
-        ],
-      },
-    ]
   }
 
   private handleError(error: unknown, stage: string): Result<never, ImageAPIError | NetworkError> {
@@ -187,18 +165,6 @@ class SeedreamTextClientImpl implements TextClient {
     }
 
     return 'Check ModelArk text API configuration and try again'
-  }
-
-  private validatePromptInput(prompt: string): Result<true, ImageAPIError> {
-    if (!prompt || prompt.trim().length === 0) {
-      return Err(new ImageAPIError('Empty prompt provided', 'Please provide a non-empty prompt'))
-    }
-
-    if (prompt.length > 100000) {
-      return Err(new ImageAPIError('Prompt too long', 'Please provide a shorter prompt'))
-    }
-
-    return Ok(true)
   }
 }
 

--- a/src/api/textClient.ts
+++ b/src/api/textClient.ts
@@ -1,6 +1,8 @@
 import type { Result } from '../types/result.js'
 import type { GeminiAPIError, ImageAPIError, NetworkError } from '../utils/errors.js'
 
+export const MAX_TEXT_PROMPT_LENGTH = 100_000
+
 /**
  * Options for text generation used by the prompt enhancer.
  */

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -5,8 +5,8 @@
 
 import { existsSync } from 'node:fs'
 import { extname } from 'node:path'
-import type { AspectRatio, GenerateImageParams } from '../types/mcp.js'
-import { IMAGE_QUALITY_VALUES } from '../types/mcp.js'
+import type { GenerateImageParams } from '../types/mcp.js'
+import { ASPECT_RATIO_VALUES, IMAGE_QUALITY_VALUES } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { InputValidationError } from '../utils/errors.js'
@@ -16,23 +16,7 @@ import { SUPPORTED_EXTENSIONS, SUPPORTED_MIME_TYPES } from '../utils/mimeUtils.j
 const PROMPT_MIN_LENGTH = 1
 const PROMPT_MAX_LENGTH = 4000
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
-const SUPPORTED_ASPECT_RATIOS: readonly AspectRatio[] = [
-  '1:1',
-  '1:4',
-  '1:8',
-  '2:3',
-  '3:2',
-  '3:4',
-  '4:1',
-  '4:3',
-  '4:5',
-  '5:4',
-  '8:1',
-  '9:16',
-  '16:9',
-  '21:9',
-] as const
-
+const SUPPORTED_ASPECT_RATIOS = ASPECT_RATIO_VALUES
 const SUPPORTED_QUALITY_VALUES = IMAGE_QUALITY_VALUES
 
 /**

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -531,8 +531,7 @@ afterEach(async () => {
 //   only the optional single-image field allowed by preflight.
 // - False prompt flags add no enhancement instruction; true prompt-only flags/purpose affect only
 //   the one text enhancement input and never add native image wire fields.
-// - Seedream image HTTP uses an AbortSignal derived from the provider-local fixed 300000 ms without
-//   changing existing apiTimeout=30000.
+// - Seedream image HTTP uses an AbortSignal derived from the provider-local fixed 300000 ms.
 // Verification items:
 // - Preflight occurs before any text or image transport call.
 // - Prompt generator call count is 0 or 1 according to the boundary row, never more than 1.

--- a/src/server/__tests__/errorHandler.test.ts
+++ b/src/server/__tests__/errorHandler.test.ts
@@ -172,9 +172,9 @@ describe('ErrorHandler', () => {
       const result = await ErrorHandler.wrapWithResultType(successOperation)
 
       // Assert
-      expect(result.ok).toBe(true)
-      if (result.ok) {
-        expect(result.value).toBe('success result')
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toBe('success result')
       }
       expect(successOperation).toHaveBeenCalledOnce()
     })
@@ -188,8 +188,8 @@ describe('ErrorHandler', () => {
       const result = await ErrorHandler.wrapWithResultType(failedOperation)
 
       // Assert
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
+      expect(result.success).toBe(false)
+      if (!result.success) {
         expect(result.error).toBe(error)
       }
       expect(failedOperation).toHaveBeenCalledOnce()
@@ -204,8 +204,8 @@ describe('ErrorHandler', () => {
       const result = await ErrorHandler.wrapWithResultType(failedOperation)
 
       // Assert
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
+      expect(result.success).toBe(false)
+      if (!result.success) {
         expect(result.error).toBeInstanceOf(Error)
         expect(result.error.message).toBe('Unknown error')
       }
@@ -234,9 +234,9 @@ describe('ErrorHandler', () => {
       const result = await ErrorHandler.wrapWithResultType(testOperation, 'test-context')
 
       // Assert
-      expect(result.ok).toBe(true)
-      if (result.ok) {
-        expect(result.value).toBe('test result')
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toBe('test result')
       }
     })
 
@@ -249,8 +249,8 @@ describe('ErrorHandler', () => {
       const result = await ErrorHandler.wrapWithResultType(testOperation, 'network-test')
 
       // Assert
-      expect(result.ok).toBe(false)
-      if (!result.ok) {
+      expect(result.success).toBe(false)
+      if (!result.success) {
         expect(result.error).toBe(testError)
       }
     })

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -99,30 +99,6 @@ vi.mock('../../business/fileManager', () => {
   }
 })
 
-// Mock the ImageGenerator for unit tests
-vi.mock('../../business/imageGenerator', () => {
-  return {
-    createImageGenerator: vi.fn().mockImplementation(() => {
-      return {
-        generateImage: vi.fn().mockResolvedValue({
-          success: true,
-          data: {
-            imageData: Buffer.from('mock-image-data', 'utf-8'),
-            metadata: {
-              model: 'gemini-3.1-flash-image',
-              prompt: 'test prompt',
-              mimeType: 'image/png',
-              timestamp: new Date(),
-              inputImageProvided: false,
-              processingTime: 1500,
-            },
-          },
-        }),
-      }
-    }),
-  }
-})
-
 // Mock the ResponseBuilder for unit tests
 vi.mock('../../business/responseBuilder', () => {
   return {
@@ -174,35 +150,6 @@ vi.mock('../../business/responseBuilder', () => {
           }
         }),
       }
-    }),
-  }
-})
-
-// Mock the InputValidator for unit tests
-vi.mock('../../business/inputValidator', async () => {
-  const originalModule = await vi.importActual('../../business/inputValidator')
-  const { Err, Ok } = await vi.importActual('../../types/result')
-  const { InputValidationError } = await vi.importActual('../../utils/errors')
-
-  return {
-    ...originalModule,
-    validateGenerateImageParams: vi.fn().mockImplementation((args) => {
-      if (!args.prompt || args.prompt === '') {
-        return Err(
-          new InputValidationError(
-            'Prompt must be between 1 and 4000 characters. Current length: 0',
-            'Please provide a descriptive prompt for image generation.'
-          )
-        )
-      }
-      return Ok({
-        prompt: args.prompt,
-        fileName: args.fileName,
-        inputImagePath: args.inputImagePath,
-        blendImages: args.blendImages,
-        maintainCharacterConsistency: args.maintainCharacterConsistency,
-        useWorldKnowledge: args.useWorldKnowledge,
-      })
     }),
   }
 })

--- a/src/server/errorHandler.ts
+++ b/src/server/errorHandler.ts
@@ -4,13 +4,14 @@
  */
 
 import type { McpToolResponse } from '../types/mcp.js'
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
 import {
   ConfigError,
   FileOperationError,
   GeminiAPIError,
   InputValidationError,
   NetworkError,
-  type Result,
 } from '../utils/errors.js'
 import { Logger, sanitizeText } from '../utils/logger.js'
 
@@ -79,7 +80,7 @@ async function wrapWithResultType<T>(
 ): Promise<Result<T, Error>> {
   try {
     const result = await operation()
-    return { ok: true, value: result }
+    return Ok(result)
   } catch (error) {
     const finalError = error instanceof Error ? error : new Error('Unknown error')
 
@@ -87,7 +88,7 @@ async function wrapWithResultType<T>(
       logger.error(context, 'Operation failed', finalError)
     }
 
-    return { ok: false, error: finalError }
+    return Err(finalError)
   }
 }
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -26,6 +26,7 @@ import {
 } from '../business/structuredPromptGenerator.js'
 // Types
 import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
+import { ASPECT_RATIO_VALUES, IMAGE_QUALITY_VALUES, IMAGE_SIZE_VALUES } from '../types/mcp.js'
 
 // Utilities
 import { type Config, getConfig } from '../utils/config.js'
@@ -188,28 +189,13 @@ export class MCPServerImpl {
                 type: 'string' as const,
                 description:
                   'Set the requested output aspect ratio. Omit to use the provider default.',
-                enum: [
-                  '1:1',
-                  '1:4',
-                  '1:8',
-                  '2:3',
-                  '3:2',
-                  '3:4',
-                  '4:1',
-                  '4:3',
-                  '4:5',
-                  '5:4',
-                  '8:1',
-                  '9:16',
-                  '16:9',
-                  '21:9',
-                ],
+                enum: [...ASPECT_RATIO_VALUES],
               },
               imageSize: {
                 type: 'string' as const,
                 description:
                   "Set the requested output size to 1K, 2K, or 4K. Omit to use the selected provider and quality preset's default. With Seedream, use 1K or 2K.",
-                enum: ['1K', '2K', '4K'],
+                enum: [...IMAGE_SIZE_VALUES],
               },
               purpose: {
                 type: 'string' as const,
@@ -220,7 +206,7 @@ export class MCPServerImpl {
                 type: 'string' as const,
                 description:
                   'Set only when the user requests a quality level; otherwise omit to use the server default. fast prioritizes speed, balanced trades speed for detail, and quality prioritizes fidelity.',
-                enum: ['fast', 'balanced', 'quality'],
+                enum: [...IMAGE_QUALITY_VALUES],
               },
             },
             required: ['prompt'],
@@ -435,8 +421,8 @@ export class MCPServerImpl {
       return this.responseBuilder.buildSuccessResponse(generationResult.data, saveResult.data)
     }, 'image-generation')
 
-    if (result.ok) {
-      return result.value
+    if (result.success) {
+      return result.data
     }
 
     return this.responseBuilder.buildErrorResponse(result.error)

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -10,26 +10,31 @@
 /**
  * Supported aspect ratios for Gemini image generation
  */
-export type AspectRatio =
-  | '1:1' // Square (default)
-  | '1:4' // Tall vertical
-  | '1:8' // Ultra-tall vertical
-  | '2:3' // Portrait
-  | '3:2' // Landscape
-  | '3:4' // Portrait
-  | '4:1' // Ultra-wide horizontal
-  | '4:3' // Landscape
-  | '4:5' // Portrait
-  | '5:4' // Landscape
-  | '8:1' // Extreme horizontal
-  | '9:16' // Vertical (social media)
-  | '16:9' // Horizontal (cinematic)
-  | '21:9' // Ultra-wide
+export const ASPECT_RATIO_VALUES = [
+  '1:1', // Square (default)
+  '1:4', // Tall vertical
+  '1:8', // Ultra-tall vertical
+  '2:3', // Portrait
+  '3:2', // Landscape
+  '3:4', // Portrait
+  '4:1', // Ultra-wide horizontal
+  '4:3', // Landscape
+  '4:5', // Portrait
+  '5:4', // Landscape
+  '8:1', // Extreme horizontal
+  '9:16', // Vertical (social media)
+  '16:9', // Horizontal (cinematic)
+  '21:9', // Ultra-wide
+] as const
+
+export type AspectRatio = (typeof ASPECT_RATIO_VALUES)[number]
 
 /**
  * Supported image sizes for high-resolution output
  */
-export type ImageSize = '1K' | '2K' | '4K'
+export const IMAGE_SIZE_VALUES = ['1K', '2K', '4K'] as const
+
+export type ImageSize = (typeof IMAGE_SIZE_VALUES)[number]
 
 /**
  * Provider-neutral output formats supported by OpenAI and Seedream.
@@ -42,7 +47,9 @@ export type ImageOutputFormat = 'png' | 'jpeg'
  * - 'balanced': Nano Banana 2 with enhanced thinking, better quality
  * - 'quality': Nano Banana Pro, highest quality output
  */
-export type ImageQuality = 'fast' | 'balanced' | 'quality'
+export const IMAGE_QUALITY_VALUES = ['fast', 'balanced', 'quality'] as const
+
+export type ImageQuality = (typeof IMAGE_QUALITY_VALUES)[number]
 
 /**
  * Supported image providers.
@@ -50,25 +57,9 @@ export type ImageQuality = 'fast' | 'balanced' | 'quality'
  * - 'openai': OpenAI GPT Image models such as gpt-image-2
  * - 'seedream': BytePlus Seedream models through ModelArk
  */
-export type ImageProvider = 'gemini' | 'openai' | 'seedream'
+export const IMAGE_PROVIDER_VALUES = ['gemini', 'openai', 'seedream'] as const
 
-/**
- * Supported quality preset values
- */
-export const IMAGE_QUALITY_VALUES: readonly ImageQuality[] = [
-  'fast',
-  'balanced',
-  'quality',
-] as const
-
-/**
- * Supported image provider values.
- */
-export const IMAGE_PROVIDER_VALUES: readonly ImageProvider[] = [
-  'gemini',
-  'openai',
-  'seedream',
-] as const
+export type ImageProvider = (typeof IMAGE_PROVIDER_VALUES)[number]
 
 /**
  * Gemini image generation model identifiers

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -30,7 +30,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -55,7 +54,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -71,31 +69,6 @@ describe('config', () => {
       }
     })
 
-    it('should return error when apiTimeout is invalid', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'gemini' as const,
-        geminiApiKey: 'valid-api-key-12345',
-        openaiApiKey: '',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        apiTimeout: -1000, // Invalid negative timeout
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('timeout')
-        expect(result.error.message).toContain('positive')
-      }
-    })
-
     it('should accept valid imageQuality values', () => {
       // Arrange
       const qualities = ['fast', 'balanced', 'quality'] as const
@@ -107,7 +80,6 @@ describe('config', () => {
           openaiApiKey: '',
           arkApiKey: '',
           imageOutputDir: './output',
-          apiTimeout: 30000,
           skipPromptEnhancement: false,
           imageQuality: quality,
         }
@@ -128,7 +100,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'invalid' as any,
       }
@@ -155,7 +126,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -178,7 +148,6 @@ describe('config', () => {
         openaiApiKey: 'test-openai-api-key-12345',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -198,7 +167,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -224,7 +192,6 @@ describe('config', () => {
           openaiApiKey: '',
           arkApiKey,
           imageOutputDir: './output',
-          apiTimeout: 30000,
           skipPromptEnhancement: false,
           imageQuality: 'fast' as const,
         }
@@ -252,7 +219,6 @@ describe('config', () => {
         openaiApiKey: '',
         arkApiKey: '  test-ark-key  ',
         imageOutputDir: './output',
-        apiTimeout: 30000,
         skipPromptEnhancement: false,
         imageQuality: 'fast' as const,
       }
@@ -293,7 +259,6 @@ describe('config', () => {
       if (result.success) {
         expect(result.data.geminiApiKey).toBe('test-api-key-12345')
         expect(result.data.imageOutputDir).toBe('/custom/output')
-        expect(result.data.apiTimeout).toBe(30000) // Default timeout
       }
     })
 
@@ -326,7 +291,6 @@ describe('config', () => {
       if (result.success) {
         expect(result.data.imageProvider).toBe('seedream')
         expect(result.data.arkApiKey).toBe('test-ark-api-key')
-        expect(result.data.apiTimeout).toBe(30000)
       }
     })
 
@@ -355,7 +319,6 @@ describe('config', () => {
       if (result.success) {
         expect(result.data.geminiApiKey).toBe('test-api-key-12345')
         expect(result.data.imageOutputDir).toBe('./output') // Default value
-        expect(result.data.apiTimeout).toBe(30000)
       }
     })
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,7 +18,6 @@ export interface Config {
   openaiApiKey: string
   arkApiKey: string
   imageOutputDir: string
-  apiTimeout: number
   skipPromptEnhancement: boolean // Skip prompt enhancement for direct control
   imageQuality: ImageQuality
 }
@@ -29,7 +28,6 @@ export interface Config {
 const DEFAULT_CONFIG = {
   imageProvider: 'gemini',
   imageOutputDir: './output',
-  apiTimeout: 30000, // 30 seconds
 } as const
 
 function readEnv(name: string): string | undefined {
@@ -113,16 +111,6 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  // Validate apiTimeout
-  if (config.apiTimeout <= 0) {
-    return Err(
-      new ConfigError(
-        'API timeout must be a positive number',
-        'Set a positive timeout value in milliseconds (e.g., 30000 for 30 seconds)'
-      )
-    )
-  }
-
   // Validate imageOutputDir (basic check - non-empty string)
   if (!config.imageOutputDir || config.imageOutputDir.trim().length === 0) {
     return Err(
@@ -157,7 +145,6 @@ export function getConfig(): Result<Config, ConfigError> {
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
     arkApiKey: (readEnv('ARK_API_KEY') || '').trim(),
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
-    apiTimeout: DEFAULT_CONFIG.apiTimeout,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',
     imageQuality: (readEnv('IMAGE_QUALITY') || 'fast') as ImageQuality,
   }

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -7,11 +7,6 @@ import { GEMINI_MODELS } from '../types/mcp.js'
 import { SUPPORTED_EXTENSIONS } from './mimeUtils.js'
 
 /**
- * Result type pattern for explicit error handling
- */
-export type Result<T, E> = { ok: true; value: T } | { ok: false; error: E }
-
-/**
  * Base class for all application errors with structured error support.
  *
  * Caller-visible error fields (code, message, suggestion) are available


### PR DESCRIPTION
## Summary

- remove the unused apiTimeout configuration while preserving provider-specific timeout behavior
- consolidate the internal Result type and shared OpenAI-compatible text input handling
- centralize supported MCP values and the text prompt length limit
- remove obsolete test mocks and related fixtures

## Behavior

This is a behavior-preserving refactor. MCP inputs and outputs, error responses, server version, output paths, and provider-specific timeout values remain unchanged.

## Verification

- npm run check:all
- 19 test files passed
- 336 tests passed
- build, lint, formatting, unused-code, and circular-dependency checks passed