### PR TITLE
feat: select image provider per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to send your prompt through unchanged.
 ## Features
 
 - **Prompt enhancement**: Adds lighting, composition, camera, and palette details using the selected provider's text model.
-- **Image providers**: Set `IMAGE_PROVIDER=openai` for OpenAI GPT Image or `IMAGE_PROVIDER=seedream` for BytePlus Seedream through ModelArk.
+- **Image providers**: Set `IMAGE_PROVIDER=openai` for OpenAI GPT Image or `IMAGE_PROVIDER=seedream` for BytePlus Seedream through ModelArk. Pass `provider` on a single request to switch providers without changing the server configuration.
 - **Quality presets**: Select `fast`, `balanced`, or `quality`. Each provider maps these values to a supported model route. [See Quality Presets](#quality-presets).
 - **Image editing**: Edit an existing image with natural-language instructions while retaining its style and visual details.
 - **Resolution controls**: Request up to 4K, depending on the provider and quality route.
@@ -251,10 +251,14 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to send prompts directly to the image generat
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `IMAGE_PROVIDER` | `gemini` | `gemini`, `openai`, or `seedream` |
-| `GEMINI_API_KEY` | - | Required when `IMAGE_PROVIDER=gemini` |
-| `OPENAI_API_KEY` | - | Required when `IMAGE_PROVIDER=openai` |
-| `ARK_API_KEY` | - | Required when `IMAGE_PROVIDER=seedream`; use a ModelArk AP region key |
+| `IMAGE_PROVIDER` | `gemini` | `gemini`, `openai`, or `seedream`. Used when a request does not set `provider` |
+| `GEMINI_API_KEY` | - | Required to use the `gemini` provider |
+| `OPENAI_API_KEY` | - | Required to use the `openai` provider |
+| `ARK_API_KEY` | - | Required to use the `seedream` provider; use a ModelArk AP region key |
+
+Configure a key for every provider you want to reach. The server starts as long as at least one
+provider is configured, and a request that selects a provider without a key fails with a
+configuration error naming the missing variable.
 
 ### Using the BytePlus Seedream provider
 
@@ -345,6 +349,7 @@ The server uses a separate model for each of its two stages:
 |-----------|------|----------|-------------|
 | `prompt` | string | ✅ | Text description or editing instruction |
 | `quality` | string | - | Quality preset: `fast` (default), `balanced`, `quality`. Overrides `IMAGE_QUALITY` env var for this request |
+| `provider` | string | - | Image provider: `gemini`, `openai`, `seedream`. Overrides `IMAGE_PROVIDER` env var for this request; the provider's API key must be configured |
 | `inputImagePath` | string | - | Absolute path to input image for image-to-image editing |
 | `fileName` | string | - | `.png`, `.jpg`, or `.jpeg` selects that output format for OpenAI/Seedream. Other or absent suffixes use the provider default, and the saved name is corrected to the actual image extension |
 | `aspectRatio` | string | - | `1:1` (default), `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`, `1:4`, `1:8`, `4:1`, `8:1` |

--- a/src/business/__tests__/inputValidator.test.ts
+++ b/src/business/__tests__/inputValidator.test.ts
@@ -397,4 +397,45 @@ describe('inputValidator', () => {
       }
     })
   })
+
+  describe('validateGenerateImageParams with provider', () => {
+    it('should accept all valid provider values', () => {
+      // Arrange
+      const validProviders = ['gemini', 'openai', 'seedream'] as const
+
+      // Act & Assert
+      for (const provider of validProviders) {
+        const result = validateGenerateImageParams({
+          prompt: 'test',
+          provider,
+        })
+        expect(result.success).toBe(true)
+      }
+    })
+
+    it('should accept undefined provider (optional)', () => {
+      // Arrange & Act
+      const result = validateGenerateImageParams({ prompt: 'test' })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject invalid provider value', () => {
+      // Arrange
+      const result = validateGenerateImageParams({
+        prompt: 'test',
+        provider: 'midjourney' as any,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.message).toContain('Invalid provider')
+        expect(result.error.message).toContain('gemini')
+        expect(result.error.message).toContain('openai')
+        expect(result.error.message).toContain('seedream')
+      }
+    })
+  })
 })

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -6,7 +6,7 @@
 import { existsSync } from 'node:fs'
 import { extname } from 'node:path'
 import type { GenerateImageParams } from '../types/mcp.js'
-import { ASPECT_RATIO_VALUES, IMAGE_QUALITY_VALUES } from '../types/mcp.js'
+import { ASPECT_RATIO_VALUES, IMAGE_PROVIDER_VALUES, IMAGE_QUALITY_VALUES } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { InputValidationError } from '../utils/errors.js'
@@ -18,6 +18,7 @@ const PROMPT_MAX_LENGTH = 4000
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024 // 10MB in bytes
 const SUPPORTED_ASPECT_RATIOS = ASPECT_RATIO_VALUES
 const SUPPORTED_QUALITY_VALUES = IMAGE_QUALITY_VALUES
+const SUPPORTED_PROVIDER_VALUES = IMAGE_PROVIDER_VALUES
 
 /**
  * Converts bytes to MB with proper formatting
@@ -230,6 +231,16 @@ export function validateGenerateImageParams(
       new InputValidationError(
         `Invalid quality value: "${params.quality}". Supported values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`,
         `Please use one of the supported quality values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`
+      )
+    )
+  }
+
+  // Validate provider parameter
+  if (params.provider !== undefined && !SUPPORTED_PROVIDER_VALUES.includes(params.provider)) {
+    return Err(
+      new InputValidationError(
+        `Invalid provider value: "${params.provider}". Supported values: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`,
+        `Please use one of the supported providers: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`
       )
     )
   }

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -517,6 +517,83 @@ describe('MCP Server', () => {
     expect(createOpenAITextClient).toHaveBeenCalled()
   })
 
+  it('should route image generation through the provider requested in the tool call', async () => {
+    // Arrange: server default stays gemini, the request asks for openai
+    process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
+    const mcpServer = createMCPServer()
+
+    // Act
+    const result = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      provider: 'openai',
+    })
+
+    // Assert
+    expect(result.isError).toBe(false)
+
+    const { createGeminiClient } = await import('../../api/geminiClient')
+    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+
+    expect(createGeminiClient).not.toHaveBeenCalled()
+    expect(createOpenAIImageClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        openaiApiKey: 'test-openai-api-key-unit-tests',
+      })
+    )
+  })
+
+  it('should build fresh clients when a later call requests another provider', async () => {
+    // Arrange
+    process.env.OPENAI_API_KEY = 'test-openai-api-key-unit-tests'
+    process.env.SKIP_PROMPT_ENHANCEMENT = 'true'
+    const mcpServer = createMCPServer()
+
+    // Act
+    const geminiResult = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      provider: 'gemini',
+    })
+    const openaiResult = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      provider: 'openai',
+    })
+    const cachedGeminiResult = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      provider: 'gemini',
+    })
+
+    // Assert
+    expect(geminiResult.isError).toBe(false)
+    expect(openaiResult.isError).toBe(false)
+    expect(cachedGeminiResult.isError).toBe(false)
+
+    const { createGeminiClient } = await import('../../api/geminiClient')
+    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+
+    // The second call must build the OpenAI client instead of reusing the Gemini one,
+    // while the third call reuses the cached Gemini client.
+    expect(createOpenAIImageClient).toHaveBeenCalledTimes(1)
+    expect(createGeminiClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('should reject a requested provider whose API key is not configured', async () => {
+    // Arrange: only GEMINI_API_KEY is set by the test setup
+    const mcpServer = createMCPServer()
+
+    // Act
+    const result = await mcpServer.callTool('generate_image', {
+      prompt: 'test prompt',
+      provider: 'openai',
+    })
+
+    // Assert
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain('OPENAI_API_KEY')
+
+    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+    expect(createOpenAIImageClient).not.toHaveBeenCalled()
+  })
+
   it('should pass JPEG preference from fileName to the selected provider', async () => {
     process.env.IMAGE_PROVIDER = 'openai'
     delete process.env.GEMINI_API_KEY
@@ -692,6 +769,40 @@ describe('MCPServer tool schema - quality', () => {
     // Assert
     expect(generateImageTool?.inputSchema.required).toContain('prompt')
     expect(generateImageTool?.inputSchema.required).not.toContain('quality')
+  })
+})
+
+// Test suite for provider parameter in generate_image tool schema
+describe('MCPServer tool schema - provider', () => {
+  it('should include provider parameter in generate_image schema', () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    const toolsList = mcpServer.getToolsList()
+    const generateImageTool = toolsList.tools.find((t) => t.name === 'generate_image')
+
+    // Assert
+    expect(generateImageTool?.inputSchema.properties).toHaveProperty('provider')
+    expect(generateImageTool?.inputSchema.properties?.provider.type).toBe('string')
+    expect(generateImageTool?.inputSchema.properties?.provider.enum).toEqual([
+      'gemini',
+      'openai',
+      'seedream',
+    ])
+  })
+
+  it('should mark provider as optional in schema', () => {
+    // Arrange
+    const mcpServer = createMCPServer()
+
+    // Act
+    const toolsList = mcpServer.getToolsList()
+    const generateImageTool = toolsList.tools.find((t) => t.name === 'generate_image')
+
+    // Assert
+    expect(generateImageTool?.inputSchema.required).toContain('prompt')
+    expect(generateImageTool?.inputSchema.required).not.toContain('provider')
   })
 })
 

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -14,7 +14,6 @@ import {
   type ListToolsResult,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { ImageApiParams, ImageClient } from '../api/imageClient.js'
-import type { TextClient } from '../api/textClient.js'
 // Business logic
 import { createFileManager, type FileManager } from '../business/fileManager.js'
 import { MAX_IMAGE_SIZE, validateGenerateImageParams } from '../business/inputValidator.js'
@@ -25,11 +24,16 @@ import {
   type StructuredPromptGenerator,
 } from '../business/structuredPromptGenerator.js'
 // Types
-import type { GenerateImageParams, MCPServerConfig } from '../types/mcp.js'
-import { ASPECT_RATIO_VALUES, IMAGE_QUALITY_VALUES, IMAGE_SIZE_VALUES } from '../types/mcp.js'
+import type { GenerateImageParams, ImageProvider, MCPServerConfig } from '../types/mcp.js'
+import {
+  ASPECT_RATIO_VALUES,
+  IMAGE_PROVIDER_VALUES,
+  IMAGE_QUALITY_VALUES,
+  IMAGE_SIZE_VALUES,
+} from '../types/mcp.js'
 
 // Utilities
-import { type Config, getConfig } from '../utils/config.js'
+import { type Config, getConfig, validateProviderCredentials } from '../utils/config.js'
 import { InputValidationError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
 import {
@@ -106,6 +110,14 @@ async function readInputImageWithinLimit(filePath: string): Promise<Buffer> {
 }
 
 /**
+ * Clients backing a single image provider.
+ */
+interface ProviderClients {
+  imageClient: ImageClient
+  structuredPromptGenerator: StructuredPromptGenerator | null
+}
+
+/**
  * Simplified MCP server
  */
 export class MCPServerImpl {
@@ -115,9 +127,7 @@ export class MCPServerImpl {
   private fileManager: FileManager
   private responseBuilder: ResponseBuilder
   private securityManager: SecurityManager
-  private structuredPromptGenerator: StructuredPromptGenerator | null = null
-  private textClient: TextClient | null = null
-  private imageClient: ImageClient | null = null
+  private clientsByProvider = new Map<ImageProvider, ProviderClients>()
 
   constructor(config: Partial<MCPServerConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config }
@@ -208,6 +218,12 @@ export class MCPServerImpl {
                   'Set only when the user requests a quality level; otherwise omit to use the server default. fast prioritizes speed, balanced trades speed for detail, and quality prioritizes fidelity.',
                 enum: [...IMAGE_QUALITY_VALUES],
               },
+              provider: {
+                type: 'string' as const,
+                description:
+                  'Set only when the user requests a specific image provider; otherwise omit to use the server default. The provider must have its API key configured on the server.',
+                enum: [...IMAGE_PROVIDER_VALUES],
+              },
             },
             required: ['prompt'],
           },
@@ -232,38 +248,39 @@ export class MCPServerImpl {
   }
 
   /**
-   * Initialize provider clients lazily.
+   * Initialize provider clients lazily, cached per provider so that requests
+   * alternating between providers do not reuse another provider's clients.
    */
-  private async initializeClients(
+  private getProviderClients(
     config: Config,
+    providerName: ImageProvider,
     provider: ImageProviderDefinition
-  ): Promise<void> {
-    if (this.imageClient && (config.skipPromptEnhancement || this.structuredPromptGenerator)) {
-      return
+  ): ProviderClients {
+    const cached = this.clientsByProvider.get(providerName)
+    if (cached && (config.skipPromptEnhancement || cached.structuredPromptGenerator)) {
+      return cached
     }
 
-    // Initialize Text Client for prompt generation when enhancement is enabled.
-    if (!config.skipPromptEnhancement && !this.textClient) {
-      this.textClient = provider.createTextClient(config)
-    }
+    // Initialize Structured Prompt Generator with its Text Client when enhancement is enabled.
+    const structuredPromptGenerator = config.skipPromptEnhancement
+      ? null
+      : createStructuredPromptGenerator(
+          provider.createTextClient(config),
+          provider.promptGeneration.maxTokens
+        )
 
-    // Initialize Structured Prompt Generator
-    if (!config.skipPromptEnhancement && this.textClient && !this.structuredPromptGenerator) {
-      this.structuredPromptGenerator = createStructuredPromptGenerator(
-        this.textClient,
-        provider.promptGeneration.maxTokens
-      )
+    const clients: ProviderClients = {
+      imageClient: cached?.imageClient ?? provider.createImageClient(config),
+      structuredPromptGenerator,
     }
-
-    // Initialize image generation client.
-    if (!this.imageClient) {
-      this.imageClient = provider.createImageClient(config)
-    }
+    this.clientsByProvider.set(providerName, clients)
 
     this.logger.info('mcp-server', 'Image provider clients initialized', {
-      provider: config.imageProvider,
+      provider: providerName,
       promptEnhancement: !config.skipPromptEnhancement,
     })
+
+    return clients
   }
 
   /**
@@ -288,10 +305,21 @@ export class MCPServerImpl {
         throw configResult.error
       }
       const config = configResult.data
-      const provider = getImageProviderDefinition(config.imageProvider)
+
+      // Resolve the provider for this request, falling back to the server default.
+      const providerName = params.provider ?? config.imageProvider
+      const credentialsResult = validateProviderCredentials(config, providerName)
+      if (!credentialsResult.success) {
+        throw credentialsResult.error
+      }
+      const provider = getImageProviderDefinition(providerName)
 
       // Initialize clients
-      await this.initializeClients(config, provider)
+      const { imageClient, structuredPromptGenerator } = this.getProviderClients(
+        config,
+        providerName,
+        provider
+      )
 
       // Handle input image if provided
       let inputImageData: string | undefined
@@ -326,7 +354,7 @@ export class MCPServerImpl {
 
       // Generate structured prompt (unless skipped)
       let structuredPrompt = params.prompt
-      if (!config.skipPromptEnhancement && this.structuredPromptGenerator) {
+      if (!config.skipPromptEnhancement && structuredPromptGenerator) {
         const features: FeatureFlags = {}
         if (params.maintainCharacterConsistency !== undefined) {
           features.maintainCharacterConsistency = params.maintainCharacterConsistency
@@ -341,7 +369,7 @@ export class MCPServerImpl {
           features.useGoogleSearch = params.useGoogleSearch
         }
 
-        const promptResult = await this.structuredPromptGenerator.generateStructuredPrompt(
+        const promptResult = await structuredPromptGenerator.generateStructuredPrompt(
           params.prompt,
           features,
           inputImageData,
@@ -367,11 +395,7 @@ export class MCPServerImpl {
       }
 
       // Generate image using selected provider.
-      if (!this.imageClient) {
-        throw new Error('Image client not initialized')
-      }
-
-      const generationResult = await this.imageClient.generateImage({
+      const generationResult = await imageClient.generateImage({
         prompt: structuredPrompt,
         ...imageOptions,
       })

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -101,6 +101,8 @@ export interface GenerateImageParams {
   purpose?: string
   /** Quality preset for image generation (default: "fast"). Controls model selection and thinking configuration */
   quality?: ImageQuality
+  /** Image provider to use for this request (default: the server's IMAGE_PROVIDER setting) */
+  provider?: ImageProvider
 }
 
 /**

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getConfig, validateConfig } from '../config'
+import { getConfig, validateConfig, validateProviderCredentials } from '../config'
 import { ConfigError } from '../errors'
 
 describe('config', () => {
@@ -228,6 +228,97 @@ describe('config', () => {
 
       // Assert
       expect(result.success).toBe(true)
+    })
+
+    it('should accept a configured non-default provider when the default provider key is missing', () => {
+      // Arrange: requests may select openai even though IMAGE_PROVIDER is gemini
+      const config = {
+        imageProvider: 'gemini' as const,
+        geminiApiKey: '',
+        openaiApiKey: 'test-openai-api-key-12345',
+        arkApiKey: '',
+        imageOutputDir: './output',
+        skipPromptEnhancement: false,
+        imageQuality: 'fast' as const,
+      }
+
+      // Act
+      const result = validateConfig(config)
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it('should report the default provider error when no provider key is configured', () => {
+      // Arrange
+      const config = {
+        imageProvider: 'seedream' as const,
+        geminiApiKey: '',
+        openaiApiKey: '',
+        arkApiKey: '',
+        imageOutputDir: './output',
+        skipPromptEnhancement: false,
+        imageQuality: 'fast' as const,
+      }
+
+      // Act
+      const result = validateConfig(config)
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ConfigError)
+        expect(result.error.message).toContain('ARK_API_KEY')
+      }
+    })
+  })
+
+  describe('validateProviderCredentials', () => {
+    const configWithOnlyOpenAIKey = {
+      imageProvider: 'gemini' as const,
+      geminiApiKey: '',
+      openaiApiKey: 'test-openai-api-key-12345',
+      arkApiKey: '',
+      imageOutputDir: './output',
+      skipPromptEnhancement: false,
+      imageQuality: 'fast' as const,
+    }
+
+    it('should accept the provider whose key is configured', () => {
+      // Act
+      const result = validateProviderCredentials(configWithOnlyOpenAIKey, 'openai')
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it.each([
+      ['gemini' as const, 'GEMINI_API_KEY'],
+      ['seedream' as const, 'ARK_API_KEY'],
+    ])('should reject %s when its key is missing', (provider, expectedKeyName) => {
+      // Act
+      const result = validateProviderCredentials(configWithOnlyOpenAIKey, provider)
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ConfigError)
+        expect(result.error.message).toContain(expectedKeyName)
+      }
+    })
+
+    it('should reject a key that is shorter than the provider minimum', () => {
+      // Arrange
+      const config = { ...configWithOnlyOpenAIKey, openaiApiKey: 'short' }
+
+      // Act
+      const result = validateProviderCredentials(config, 'openai')
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.message).toContain('OPENAI_API_KEY')
+      }
     })
   })
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -39,6 +39,74 @@ function readEnv(name: string): string | undefined {
 }
 
 /**
+ * Validates the API credentials required by a single image provider.
+ *
+ * Provider selection is a per-request concern, so this check runs when a
+ * provider is actually used rather than only at startup.
+ * @param config The configuration holding the provider API keys
+ * @param provider The provider whose credentials should be validated
+ * @returns Result containing the config or ConfigError
+ */
+export function validateProviderCredentials(
+  config: Config,
+  provider: ImageProvider
+): Result<Config, ConfigError> {
+  // Validate GEMINI_API_KEY only when Gemini is the selected provider.
+  if (provider === 'gemini') {
+    if (!config.geminiApiKey || config.geminiApiKey.trim().length === 0) {
+      return Err(
+        new ConfigError(
+          'GEMINI_API_KEY is required but not provided',
+          'Set GEMINI_API_KEY environment variable with your Google AI API key'
+        )
+      )
+    }
+
+    if (config.geminiApiKey.length < 10) {
+      return Err(
+        new ConfigError(
+          'GEMINI_API_KEY appears to be invalid - must be at least 10 characters',
+          'Set the GEMINI_API_KEY environment variable to your valid Google AI API key'
+        )
+      )
+    }
+  }
+
+  // Validate OPENAI_API_KEY only when OpenAI is the selected provider.
+  if (provider === 'openai') {
+    if (!config.openaiApiKey || config.openaiApiKey.trim().length === 0) {
+      return Err(
+        new ConfigError(
+          'OPENAI_API_KEY is required but not provided',
+          'Set OPENAI_API_KEY environment variable with your OpenAI API key'
+        )
+      )
+    }
+
+    if (config.openaiApiKey.length < 10) {
+      return Err(
+        new ConfigError(
+          'OPENAI_API_KEY appears to be invalid - must be at least 10 characters',
+          'Set the OPENAI_API_KEY environment variable to your valid OpenAI API key'
+        )
+      )
+    }
+  }
+
+  // Seedream only requires a trimmed non-empty key; no vendor-specific length heuristic is defined.
+  if (provider === 'seedream' && (!config.arkApiKey || config.arkApiKey.trim().length === 0)) {
+    return Err(
+      new ConfigError(
+        'ARK_API_KEY is required but not provided',
+        'Set ARK_API_KEY environment variable with your BytePlus ModelArk API key'
+      )
+    )
+  }
+
+  return Ok(config)
+}
+
+/**
  * Validates the configuration
  * @param config The configuration to validate
  * @returns Result containing validated config or ConfigError
@@ -54,61 +122,17 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  // Validate GEMINI_API_KEY only when Gemini is the selected provider.
-  if (
-    config.imageProvider === 'gemini' &&
-    (!config.geminiApiKey || config.geminiApiKey.trim().length === 0)
-  ) {
-    return Err(
-      new ConfigError(
-        'GEMINI_API_KEY is required but not provided',
-        'Set GEMINI_API_KEY environment variable with your Google AI API key'
-      )
+  // Requests may select any provider, so startup only requires that at least one
+  // provider is usable. The default provider's error is reported when none is.
+  const defaultProviderCredentials = validateProviderCredentials(config, config.imageProvider)
+  if (!defaultProviderCredentials.success) {
+    const hasUsableProvider = IMAGE_PROVIDER_VALUES.some(
+      (provider) =>
+        provider !== config.imageProvider && validateProviderCredentials(config, provider).success
     )
-  }
-
-  if (config.imageProvider === 'gemini' && config.geminiApiKey.length < 10) {
-    return Err(
-      new ConfigError(
-        'GEMINI_API_KEY appears to be invalid - must be at least 10 characters',
-        'Set the GEMINI_API_KEY environment variable to your valid Google AI API key'
-      )
-    )
-  }
-
-  // Validate OPENAI_API_KEY only when OpenAI is the selected provider.
-  if (
-    config.imageProvider === 'openai' &&
-    (!config.openaiApiKey || config.openaiApiKey.trim().length === 0)
-  ) {
-    return Err(
-      new ConfigError(
-        'OPENAI_API_KEY is required but not provided',
-        'Set OPENAI_API_KEY environment variable with your OpenAI API key'
-      )
-    )
-  }
-
-  if (config.imageProvider === 'openai' && config.openaiApiKey.length < 10) {
-    return Err(
-      new ConfigError(
-        'OPENAI_API_KEY appears to be invalid - must be at least 10 characters',
-        'Set the OPENAI_API_KEY environment variable to your valid OpenAI API key'
-      )
-    )
-  }
-
-  // Seedream only requires a trimmed non-empty key; no vendor-specific length heuristic is defined.
-  if (
-    config.imageProvider === 'seedream' &&
-    (!config.arkApiKey || config.arkApiKey.trim().length === 0)
-  ) {
-    return Err(
-      new ConfigError(
-        'ARK_API_KEY is required but not provided',
-        'Set ARK_API_KEY environment variable with your BytePlus ModelArk API key'
-      )
-    )
+    if (!hasUsableProvider) {
+      return Err(defaultProviderCredentials.error)
+    }
   }
 
   // Validate imageOutputDir (basic check - non-empty string)


### PR DESCRIPTION
## Summary

Adds an optional `provider` parameter to the `generate_image` tool so a single server can serve requests for different image providers, instead of being fixed to `IMAGE_PROVIDER` for its whole lifetime. When the parameter is omitted, behaviour is unchanged and the configured `IMAGE_PROVIDER` is used.

This is useful when the assistant wants to pick a provider per task — for example Gemini for search-grounded images and OpenAI for a transparent-background asset — without restarting the server with a different environment.

## Changes

- **`src/types/mcp.ts`**: optional `provider?: ImageProvider` on `GenerateImageParams`.
- **`src/server/mcpServer.ts`**: the tool schema exposes `provider` with the `IMAGE_PROVIDER_VALUES` enum; `handleGenerateImage` resolves `params.provider ?? config.imageProvider` and dispatches through the existing `imageProviderRegistry`.
- **`src/business/inputValidator.ts`**: validates `provider` against the supported values, matching the existing `quality` / `aspectRatio` checks.
- **`src/utils/config.ts`**: the per-provider API key checks move into an exported `validateProviderCredentials(config, provider)`, which now runs when a provider is actually used rather than only at startup.
- **`README.md`**: documents the parameter and the credential requirements.

## Two points worth reviewing

**1. Provider clients are now cached per provider.**

`initializeClients` kept `imageClient` / `textClient` in a single instance slot guarded by an early return. With a per-request provider that would silently reuse the first provider's client for every subsequent request. The clients now live in a `Map<ImageProvider, ProviderClients>`, so each provider is still constructed lazily and reused, but never across providers. `should build fresh clients when a later call requests another provider` covers this — it fails against a single-slot cache even when the routing itself is correct.

**2. Startup credential validation is slightly relaxed.**

Since any provider can be requested at call time, `validateConfig` can no longer know which key will be needed. It now requires that *at least one* provider is usable, and a request selecting a provider without a key fails with the existing, specific `ConfigError` naming the missing variable.

To keep the error quality of the current behaviour, when no provider is usable the reported error is still the configured `IMAGE_PROVIDER`'s own error (e.g. `GEMINI_API_KEY is required but not provided`) rather than a generic message. All existing `validateConfig` tests pass unchanged; the only new startup behaviour is that `IMAGE_PROVIDER=gemini` with just `OPENAI_API_KEY` set now starts instead of refusing.

If you would rather keep startup strict — validating the default provider's key as before, in addition to the per-request check — that is a small change and I am happy to make it.

## Tests

14 new tests: provider routing and the client-cache regression in `mcpServer.test.ts`, `validateProviderCredentials` and the relaxed startup rule in `config.test.ts`, and parameter validation in `inputValidator.test.ts`. `npm run check`, `lint`, `format:check`, `check:deps`, `build` and the suite are green.
