### PR TITLE
Validate credentials for the selected image provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ Set `SKIP_PROMPT_ENHANCEMENT=true` to send prompts directly to the image generat
 | `OPENAI_API_KEY` | - | Required to use the `openai` provider |
 | `ARK_API_KEY` | - | Required to use the `seedream` provider; use a ModelArk AP region key |
 
-Configure a key for every provider you want to reach. The server starts as long as at least one
-provider is configured, and a request that selects a provider without a key fails with a
-configuration error naming the missing variable.
+A request-level `provider` takes precedence over `IMAGE_PROVIDER`; if neither is set, `gemini` is
+used. The server can start without any API keys, but `generate_image` requires a key for the
+selected provider. If a key is missing, the error identifies the environment variable to configure.
 
 ### Using the BytePlus Seedream provider
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-image",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-image",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "description": "MCP server for AI image generation",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.12.2",
+  "version": "0.13.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -124,14 +124,14 @@ afterEach(() => {
 })
 
 describe('seedreamImageClient', () => {
-  it('uses the configuration-normalized environment key in direct HTTP Authorization', async () => {
+  it('passes the untrimmed environment key to direct HTTP Authorization', async () => {
     stubSeedreamEnvironment()
     const configResult = getConfig()
     expect(configResult.success).toBe(true)
     if (!configResult.success) {
       throw configResult.error
     }
-    expect(configResult.data.arkApiKey).toBe(DUMMY_API_KEY)
+    expect(configResult.data.arkApiKey).toBe(WRAPPED_DUMMY_API_KEY)
 
     const result = await createClient(configResult.data).generateImage({
       prompt: PRIVATE_PROMPT,
@@ -139,7 +139,11 @@ describe('seedreamImageClient', () => {
 
     expect(result.success).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(readRequest().headers.get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+    const request = readRequest()
+    expect((request.init.headers as Record<string, string>).Authorization).toBe(
+      `Bearer ${WRAPPED_DUMMY_API_KEY}`
+    )
+    expect(request.headers.get('authorization')).toBe(`Bearer  \t${DUMMY_API_KEY}`)
   })
 
   it.each([

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -57,18 +57,18 @@ afterEach(() => {
 })
 
 describe('seedreamTextClient', () => {
-  it('uses the configuration-normalized environment key in SDK Authorization', async () => {
+  it('preserves the environment key before SDK Authorization normalization', async () => {
     stubSeedreamEnvironment()
     const configResult = getConfig()
     expect(configResult.success).toBe(true)
     if (!configResult.success) {
       throw configResult.error
     }
-    expect(configResult.data.arkApiKey).toBe(DUMMY_API_KEY)
+    expect(configResult.data.arkApiKey).toBe(WRAPPED_DUMMY_API_KEY)
 
     const transport = vi
       .fn<typeof fetch>()
-      .mockResolvedValue(successfulResponse('normalized authorization response'))
+      .mockResolvedValue(successfulResponse('exact authorization response'))
     vi.stubGlobal('fetch', transport)
     const clientResult = createSeedreamTextClient(configResult.data)
     expect(clientResult.success).toBe(true)
@@ -78,10 +78,10 @@ describe('seedreamTextClient', () => {
 
     const result = await clientResult.data.generateText(PRIVATE_PROMPT)
 
-    expect(result).toEqual({ success: true, data: 'normalized authorization response' })
+    expect(result).toEqual({ success: true, data: 'exact authorization response' })
     expect(transport).toHaveBeenCalledTimes(1)
     const [, init] = transport.mock.calls[0]
-    expect(new Headers(init?.headers).get('authorization')).toBe(`Bearer ${DUMMY_API_KEY}`)
+    expect(new Headers(init?.headers).get('authorization')).toBe(`Bearer  \t${DUMMY_API_KEY}`)
   })
 
   it('serializes the pinned Responses request through the installed SDK and returns exact text', async () => {

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -514,7 +514,11 @@ describe('MCP Server', () => {
         openaiApiKey: 'test-openai-api-key-unit-tests',
       })
     )
-    expect(createOpenAITextClient).toHaveBeenCalled()
+    expect(createOpenAITextClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        openaiApiKey: 'test-openai-api-key-unit-tests',
+      })
+    )
   })
 
   it('should route image generation through the provider requested in the tool call', async () => {
@@ -533,9 +537,15 @@ describe('MCP Server', () => {
 
     const { createGeminiClient } = await import('../../api/geminiClient')
     const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+    const { createOpenAITextClient } = await import('../../api/openaiTextClient')
 
     expect(createGeminiClient).not.toHaveBeenCalled()
     expect(createOpenAIImageClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        openaiApiKey: 'test-openai-api-key-unit-tests',
+      })
+    )
+    expect(createOpenAITextClient).toHaveBeenCalledWith(
       expect.objectContaining({
         openaiApiKey: 'test-openai-api-key-unit-tests',
       })
@@ -576,23 +586,69 @@ describe('MCP Server', () => {
     expect(createGeminiClient).toHaveBeenCalledTimes(1)
   })
 
-  it('should reject a requested provider whose API key is not configured', async () => {
-    // Arrange: only GEMINI_API_KEY is set by the test setup
-    const mcpServer = createMCPServer()
+  it.each([
+    {
+      route: 'request provider',
+      requestProvider: 'openai' as const,
+      configuredDefault: undefined,
+      expectedProvider: 'openai',
+      expectedEnvironmentVariable: 'OPENAI_API_KEY',
+    },
+    {
+      route: 'configured default provider',
+      requestProvider: undefined,
+      configuredDefault: 'seedream' as const,
+      expectedProvider: 'seedream',
+      expectedEnvironmentVariable: 'ARK_API_KEY',
+    },
+    {
+      route: 'built-in default provider',
+      requestProvider: undefined,
+      configuredDefault: undefined,
+      expectedProvider: 'gemini',
+      expectedEnvironmentVariable: 'GEMINI_API_KEY',
+    },
+  ])(
+    'should guide the caller to configure credentials for the $route',
+    async ({
+      requestProvider,
+      configuredDefault,
+      expectedProvider,
+      expectedEnvironmentVariable,
+    }) => {
+      // Arrange
+      delete process.env.GEMINI_API_KEY
+      delete process.env.OPENAI_API_KEY
+      delete process.env.ARK_API_KEY
+      if (configuredDefault) {
+        process.env.IMAGE_PROVIDER = configuredDefault
+      } else {
+        delete process.env.IMAGE_PROVIDER
+      }
+      const mcpServer = createMCPServer()
 
-    // Act
-    const result = await mcpServer.callTool('generate_image', {
-      prompt: 'test prompt',
-      provider: 'openai',
-    })
+      // Act
+      const result = await mcpServer.callTool('generate_image', {
+        prompt: 'test prompt',
+        ...(requestProvider && { provider: requestProvider }),
+      })
 
-    // Assert
-    expect(result.isError).toBe(true)
-    expect(result.content[0].text).toContain('OPENAI_API_KEY')
+      // Assert
+      expect(result.isError).toBe(true)
+      const responseData = JSON.parse(result.content[0].text)
+      expect(responseData.error.code).toBe('CONFIG_ERROR')
+      expect(responseData.error.message).toContain(`"${expectedProvider}"`)
+      expect(responseData.error.suggestion).toContain(expectedEnvironmentVariable)
+      expect(responseData.error.suggestion).toContain(
+        `retry generate_image with provider "${expectedProvider}"`
+      )
 
-    const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
-    expect(createOpenAIImageClient).not.toHaveBeenCalled()
-  })
+      if (expectedProvider === 'openai') {
+        const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
+        expect(createOpenAIImageClient).not.toHaveBeenCalled()
+      }
+    }
+  )
 
   it('should pass JPEG preference from fileName to the selected provider', async () => {
     process.env.IMAGE_PROVIDER = 'openai'

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -22,7 +22,7 @@ describe('config', () => {
   })
 
   describe('validateConfig', () => {
-    it('should return error when GEMINI_API_KEY is missing', () => {
+    it('should validate settings without requiring provider credentials', () => {
       // Arrange
       const config = {
         imageProvider: 'gemini' as const,
@@ -38,35 +38,7 @@ describe('config', () => {
       const result = validateConfig(config)
 
       // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('GEMINI_API_KEY')
-        expect(result.error.suggestion).toContain('Set GEMINI_API_KEY')
-      }
-    })
-
-    it('should return error when GEMINI_API_KEY is too short', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'gemini' as const,
-        geminiApiKey: 'short',
-        openaiApiKey: '',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('at least 10 characters')
-      }
+      expect(result.success).toBe(true)
     })
 
     it('should accept valid imageQuality values', () => {
@@ -139,187 +111,63 @@ describe('config', () => {
         expect(result.data).toEqual(config)
       }
     })
-
-    it('should accept OpenAI provider without GEMINI_API_KEY', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'openai' as const,
-        geminiApiKey: '',
-        openaiApiKey: 'test-openai-api-key-12345',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(true)
-    })
-
-    it('should require OPENAI_API_KEY for OpenAI provider', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'openai' as const,
-        geminiApiKey: '',
-        openaiApiKey: '',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('OPENAI_API_KEY')
-      }
-    })
-
-    it.each(['', '   '])(
-      'should require a trimmed non-empty ARK_API_KEY for the Seedream provider',
-      (arkApiKey) => {
-        // Arrange
-        const config = {
-          imageProvider: 'seedream' as const,
-          geminiApiKey: '',
-          openaiApiKey: '',
-          arkApiKey,
-          imageOutputDir: './output',
-          skipPromptEnhancement: false,
-          imageQuality: 'fast' as const,
-        }
-
-        // Act
-        const result = validateConfig(config)
-
-        // Assert
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.error).toBeInstanceOf(ConfigError)
-          expect(result.error.message).toContain('ARK_API_KEY')
-          if (arkApiKey.length > 0) {
-            expect(result.error.message).not.toContain(arkApiKey)
-          }
-        }
-      }
-    )
-
-    it('should accept a trimmed non-empty ARK_API_KEY without other provider keys', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'seedream' as const,
-        geminiApiKey: '',
-        openaiApiKey: '',
-        arkApiKey: '  test-ark-key  ',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(true)
-    })
-
-    it('should accept a configured non-default provider when the default provider key is missing', () => {
-      // Arrange: requests may select openai even though IMAGE_PROVIDER is gemini
-      const config = {
-        imageProvider: 'gemini' as const,
-        geminiApiKey: '',
-        openaiApiKey: 'test-openai-api-key-12345',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(true)
-    })
-
-    it('should report the default provider error when no provider key is configured', () => {
-      // Arrange
-      const config = {
-        imageProvider: 'seedream' as const,
-        geminiApiKey: '',
-        openaiApiKey: '',
-        arkApiKey: '',
-        imageOutputDir: './output',
-        skipPromptEnhancement: false,
-        imageQuality: 'fast' as const,
-      }
-
-      // Act
-      const result = validateConfig(config)
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('ARK_API_KEY')
-      }
-    })
   })
 
   describe('validateProviderCredentials', () => {
-    const configWithOnlyOpenAIKey = {
+    const configWithoutCredentials = {
       imageProvider: 'gemini' as const,
       geminiApiKey: '',
-      openaiApiKey: 'test-openai-api-key-12345',
+      openaiApiKey: '',
       arkApiKey: '',
       imageOutputDir: './output',
       skipPromptEnhancement: false,
       imageQuality: 'fast' as const,
     }
 
-    it('should accept the provider whose key is configured', () => {
+    it.each([
+      ['gemini' as const, { geminiApiKey: 'x' }],
+      ['openai' as const, { openaiApiKey: 'x' }],
+      ['seedream' as const, { arkApiKey: 'x' }],
+    ])('should accept %s credentials without inferring a key format', (provider, credentials) => {
+      // Arrange
+      const config = { ...configWithoutCredentials, ...credentials }
+
       // Act
-      const result = validateProviderCredentials(configWithOnlyOpenAIKey, 'openai')
+      const result = validateProviderCredentials(config, provider)
 
       // Assert
       expect(result.success).toBe(true)
     })
 
     it.each([
-      ['gemini' as const, 'GEMINI_API_KEY'],
-      ['seedream' as const, 'ARK_API_KEY'],
-    ])('should reject %s when its key is missing', (provider, expectedKeyName) => {
-      // Act
-      const result = validateProviderCredentials(configWithOnlyOpenAIKey, provider)
+      ['gemini' as const, { geminiApiKey: '' }, 'GEMINI_API_KEY'],
+      ['gemini' as const, { geminiApiKey: ' \t\n ' }, 'GEMINI_API_KEY'],
+      ['openai' as const, { openaiApiKey: '' }, 'OPENAI_API_KEY'],
+      ['openai' as const, { openaiApiKey: ' \t\n ' }, 'OPENAI_API_KEY'],
+      ['seedream' as const, { arkApiKey: '' }, 'ARK_API_KEY'],
+      ['seedream' as const, { arkApiKey: ' \t\n ' }, 'ARK_API_KEY'],
+    ])(
+      'should guide the caller when %s credentials are missing',
+      (provider, credentials, environmentVariable) => {
+        // Arrange
+        const config = { ...configWithoutCredentials, ...credentials }
 
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain(expectedKeyName)
+        // Act
+        const result = validateProviderCredentials(config, provider)
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error).toBeInstanceOf(ConfigError)
+          expect(result.error.message).toBe(
+            `The selected image provider "${provider}" is not configured on this server.`
+          )
+          expect(result.error.suggestion).toBe(
+            `Ask the user to configure ${environmentVariable} and restart the MCP server. After the server restarts, retry generate_image with provider "${provider}".`
+          )
+        }
       }
-    })
-
-    it('should reject a key that is shorter than the provider minimum', () => {
-      // Arrange
-      const config = { ...configWithOnlyOpenAIKey, openaiApiKey: 'short' }
-
-      // Act
-      const result = validateProviderCredentials(config, 'openai')
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error.message).toContain('OPENAI_API_KEY')
-      }
-    })
+    )
   })
 
   describe('getConfig', () => {
@@ -330,10 +178,16 @@ describe('config', () => {
       const result = getConfig()
 
       // Assert
-      expect(result.success).toBe(false) // Should fail because API key is required
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('GEMINI_API_KEY')
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toMatchObject({
+          imageProvider: 'gemini',
+          geminiApiKey: '',
+          openaiApiKey: '',
+          arkApiKey: '',
+          imageOutputDir: './output',
+          imageQuality: 'fast',
+        })
       }
     })
 
@@ -385,15 +239,22 @@ describe('config', () => {
       }
     })
 
-    it('should trim ARK_API_KEY while loading Seedream environment config', () => {
-      process.env.IMAGE_PROVIDER = 'seedream'
-      process.env.ARK_API_KEY = ' \ttest-ark-api-key\n '
+    it.each([
+      ['GEMINI_API_KEY', 'geminiApiKey' as const],
+      ['OPENAI_API_KEY', 'openaiApiKey' as const],
+      ['ARK_API_KEY', 'arkApiKey' as const],
+    ])('should preserve %s exactly as configured', (environmentVariable, configKey) => {
+      // Arrange
+      const credential = ' \ttest-api-key\n '
+      process.env[environmentVariable] = credential
 
+      // Act
       const result = getConfig()
 
+      // Assert
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data.arkApiKey).toBe('test-ark-api-key')
+        expect(result.data[configKey]).toBe(credential)
       }
     })
 
@@ -454,21 +315,6 @@ describe('config', () => {
       expect(result.success).toBe(false)
       if (!result.success) {
         expect(result.error.message).toContain('Invalid IMAGE_QUALITY')
-      }
-    })
-
-    it('should validate the loaded config', () => {
-      // Arrange
-      process.env.GEMINI_API_KEY = 'short' // Invalid short API key
-
-      // Act
-      const result = getConfig()
-
-      // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error).toBeInstanceOf(ConfigError)
-        expect(result.error.message).toContain('at least 10 characters')
       }
     })
   })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -38,11 +38,31 @@ function readEnv(name: string): string | undefined {
   return value
 }
 
+type ProviderCredentialConfig = {
+  configKey: 'geminiApiKey' | 'openaiApiKey' | 'arkApiKey'
+  environmentVariable: string
+}
+
+const PROVIDER_CREDENTIALS = {
+  gemini: {
+    configKey: 'geminiApiKey',
+    environmentVariable: 'GEMINI_API_KEY',
+  },
+  openai: {
+    configKey: 'openaiApiKey',
+    environmentVariable: 'OPENAI_API_KEY',
+  },
+  seedream: {
+    configKey: 'arkApiKey',
+    environmentVariable: 'ARK_API_KEY',
+  },
+} as const satisfies Record<ImageProvider, ProviderCredentialConfig>
+
 /**
  * Validates the API credentials required by a single image provider.
  *
- * Provider selection is a per-request concern, so this check runs when a
- * provider is actually used rather than only at startup.
+ * Provider selection is a per-request concern, so this check runs after each
+ * request resolves its effective provider.
  * @param config The configuration holding the provider API keys
  * @param provider The provider whose credentials should be validated
  * @returns Result containing the config or ConfigError
@@ -51,54 +71,14 @@ export function validateProviderCredentials(
   config: Config,
   provider: ImageProvider
 ): Result<Config, ConfigError> {
-  // Validate GEMINI_API_KEY only when Gemini is the selected provider.
-  if (provider === 'gemini') {
-    if (!config.geminiApiKey || config.geminiApiKey.trim().length === 0) {
-      return Err(
-        new ConfigError(
-          'GEMINI_API_KEY is required but not provided',
-          'Set GEMINI_API_KEY environment variable with your Google AI API key'
-        )
-      )
-    }
+  const { configKey, environmentVariable } = PROVIDER_CREDENTIALS[provider]
+  const credential = config[configKey]
 
-    if (config.geminiApiKey.length < 10) {
-      return Err(
-        new ConfigError(
-          'GEMINI_API_KEY appears to be invalid - must be at least 10 characters',
-          'Set the GEMINI_API_KEY environment variable to your valid Google AI API key'
-        )
-      )
-    }
-  }
-
-  // Validate OPENAI_API_KEY only when OpenAI is the selected provider.
-  if (provider === 'openai') {
-    if (!config.openaiApiKey || config.openaiApiKey.trim().length === 0) {
-      return Err(
-        new ConfigError(
-          'OPENAI_API_KEY is required but not provided',
-          'Set OPENAI_API_KEY environment variable with your OpenAI API key'
-        )
-      )
-    }
-
-    if (config.openaiApiKey.length < 10) {
-      return Err(
-        new ConfigError(
-          'OPENAI_API_KEY appears to be invalid - must be at least 10 characters',
-          'Set the OPENAI_API_KEY environment variable to your valid OpenAI API key'
-        )
-      )
-    }
-  }
-
-  // Seedream only requires a trimmed non-empty key; no vendor-specific length heuristic is defined.
-  if (provider === 'seedream' && (!config.arkApiKey || config.arkApiKey.trim().length === 0)) {
+  if (!credential || credential.trim().length === 0) {
     return Err(
       new ConfigError(
-        'ARK_API_KEY is required but not provided',
-        'Set ARK_API_KEY environment variable with your BytePlus ModelArk API key'
+        `The selected image provider "${provider}" is not configured on this server.`,
+        `Ask the user to configure ${environmentVariable} and restart the MCP server. After the server restarts, retry generate_image with provider "${provider}".`
       )
     )
   }
@@ -120,19 +100,6 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
         `Set IMAGE_PROVIDER to one of: ${IMAGE_PROVIDER_VALUES.join(', ')}`
       )
     )
-  }
-
-  // Requests may select any provider, so startup only requires that at least one
-  // provider is usable. The default provider's error is reported when none is.
-  const defaultProviderCredentials = validateProviderCredentials(config, config.imageProvider)
-  if (!defaultProviderCredentials.success) {
-    const hasUsableProvider = IMAGE_PROVIDER_VALUES.some(
-      (provider) =>
-        provider !== config.imageProvider && validateProviderCredentials(config, provider).success
-    )
-    if (!hasUsableProvider) {
-      return Err(defaultProviderCredentials.error)
-    }
   }
 
   // Validate imageOutputDir (basic check - non-empty string)
@@ -167,7 +134,7 @@ export function getConfig(): Result<Config, ConfigError> {
     imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
     geminiApiKey: readEnv('GEMINI_API_KEY') || '',
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
-    arkApiKey: (readEnv('ARK_API_KEY') || '').trim(),
+    arkApiKey: readEnv('ARK_API_KEY') || '',
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',
     imageQuality: (readEnv('IMAGE_QUALITY') || 'fast') as ImageQuality,


### PR DESCRIPTION
## Summary

- validate credentials after resolving the provider for each image generation request
- return actionable configuration errors that identify the required environment variable and retry action
- preserve API keys as configured and reject only missing or whitespace-only values
- document provider precedence and update the package version to 0.13.0

## Testing

- npm run check:all