### PR TITLE
docs: streamline MCP setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,6 @@ See [Using the BytePlus Seedream provider](#using-the-byteplus-seedream-provider
 
 ### 2. MCP Configuration
 
-The examples below use Gemini. For OpenAI or Seedream, keep the same `npx -y mcp-image`
-command and replace `GEMINI_API_KEY` with the provider settings shown above.
-
 #### For Codex
 
 Add to `~/.codex/config.toml`:

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ See [Using the BytePlus Seedream provider](#using-the-byteplus-seedream-provider
 
 ### 2. MCP Configuration
 
+The examples below use Gemini. For OpenAI or Seedream, keep the same `npx -y mcp-image`
+command and replace `GEMINI_API_KEY` with the provider settings shown above.
+
 #### For Codex
 
 Add to `~/.codex/config.toml`:
@@ -119,19 +122,6 @@ args = ["-y", "mcp-image"]
 
 [mcp_servers.mcp-image.env]
 GEMINI_API_KEY = "your_gemini_api_key_here"
-IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
-```
-
-For OpenAI GPT Image from a local fork:
-
-```toml
-[mcp_servers.mcp-image]
-command = "node"
-args = ["/absolute/path/to/mcp-image/dist/index.js"]
-
-[mcp_servers.mcp-image.env]
-IMAGE_PROVIDER = "openai"
-OPENAI_API_KEY = "your_openai_api_key_here"
 IMAGE_OUTPUT_DIR = "/absolute/path/to/images"
 ```
 
@@ -156,24 +146,6 @@ Add to your Cursor settings:
 }
 ```
 
-For OpenAI GPT Image from a local fork:
-
-```json
-{
-  "mcpServers": {
-    "mcp-image": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-image/dist/index.js"],
-      "env": {
-        "IMAGE_PROVIDER": "openai",
-        "OPENAI_API_KEY": "your_openai_api_key_here",
-        "IMAGE_OUTPUT_DIR": "/absolute/path/to/images"
-      }
-    }
-  }
-}
-```
-
 #### For Claude Code
 
 Run in your project directory to enable for that project:
@@ -189,17 +161,26 @@ Or add globally for all projects:
 claude mcp add mcp-image --scope user --env GEMINI_API_KEY=your-api-key --env IMAGE_OUTPUT_DIR=/absolute/path/to/images -- npx -y mcp-image
 ```
 
-For OpenAI GPT Image from a local fork:
+<details>
+<summary>Run from a local checkout</summary>
+
+Use this when testing changes that are not in the npm package:
 
 ```bash
 pnpm install
 pnpm run build
-claude mcp add mcp-image --scope user \
-  --env IMAGE_PROVIDER=openai \
-  --env OPENAI_API_KEY=your-openai-api-key \
-  --env IMAGE_OUTPUT_DIR=/absolute/path/to/images \
-  -- node /absolute/path/to/mcp-image/dist/index.js
 ```
+
+Then configure your MCP client to run:
+
+```bash
+node /absolute/path/to/mcp-image/dist/index.js
+```
+
+For Codex and Cursor, set the command to `node` and use the path as its only argument. For
+Claude Code, put the command after `--` in the `claude mcp add` command.
+
+</details>
 
 **Security:** Never commit API keys to version control. Use environment-specific configuration.
 


### PR DESCRIPTION
## Summary

- use the npm package command for Gemini, OpenAI, and Seedream setup
- remove the repeated local checkout examples from the Codex, Cursor, and Claude Code sections
- keep one collapsed note for contributors who need to run a local build

## Checks

- git diff --check
- biome check src (pre-push hook)
- tsc (pre-push hook)