### PR TITLE
Fix image generation request and output handling for v0.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,14 +223,6 @@ Use an absolute path and make sure the MCP server can read the file. Input image
 
 Check the requested size in the provider table. `useGoogleSearch` works with Gemini only, and Seedream does not support 4K. For OpenAI permission errors, check your [organization settings](https://platform.openai.com/settings/organization/general). For quota or rate-limit errors, check the selected provider account.
 
-OpenAI preserves supported aspect ratios with dimensions rounded to 16-pixel increments. Ratios wider or taller than 3:1 (`1:4`, `1:8`, `4:1`, `8:1`) are rejected before generation. Near-square 4K requests are reduced to fit the provider's pixel limit.
-
-### Long-running requests and cancellation
-
-Your MCP client's tool timeout must allow enough time for prompt enhancement and image generation. Seedream image requests can run for up to 300 seconds, plus prompt enhancement time. Set your client's timeout above that combined duration when using this provider; the server cannot extend a client-side timeout.
-
-Cancelling a tool request stops subsequent generation stages and prevents saving a late provider response. The server also forwards cancellation to the active API request, although this cannot guarantee that the provider stops or refunds work it has already accepted.
-
 ## Image Generation Prompt Skill
 
 This repository also includes an [Agent Skill](https://agentskills.io) for assistants that already have access to an image generation tool. It teaches the prompt-writing approach used by mcp-image and works independently of this server.

--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ Use an absolute path and make sure the MCP server can read the file. Input image
 
 Check the requested size in the provider table. `useGoogleSearch` works with Gemini only, and Seedream does not support 4K. For OpenAI permission errors, check your [organization settings](https://platform.openai.com/settings/organization/general). For quota or rate-limit errors, check the selected provider account.
 
+OpenAI preserves supported aspect ratios with dimensions rounded to 16-pixel increments. Ratios wider or taller than 3:1 (`1:4`, `1:8`, `4:1`, `8:1`) are rejected before generation. Near-square 4K requests are reduced to fit the provider's pixel limit.
+
+### Long-running requests and cancellation
+
+Your MCP client's tool timeout must allow enough time for prompt enhancement and image generation. Seedream image requests can run for up to 300 seconds, plus prompt enhancement time. Set your client's timeout above that combined duration when using this provider; the server cannot extend a client-side timeout.
+
+Cancelling a tool request stops subsequent generation stages and prevents saving a late provider response. The server also forwards cancellation to the active API request, although this cannot guarantee that the provider stops or refunds work it has already accepted.
+
 ## Image Generation Prompt Skill
 
 This repository also includes an [Agent Skill](https://agentskills.io) for assistants that already have access to an image generation tool. It teaches the prompt-writing approach used by mcp-image and works independently of this server.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "packageManager": "pnpm@11.24.0",
   "description": "MCP server for AI image generation",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.13.1",
+  "version": "0.13.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -81,7 +81,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate).toHaveBeenCalledWith({
+      expect(mockGenerate.mock.calls[0]![0]).toEqual({
         model: 'gpt-image-2',
         prompt: 'Generate a beautiful landscape',
         n: 1,
@@ -122,7 +122,7 @@ describe('openaiImageClient', () => {
       expect(mockToFile).toHaveBeenCalledWith(Buffer.from('input-image-data'), 'input.png', {
         type: 'image/png',
       })
-      expect(mockEdit).toHaveBeenCalledWith({
+      expect(mockEdit.mock.calls[0]![0]).toEqual({
         model: 'gpt-image-2',
         prompt: 'Make this image warmer',
         image: { name: 'input.png', type: 'image/png' },
@@ -147,7 +147,7 @@ describe('openaiImageClient', () => {
         quality: 'balanced',
       })
 
-      expect(mockGenerate).toHaveBeenCalledWith(
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
           quality: 'medium',
         })
@@ -168,14 +168,14 @@ describe('openaiImageClient', () => {
         quality: 'quality',
       })
 
-      expect(mockGenerate).toHaveBeenCalledWith(
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
           quality: 'high',
         })
       )
     })
 
-    it('should map aspect ratio to closest OpenAI size', async () => {
+    it('should preserve a 16:9 aspect ratio at the default size', async () => {
       mockGenerate.mockResolvedValue({
         data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
@@ -189,14 +189,14 @@ describe('openaiImageClient', () => {
         aspectRatio: '16:9',
       })
 
-      expect(mockGenerate).toHaveBeenCalledWith(
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
-          size: '1536x1024',
+          size: '1536x864',
         })
       )
     })
 
-    it('should fall back to square size when aspect ratio is malformed', async () => {
+    it('should reject a malformed aspect ratio before calling OpenAI', async () => {
       mockGenerate.mockResolvedValue({
         data: [{ b64_json: PNG_BYTES.toString('base64') }],
       })
@@ -205,21 +205,44 @@ describe('openaiImageClient', () => {
       expect(clientResult.success).toBe(true)
       if (!clientResult.success) return
 
-      // 'abc:1' parses to NaN width — current behavior is silent fallback to square.
-      // Pinning this so future changes that promote it to a typed error are deliberate.
-      // 'abc:1' is not a valid AspectRatio union member; cast through unknown to
-      // exercise the runtime fallback branch in mapSize.
-      await clientResult.data.generateImage({
+      const result = await clientResult.data.generateImage({
         prompt: 'Generate an image',
         aspectRatio: 'abc:1' as unknown as never,
       })
 
-      expect(mockGenerate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          size: '1024x1024',
-        })
-      )
+      expect(result.success).toBe(false)
+      expect(mockGenerate).not.toHaveBeenCalled()
     })
+
+    it.each([
+      ['4:5', '1K'],
+      ['3:4', '2K'],
+      ['16:9', '2K'],
+      ['21:9', '4K'],
+      ['4:5', '4K'],
+      ['1:1', '4K'],
+    ] as const)(
+      'preserves %s at %s within provider dimension limits',
+      async (aspectRatio, imageSize) => {
+        mockGenerate.mockResolvedValue({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })
+        const clientResult = createOpenAIImageClient(testConfig)
+        if (!clientResult.success) throw clientResult.error
+        const result = await clientResult.data.generateImage({
+          prompt: 'test',
+          aspectRatio,
+          imageSize,
+        })
+        expect(result.success).toBe(true)
+        const [width, height] = mockGenerate.mock.calls[0]![0].size.split('x').map(Number)
+        const [ratioWidth, ratioHeight] = aspectRatio.split(':').map(Number)
+        expect(Math.abs(width / height - ratioWidth! / ratioHeight!)).toBeLessThan(0.025)
+        expect(width % 16).toBe(0)
+        expect(height % 16).toBe(0)
+        expect(Math.max(width, height)).toBeLessThanOrEqual(3840)
+        expect(width * height).toBeGreaterThanOrEqual(655360)
+        expect(width * height).toBeLessThanOrEqual(8294400)
+      }
+    )
 
     it('should return ImageAPIError when response data array is empty', async () => {
       mockGenerate.mockResolvedValue({ data: [] })
@@ -272,7 +295,9 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate).toHaveBeenCalledWith(expect.objectContaining({ output_format: 'jpeg' }))
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+        expect.objectContaining({ output_format: 'jpeg' })
+      )
       if (result.success) {
         expect(result.data.imageData).toEqual(JPEG_BYTES)
         expect(result.data.metadata.mimeType).toBe('image/jpeg')
@@ -295,7 +320,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockEdit).toHaveBeenCalledWith(expect.objectContaining({ output_format: 'jpeg' }))
+      expect(mockEdit.mock.calls[0]![0]).toEqual(expect.objectContaining({ output_format: 'jpeg' }))
     })
 
     it('should reject bytes that contradict the requested format', async () => {
@@ -331,7 +356,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate).toHaveBeenCalledWith(
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
           size: '2048x1152',
         })
@@ -354,7 +379,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate).toHaveBeenCalledWith(
+      expect(mockGenerate.mock.calls[0]![0]).toEqual(
         expect.objectContaining({
           size: '2160x3840',
         })

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -97,11 +97,17 @@ function isGeminiResponse(obj: unknown): obj is GeminiResponse {
   const response = obj as Record<string, unknown>
 
   if ('response' in response && response['response'] && typeof response['response'] === 'object') {
-    const innerResponse = response['response'] as Record<string, unknown>
-    return 'candidates' in innerResponse && Array.isArray(innerResponse['candidates'])
+    return isGeminiResponse(response['response'])
   }
 
-  return 'candidates' in response && Array.isArray(response['candidates'])
+  const feedback = response['promptFeedback']
+  return (
+    Array.isArray(response['candidates']) ||
+    (typeof feedback === 'object' &&
+      feedback !== null &&
+      'blockReason' in feedback &&
+      typeof feedback.blockReason === 'string')
+  )
 }
 
 class GeminiClientImpl implements ImageClient {
@@ -153,6 +159,7 @@ class GeminiClientImpl implements ImageClient {
       }
 
       const config: GenerateContentConfig = {
+        ...(params.signal && { abortSignal: params.signal }),
         ...(Object.keys(imageConfig).length > 0 && { imageConfig }),
         responseModalities: ['IMAGE'],
         ...(effectiveQuality === 'balanced' && {
@@ -319,6 +326,15 @@ class GeminiClientImpl implements ImageClient {
       }
 
       const imageBuffer = Buffer.from(imagePart.inlineData.data, 'base64')
+      if (imageBuffer.length === 0) {
+        return Err(
+          new GeminiAPIError('Gemini returned empty image data', {
+            provider: 'gemini',
+            stage: 'image_extraction',
+            suggestion: 'Retry the request; the provider returned no image bytes',
+          })
+        )
+      }
       const mimeType = normalizeMimeType(imagePart.inlineData.mimeType || DEFAULT_MIME_TYPE)
 
       const metadata: ImageGenerationMetadata = {
@@ -372,13 +388,17 @@ class GeminiClientImpl implements ImageClient {
     }
 
     return Err(
-      new GeminiAPIError('Failed to generate image with Gemini', {
-        provider: 'gemini',
-        prompt,
-        upstreamMessage: errorMessage,
-        suggestion:
-          'Check your API key, quota, and prompt validity. Try again with a different prompt',
-      })
+      new GeminiAPIError(
+        'Failed to generate image with Gemini',
+        {
+          provider: 'gemini',
+          prompt,
+          upstreamMessage: errorMessage,
+          suggestion:
+            'Check your API key, quota, and prompt validity. Try again with a different prompt',
+        },
+        extractStatusCode(error)
+      )
     )
   }
 

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -38,9 +38,11 @@ interface GeminiAIInstance {
       }
     }): Promise<{
       text: string
+      candidates?: Array<{ finishReason?: string }>
       response?: {
         text?: () => string
         candidates?: Array<{
+          finishReason?: string
           content: {
             parts: Array<{ text: string }>
           }
@@ -84,6 +86,7 @@ class GeminiTextClientImpl implements GeminiTextClient {
 
   private async callGeminiAPI(prompt: string, config: GenerationConfig): Promise<string> {
     try {
+      const timeoutSignal = AbortSignal.timeout(config.timeout || 15000)
       let contents:
         | string
         | Array<{
@@ -125,9 +128,16 @@ class GeminiTextClientImpl implements GeminiTextClient {
           thinkingConfig: {
             thinkingBudget: 0,
           },
-          abortSignal: AbortSignal.timeout(config.timeout || 15000),
+          abortSignal: config.signal
+            ? AbortSignal.any([config.signal, timeoutSignal])
+            : timeoutSignal,
         },
       })
+
+      const candidate = response.candidates?.[0] ?? response.response?.candidates?.[0]
+      if (candidate?.finishReason === 'MAX_TOKENS') {
+        throw new Error('Gemini text generation was truncated at the token limit')
+      }
 
       let responseText: string
       if (typeof response.text === 'string') {

--- a/src/api/imageClient.ts
+++ b/src/api/imageClient.ts
@@ -16,6 +16,7 @@ export interface ImageGenerationMetadata {
 
 export interface ImageApiParams {
   prompt: string
+  signal?: AbortSignal
   inputImage?: string
   inputImageMimeType?: string
   aspectRatio?: AspectRatio

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -5,6 +5,7 @@ import type {
   ImagesResponse,
 } from 'openai/resources/images'
 import type { ImageOutputFormat, ImageQuality } from '../types/mcp.js'
+import { ASPECT_RATIO_VALUES } from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
@@ -18,16 +19,7 @@ import {
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
-type OpenAIImageSize =
-  | '1024x1024'
-  | '1536x1024'
-  | '1024x1536'
-  | '2048x2048'
-  | '2048x1152'
-  | '1152x2048'
-  | '2880x2880'
-  | '3840x2160'
-  | '2160x3840'
+type OpenAIImageSize = `${number}x${number}`
 type OpenAIImageQuality = 'low' | 'medium' | 'high'
 // The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
 // enumerate the older fixed GPT image sizes. Keep the request cast local to this file.
@@ -46,55 +38,16 @@ function mapQuality(quality: ImageQuality): OpenAIImageQuality {
   }
 }
 
-function getOrientation(params: ImageApiParams): 'square' | 'landscape' | 'portrait' {
-  if (!params.aspectRatio) {
-    return 'square'
-  }
-
-  const [widthRaw, heightRaw] = params.aspectRatio.split(':')
-  const width = Number(widthRaw)
-  const height = Number(heightRaw)
-
-  if (!Number.isFinite(width) || !Number.isFinite(height) || width === height) {
-    return 'square'
-  }
-
-  return width > height ? 'landscape' : 'portrait'
-}
-
 function mapSize(params: ImageApiParams): OpenAIImageSize {
-  const orientation = getOrientation(params)
-
-  if (params.imageSize === '2K') {
-    switch (orientation) {
-      case 'landscape':
-        return '2048x1152'
-      case 'portrait':
-        return '1152x2048'
-      case 'square':
-        return '2048x2048'
-    }
-  }
-
-  if (params.imageSize === '4K') {
-    switch (orientation) {
-      case 'landscape':
-        return '3840x2160'
-      case 'portrait':
-        return '2160x3840'
-      case 'square':
-        return '2880x2880'
-    }
-  }
-
-  switch (orientation) {
-    case 'landscape':
-      return '1536x1024'
-    case 'portrait':
-      return '1024x1536'
-    case 'square':
-      return '1024x1024'
-  }
+  const [width = 1, height = 1] = (params.aspectRatio ?? '1:1').split(':').map(Number)
+  const ratio = Math.max(width, height) / Math.min(width, height)
+  const requestedEdge =
+    params.imageSize === '4K' ? 3840 : params.imageSize === '2K' ? 2048 : ratio === 1 ? 1024 : 1536
+  // GPT Image 2: 16px increments, at most 3840px per edge and 8,294,400 pixels.
+  // Flooring keeps the pixel cap intact even for near-square 4K requests.
+  const longEdge = Math.floor(Math.min(requestedEdge, Math.sqrt(8_294_400 * ratio)) / 16) * 16
+  const shortEdge = Math.floor(longEdge / ratio / 16) * 16
+  return width >= height ? `${longEdge}x${shortEdge}` : `${shortEdge}x${longEdge}`
 }
 
 function mimeTypeToExtension(mimeType: string): string {
@@ -114,7 +67,9 @@ function hasInputImage(params: ImageApiParams): params is ImageEditApiParams {
   return typeof params.inputImage === 'string' && params.inputImage.length > 0
 }
 
-function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIError> {
+export function validateOpenAIOptions(
+  params: Pick<ImageApiParams, 'useGoogleSearch' | 'aspectRatio'>
+): Result<true, ImageAPIError> {
   if (params.useGoogleSearch) {
     return Err(
       new ImageAPIError(
@@ -122,6 +77,21 @@ function validateOpenAIOptions(params: ImageApiParams): Result<true, ImageAPIErr
         'Disable useGoogleSearch or use IMAGE_PROVIDER=gemini for Google Search grounding'
       )
     )
+  }
+
+  if (params.aspectRatio !== undefined) {
+    const [width = 0, height = 0] = params.aspectRatio.split(':').map(Number)
+    if (
+      !ASPECT_RATIO_VALUES.includes(params.aspectRatio) ||
+      Math.max(width, height) / Math.min(width, height) > 3
+    ) {
+      return Err(
+        new ImageAPIError(
+          'Unsupported OpenAI image aspect ratio',
+          'Use a supported aspect ratio between 1:3 and 3:1'
+        )
+      )
+    }
   }
 
   return Ok(true)
@@ -210,7 +180,9 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return await this.client.images.generate(request as unknown as OpenAIImageGenerateRequest)
+    return await this.client.images.generate(request as unknown as OpenAIImageGenerateRequest, {
+      ...(params.signal && { signal: params.signal }),
+    })
   }
 
   private async editImage(
@@ -236,7 +208,9 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return await this.client.images.edit(request as unknown as OpenAIImageEditRequest)
+    return await this.client.images.edit(request as unknown as OpenAIImageEditRequest, {
+      ...(params.signal && { signal: params.signal }),
+    })
   }
 
   private handleError(error: unknown, prompt: string): Result<never, ImageAPIError | NetworkError> {

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -48,6 +48,7 @@ class OpenAITextClientImpl implements TextClient {
     const timeout = config.timeout ?? 30000
 
     try {
+      const timeoutSignal = AbortSignal.timeout(timeout)
       const response = (await this.client.responses.create(
         {
           model: this.modelName,
@@ -57,7 +58,7 @@ class OpenAITextClientImpl implements TextClient {
           temperature: config.temperature ?? 0.7,
           top_p: config.topP ?? 0.95,
         },
-        { signal: AbortSignal.timeout(timeout) }
+        { signal: config.signal ? AbortSignal.any([config.signal, timeoutSignal]) : timeoutSignal }
       )) as OpenAITextResponse
 
       if (response.status === 'incomplete') {

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -339,6 +339,7 @@ class SeedreamImageClientImpl implements ImageClient {
     const request = buildWireRequest(params, resolvedResult.data)
 
     try {
+      const timeoutSignal = AbortSignal.timeout(SEEDREAM_IMAGE_TIMEOUT_MS)
       const response = await fetch(SEEDREAM_IMAGE_ENDPOINT, {
         method: 'POST',
         headers: {
@@ -346,7 +347,7 @@ class SeedreamImageClientImpl implements ImageClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(request),
-        signal: AbortSignal.timeout(SEEDREAM_IMAGE_TIMEOUT_MS),
+        signal: params.signal ? AbortSignal.any([params.signal, timeoutSignal]) : timeoutSignal,
       })
 
       if (!response.ok) {

--- a/src/api/seedreamTextClient.ts
+++ b/src/api/seedreamTextClient.ts
@@ -54,8 +54,9 @@ class SeedreamTextClientImpl implements TextClient {
     }
 
     try {
+      const timeoutSignal = AbortSignal.timeout(config.timeout ?? DEFAULT_TEXT_TIMEOUT)
       const response = await this.client.responses.create(request, {
-        signal: AbortSignal.timeout(config.timeout ?? DEFAULT_TEXT_TIMEOUT),
+        signal: config.signal ? AbortSignal.any([config.signal, timeoutSignal]) : timeoutSignal,
       })
       const responseText = response.output_text
 

--- a/src/api/textClient.ts
+++ b/src/api/textClient.ts
@@ -4,6 +4,7 @@ import type { GeminiAPIError, ImageAPIError, NetworkError } from '../utils/error
 export const MAX_TEXT_PROMPT_LENGTH = 100_000
 
 export interface GenerationConfig {
+  signal?: AbortSignal
   temperature?: number
   maxTokens?: number
   timeout?: number

--- a/src/business/fileManager.ts
+++ b/src/business/fileManager.ts
@@ -126,7 +126,18 @@ export async function saveImage(
       return Err(dirResult.error)
     }
 
-    await fs.writeFile(outputPath, imageData)
+    const fileHandle = await fs.open(
+      outputPath,
+      fsConstants.O_WRONLY |
+        fsConstants.O_CREAT |
+        fsConstants.O_TRUNC |
+        (typeof fsConstants.O_NOFOLLOW === 'number' ? fsConstants.O_NOFOLLOW : 0)
+    )
+    try {
+      await fileHandle.writeFile(imageData)
+    } finally {
+      await fileHandle.close()
+    }
     return Ok(outputPath)
   } catch (error) {
     return Err(

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -1,7 +1,12 @@
 import { existsSync } from 'node:fs'
 import { extname } from 'node:path'
 import type { GenerateImageParams } from '../types/mcp.js'
-import { ASPECT_RATIO_VALUES, IMAGE_PROVIDER_VALUES, IMAGE_QUALITY_VALUES } from '../types/mcp.js'
+import {
+  ASPECT_RATIO_VALUES,
+  IMAGE_PROVIDER_VALUES,
+  IMAGE_QUALITY_VALUES,
+  IMAGE_SIZE_VALUES,
+} from '../types/mcp.js'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import { InputValidationError } from '../utils/errors.js'
@@ -18,7 +23,15 @@ function formatFileSize(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1)
 }
 
-export function validatePrompt(prompt: string): Result<string, InputValidationError> {
+export function validatePrompt(prompt: unknown): Result<string, InputValidationError> {
+  if (typeof prompt !== 'string') {
+    return Err(
+      new InputValidationError(
+        'Prompt must be a non-empty string',
+        'Please provide a descriptive prompt for image generation.'
+      )
+    )
+  }
   if (prompt.length < PROMPT_MIN_LENGTH || prompt.length > PROMPT_MAX_LENGTH) {
     return Err(
       new InputValidationError(
@@ -26,6 +39,15 @@ export function validatePrompt(prompt: string): Result<string, InputValidationEr
         prompt.length === 0
           ? 'Please provide a descriptive prompt for image generation.'
           : `Please shorten your prompt by ${prompt.length - PROMPT_MAX_LENGTH} characters.`
+      )
+    )
+  }
+
+  if (prompt.trim().length === 0) {
+    return Err(
+      new InputValidationError(
+        'Prompt must be a non-empty string',
+        'Please provide a descriptive prompt for image generation.'
       )
     )
   }
@@ -116,8 +138,39 @@ function validateImagePath(imagePath?: string): Result<string | undefined, Input
 }
 
 export function validateGenerateImageParams(
-  params: GenerateImageParams
+  input: unknown
 ): Result<GenerateImageParams, InputValidationError> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return Err(
+      new InputValidationError(
+        'Tool arguments must be an object',
+        'Provide an object containing a prompt and optional image parameters'
+      )
+    )
+  }
+  for (const field of [
+    'fileName',
+    'inputImagePath',
+    'purpose',
+    'inputImage',
+    'inputImageMimeType',
+    'aspectRatio',
+    'imageSize',
+    'quality',
+    'provider',
+  ] as const) {
+    const value = (input as Record<string, unknown>)[field]
+    if (value !== undefined && typeof value !== 'string') {
+      return Err(
+        new InputValidationError(
+          `${field} must be a string`,
+          `Provide a string for ${field} or omit it`
+        )
+      )
+    }
+  }
+  // The remaining required string, boolean, and enum fields are checked below.
+  const params = input as GenerateImageParams
   const promptResult = validatePrompt(params.prompt)
   if (!promptResult.success) {
     return Err(promptResult.error)
@@ -174,7 +227,16 @@ export function validateGenerateImageParams(
     }
   }
 
-  if (params.aspectRatio && !SUPPORTED_ASPECT_RATIOS.includes(params.aspectRatio)) {
+  if (params.imageSize !== undefined && !IMAGE_SIZE_VALUES.includes(params.imageSize)) {
+    return Err(
+      new InputValidationError(
+        `Invalid image size: ${params.imageSize}`,
+        `Use one of: ${IMAGE_SIZE_VALUES.join(', ')}`
+      )
+    )
+  }
+
+  if (params.aspectRatio !== undefined && !SUPPORTED_ASPECT_RATIOS.includes(params.aspectRatio)) {
     return Err(
       new InputValidationError(
         `Invalid aspect ratio: ${params.aspectRatio}. Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`,

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import type { GeneratedImageResult } from '../api/imageClient.js'
 import type { McpToolResponse, ResourceContent } from '../types/mcp.js'
 import { BaseError } from '../utils/errors.js'
@@ -30,10 +31,8 @@ const SAFE_CONTEXT_KEYS = ['provider', 'stage', 'statusCode'] as const
  * inclusion in caller-visible error responses. The upstream API message is
  * passed through the logger's redaction patterns before exposure.
  */
-function buildPublicDetails(
-  context: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined {
-  if (!context) return undefined
+function buildPublicDetails(error: BaseError): Record<string, unknown> | undefined {
+  const context = error.context ?? {}
 
   const details: Record<string, unknown> = {}
 
@@ -41,6 +40,12 @@ function buildPublicDetails(
     if (context[key] !== undefined) {
       details[key] = context[key]
     }
+  }
+
+  const statusCode =
+    context['statusCode'] ?? Reflect.get(error, 'statusCode') ?? context['upstreamStatus']
+  if (typeof statusCode === 'number') {
+    details['statusCode'] = statusCode
   }
 
   if (typeof context['upstreamMessage'] === 'string') {
@@ -73,7 +78,7 @@ function convertErrorToStructured(
   }
 
   if (error instanceof BaseError) {
-    const details = buildPublicDetails(error.context)
+    const details = buildPublicDetails(error)
     return {
       ...baseError,
       code: error.code,
@@ -101,7 +106,7 @@ export function buildSuccessResponse(
   const resourceContent: ResourceContent = {
     type: 'resource',
     resource: {
-      uri: `file://${filePath}`,
+      uri: pathToFileURL(filePath).href,
       name: fileName,
       mimeType,
     },

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -50,7 +50,8 @@ export interface StructuredPromptGenerator {
     features?: FeatureFlags,
     inputImageData?: string,
     purpose?: string,
-    inputImageMimeType?: string
+    inputImageMimeType?: string,
+    signal?: AbortSignal
   ): Promise<Result<string, Error>>
 }
 
@@ -65,7 +66,8 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
     features: FeatureFlags = {},
     inputImageData?: string,
     purpose?: string,
-    inputImageMimeType?: string
+    inputImageMimeType?: string,
+    signal?: AbortSignal
   ): Promise<Result<string, Error>> {
     try {
       if (!userPrompt || userPrompt.trim().length === 0) {
@@ -84,6 +86,7 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
         : SYSTEM_PROMPT
 
       const config = {
+        ...(signal && { signal }),
         temperature: 0.7,
         maxTokens: this.maxTokens,
         systemInstruction,

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -853,7 +853,12 @@ describe('BytePlus Seedream integration', () => {
       .map(([size]) => size)
 
     expect.soft(exactResult.isError, 'exact-limit').toBe(false)
-    expect.soft(fileSystem.open, 'exact-limit').toHaveBeenCalledTimes(1)
+    expect
+      .soft(
+        fileSystem.open.mock.calls.filter(([, flags]) => flags === expectedInputOpenFlags),
+        'exact-limit:one input open'
+      )
+      .toHaveLength(1)
     expect
       .soft(fileSystem.open, 'exact-limit')
       .toHaveBeenCalledWith(expect.stringMatching(/\/exact-limit\.png$/), expectedInputOpenFlags)

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -36,8 +36,10 @@ vi.mock('../../api/geminiClient', () => {
   }
 })
 
-vi.mock('../../api/openaiImageClient', () => {
+vi.mock('../../api/openaiImageClient', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../api/openaiImageClient.js')>()
   return {
+    ...original,
     createOpenAIImageClient: vi.fn().mockImplementation(() => {
       const mockClient = {
         generateImage: vi.fn().mockImplementation((params) => {

--- a/src/server/__tests__/requestBoundaries.int.test.ts
+++ b/src/server/__tests__/requestBoundaries.int.test.ts
@@ -1,0 +1,340 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ImageProvider } from '../../types/mcp.js'
+import { MCPServerImpl } from '../mcpServer.js'
+
+const PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jB1kAAAAASUVORK5CYII=',
+  'base64'
+)
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', 'x-should-retry': 'false' },
+  })
+}
+
+function imageResponse(provider: ImageProvider): Response {
+  return jsonResponse(
+    provider === 'gemini'
+      ? {
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { data: PNG.toString('base64'), mimeType: 'image/png' } }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        }
+      : { data: [{ b64_json: PNG.toString('base64') }] }
+  )
+}
+
+function textResponse(provider: ImageProvider): Response {
+  return jsonResponse(
+    provider === 'gemini'
+      ? {
+          candidates: [{ content: { parts: [{ text: 'enhanced prompt' }] }, finishReason: 'STOP' }],
+        }
+      : {
+          id: 'test-response',
+          object: 'response',
+          status: 'completed',
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'enhanced prompt', annotations: [] }],
+            },
+          ],
+        }
+  )
+}
+
+describe('request and output boundaries', () => {
+  let outputDir: string
+  let impl: MCPServerImpl
+  let server: ReturnType<MCPServerImpl['initialize']>
+  let client: Client
+  const fetchMock = vi.fn<typeof fetch>()
+
+  beforeEach(async () => {
+    await mkdir(resolve('tmp'), { recursive: true })
+    outputDir = await mkdtemp(resolve('tmp/request-boundaries-'))
+    vi.stubEnv('IMAGE_OUTPUT_DIR', outputDir)
+    vi.stubEnv('IMAGE_PROVIDER', 'openai')
+    vi.stubEnv('IMAGE_QUALITY', 'fast')
+    vi.stubEnv('GEMINI_API_KEY', 'test-gemini-key')
+    vi.stubEnv('OPENAI_API_KEY', 'test-openai-key')
+    vi.stubEnv('ARK_API_KEY', 'test-ark-key')
+    vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', 'true')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockReset().mockImplementation(async () => imageResponse('openai'))
+    vi.stubGlobal('fetch', fetchMock)
+    impl = new MCPServerImpl()
+    server = impl.initialize()
+    client = new Client({ name: 'boundary-test', version: '1' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)])
+  })
+
+  afterEach(async () => {
+    await client.close()
+    await server.close()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    await rm(outputDir, { recursive: true, force: true })
+  })
+
+  it.each([
+    {},
+    { prompt: 123 },
+    { prompt: '   ' },
+    { prompt: 'test', imageSize: '8K' },
+    { prompt: 'test', imageSize: null },
+    { prompt: 'test', purpose: { x: 1 } },
+    { prompt: 'test', fileName: 42 },
+    { prompt: 'test', inputImagePath: null },
+    { prompt: 'test', aspectRatio: '' },
+    { prompt: 'test', imageSize: { toString: null } },
+  ])('rejects invalid arguments before any provider request: %j', async (args) => {
+    const result = await client.callTool({ name: 'generate_image', arguments: args })
+    expect(result.isError).toBe(true)
+    expect(JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error.code).toBe(
+      'INPUT_VALIDATION_ERROR'
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(await readdir(outputDir)).toEqual([])
+  })
+
+  it.each([{ useGoogleSearch: true }, { aspectRatio: '8:1' }, { fileName: 'draft..png' }])(
+    'preflights deterministic failures before enhancement: %j',
+    async (options) => {
+      vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', 'false')
+      const result = await client.callTool({
+        name: 'generate_image',
+        arguments: { prompt: 'test', ...options },
+      })
+      expect(result.isError).toBe(true)
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(await readdir(outputDir)).toEqual([])
+    }
+  )
+
+  it('preserves the complete original prompt when Gemini enhancement is truncated', async () => {
+    vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', 'false')
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          candidates: [
+            { content: { parts: [{ text: 'partial enhancement' }] }, finishReason: 'MAX_TOKENS' },
+          ],
+        })
+      )
+      .mockImplementation(async () => imageResponse('gemini'))
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: {
+        provider: 'gemini',
+        prompt: 'complete original instructions',
+        fileName: 'fallback.png',
+      },
+    })
+    expect(result.isError).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const imageRequest = JSON.parse(fetchMock.mock.calls[1]![1]!.body as string)
+    expect(imageRequest.contents[0].parts[0].text).toBe('complete original instructions')
+    expect(await readFile(resolve(outputDir, 'fallback.png'))).toEqual(PNG)
+  })
+
+  it('does not save a Gemini response that decodes to an empty buffer', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        candidates: [
+          {
+            content: { parts: [{ inlineData: { data: '!!!', mimeType: 'image/png' } }] },
+            finishReason: 'STOP',
+          },
+        ],
+      })
+    )
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: { provider: 'gemini', prompt: 'test' },
+    })
+    expect(result.isError).toBe(true)
+    expect(await readdir(outputDir)).toEqual([])
+  })
+
+  it('identifies Gemini prompt blocking when candidates are omitted', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ promptFeedback: { blockReason: 'SAFETY' } }))
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: { provider: 'gemini', prompt: 'test' },
+    })
+    const error = JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error
+    expect(result.isError).toBe(true)
+    expect(error.suggestion).toContain('Rephrase')
+    expect(error.details.stage).toBe('prompt_analysis')
+  })
+
+  it.each([401, 429, 503])(
+    'preserves Seedream HTTP %i without exposing the response body',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'private upstream body' }, status))
+      const result = await client.callTool({
+        name: 'generate_image',
+        arguments: { provider: 'seedream', prompt: 'private prompt' },
+      })
+      const text = (result.content as Array<{ text: string }>)[0]!.text
+      expect(result.isError).toBe(true)
+      expect(JSON.parse(text).error.details.statusCode).toBe(status)
+      expect(text).not.toContain('private')
+      expect(await readdir(outputDir)).toEqual([])
+    }
+  )
+
+  it('returns a URI that resolves to the exact saved special-character filename', async () => {
+    const fileName = '画像 #1?50%.png'
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: { prompt: 'test', fileName },
+    })
+    expect(result.isError).toBe(false)
+    const uri = JSON.parse((result.content as Array<{ text: string }>)[0]!.text).resource.uri
+    expect(fileURLToPath(uri)).toBe(resolve(outputDir, fileName))
+    expect(await readFile(fileURLToPath(uri))).toEqual(PNG)
+  })
+
+  it.each(['gemini', 'openai'] as const)(
+    'preserves %s HTTP status in public errors',
+    async (provider) => {
+      fetchMock.mockImplementation(async () =>
+        jsonResponse(
+          { error: { code: 503, message: 'Service unavailable', status: 'UNAVAILABLE' } },
+          503
+        )
+      )
+      const result = await client.callTool({
+        name: 'generate_image',
+        arguments: { provider, prompt: 'test' },
+      })
+      expect(result.isError).toBe(true)
+      expect(
+        JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error.details.statusCode
+      ).toBe(503)
+    }
+  )
+
+  it('still replaces an ordinary output file without retaining its old trailing bytes', async () => {
+    const outputPath = resolve(outputDir, 'existing.png')
+    await writeFile(outputPath, Buffer.alloc(512))
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: { prompt: 'test', fileName: 'existing.png' },
+    })
+    expect(result.isError).toBe(false)
+    expect(await readFile(outputPath)).toEqual(PNG)
+  })
+
+  it('leaves a symlink target unchanged when saving a generated image', async () => {
+    const target = resolve(outputDir, 'original.txt')
+    await writeFile(target, 'original content')
+    await symlink(target, resolve(outputDir, 'output.png'))
+    const result = await client.callTool({
+      name: 'generate_image',
+      arguments: { prompt: 'test', fileName: 'output.png' },
+    })
+    expect(result.isError).toBe(true)
+    expect(await readFile(target, 'utf8')).toBe('original content')
+  })
+
+  it.each(['gemini', 'openai', 'seedream'] as const)(
+    'propagates cancellation during %s enhancement without fallback or saving',
+    async (provider) => {
+      await checkCancellation(provider, 'text')
+    }
+  )
+
+  it.each(['gemini', 'openai', 'seedream'] as const)(
+    'propagates cancellation during %s generation and does not save a late response',
+    async (provider) => {
+      await checkCancellation(provider, 'image')
+    }
+  )
+
+  it('propagates cancellation to the OpenAI editing endpoint', async () => {
+    const inputImagePath = resolve(outputDir, 'input.png')
+    await writeFile(inputImagePath, PNG)
+    await checkCancellation('openai', 'image', inputImagePath)
+  })
+
+  async function checkCancellation(
+    provider: ImageProvider,
+    stage: 'text' | 'image',
+    inputImagePath?: string
+  ) {
+    vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', String(stage !== 'text'))
+    let release!: () => void
+    let started!: () => void
+    let upstreamSignal: AbortSignal | null | undefined
+    const held = new Promise<void>((done) => {
+      release = done
+    })
+    const entered = new Promise<void>((done) => {
+      started = done
+    })
+    fetchMock.mockImplementation(async (url, options) => {
+      // The installed OpenAI SDK checks FormData support with a local data URL.
+      if (String(url) === 'data:,') return new Response('')
+      upstreamSignal = options?.signal
+      started()
+      await held
+      return stage === 'text' ? textResponse(provider) : imageResponse(provider)
+    })
+    const execution = vi.spyOn(impl, 'callTool')
+    const controller = new AbortController()
+    const call = client
+      .callTool(
+        {
+          name: 'generate_image',
+          arguments: {
+            provider,
+            prompt: 'test',
+            fileName: 'cancelled.png',
+            ...(inputImagePath && { inputImagePath }),
+          },
+        },
+        CallToolResultSchema,
+        { signal: controller.signal }
+      )
+      .catch((error: unknown) => error)
+    try {
+      await entered
+      controller.abort()
+      expect(await call).toBeInstanceOf(Error)
+      // Let the in-memory transport deliver notifications/cancelled.
+      await new Promise<void>((done) => setImmediate(done))
+      const forwarded = upstreamSignal?.aborted
+      release()
+      await execution.mock.results[0]!.value
+      expect(forwarded).toBe(true)
+      const apiCalls = fetchMock.mock.calls.filter(([url]) => String(url) !== 'data:,')
+      expect(apiCalls).toHaveLength(1)
+      if (inputImagePath) expect(String(apiCalls[0]![0])).toMatch(/\/images\/edits$/)
+      expect(await readdir(outputDir)).toEqual(inputImagePath ? ['input.png'] : [])
+    } finally {
+      release()
+      await call
+      await execution.mock.results[0]?.value
+    }
+  }
+})

--- a/src/server/imageProviderRegistry.ts
+++ b/src/server/imageProviderRegistry.ts
@@ -1,7 +1,7 @@
 import { createGeminiClient } from '../api/geminiClient.js'
 import { createGeminiTextClient } from '../api/geminiTextClient.js'
 import type { ImageApiParams, ImageClient } from '../api/imageClient.js'
-import { createOpenAIImageClient } from '../api/openaiImageClient.js'
+import { createOpenAIImageClient, validateOpenAIOptions } from '../api/openaiImageClient.js'
 import { createOpenAITextClient } from '../api/openaiTextClient.js'
 import {
   createSeedreamImageClient,
@@ -41,6 +41,9 @@ const IMAGE_PROVIDERS = {
     promptGeneration: { maxTokens: 1000 },
     createTextClient: (config) => unwrap(createOpenAITextClient(config)),
     createImageClient: (config) => unwrap(createOpenAIImageClient(config)),
+    validateImageOptions: (options) => {
+      unwrap(validateOpenAIOptions(options))
+    },
   },
   seedream: {
     promptGeneration: { maxTokens: 384 },

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -16,7 +16,7 @@ import {
   type FeatureFlags,
   type StructuredPromptGenerator,
 } from '../business/structuredPromptGenerator.js'
-import type { GenerateImageParams, ImageProvider, MCPServerConfig } from '../types/mcp.js'
+import type { ImageProvider, MCPServerConfig } from '../types/mcp.js'
 import {
   ASPECT_RATIO_VALUES,
   IMAGE_PROVIDER_VALUES,
@@ -123,7 +123,7 @@ export class MCPServerImpl {
               aspectRatio: {
                 type: 'string' as const,
                 description:
-                  'Set the requested output aspect ratio. Omit to use the provider default.',
+                  'Set the requested output aspect ratio. Omit to use the provider default. OpenAI does not support 1:4, 1:8, 4:1, or 8:1.',
                 enum: [...ASPECT_RATIO_VALUES],
               },
               imageSize: {
@@ -157,10 +157,10 @@ export class MCPServerImpl {
     }
   }
 
-  public async callTool(name: string, args: unknown) {
+  public async callTool(name: string, args: unknown, signal?: AbortSignal) {
     try {
       if (name === 'generate_image') {
-        return await this.handleGenerateImage(args as GenerateImageParams)
+        return await this.handleGenerateImage(args, signal)
       }
       throw new Error(`Unknown tool: ${name}`)
     } catch (error) {
@@ -204,12 +204,14 @@ export class MCPServerImpl {
     return clients
   }
 
-  private async handleGenerateImage(params: GenerateImageParams) {
+  private async handleGenerateImage(args: unknown, signal?: AbortSignal) {
     const result = await ErrorHandler.wrapWithResultType(async () => {
-      const validationResult = validateGenerateImageParams(params)
+      signal?.throwIfAborted()
+      const validationResult = validateGenerateImageParams(args)
       if (!validationResult.success) {
         throw validationResult.error
       }
+      const params = validationResult.data
 
       const sanitizedFileName = params.fileName
         ? this.securityManager.sanitizeFilename(params.fileName)
@@ -221,6 +223,13 @@ export class MCPServerImpl {
         throw configResult.error
       }
       const config = configResult.data
+
+      const outputPreflight = this.securityManager.sanitizeFilePath(
+        path.join(config.imageOutputDir, sanitizedFileName ?? 'image.png')
+      )
+      if (!outputPreflight.success) {
+        throw outputPreflight.error
+      }
 
       const providerName = params.provider ?? config.imageProvider
       const credentialsResult = validateProviderCredentials(config, providerName)
@@ -256,6 +265,7 @@ export class MCPServerImpl {
       } satisfies Omit<ImageApiParams, 'prompt'>
 
       provider.validateImageOptions?.(imageOptions, config)
+      signal?.throwIfAborted()
 
       let structuredPrompt = params.prompt
       if (!config.skipPromptEnhancement && structuredPromptGenerator) {
@@ -274,8 +284,10 @@ export class MCPServerImpl {
           features,
           inputImageData,
           params.purpose,
-          inputImageMimeType
+          inputImageMimeType,
+          signal
         )
+        signal?.throwIfAborted()
 
         if (promptResult.success) {
           structuredPrompt = promptResult.data
@@ -296,7 +308,9 @@ export class MCPServerImpl {
       const generationResult = await imageClient.generateImage({
         prompt: structuredPrompt,
         ...imageOptions,
+        ...(signal && { signal }),
       })
+      signal?.throwIfAborted()
 
       if (!generationResult.success) {
         throw generationResult.error
@@ -374,9 +388,9 @@ export class MCPServerImpl {
 
     this.server.setRequestHandler(
       CallToolRequestSchema,
-      async (request): Promise<CallToolResult> => {
+      async (request, { signal }): Promise<CallToolResult> => {
         const { name, arguments: args } = request.params
-        const result = await this.callTool(name, args)
+        const result = await this.callTool(name, args, signal)
         const response: CallToolResult = {
           content: result.content,
           isError: result.isError,


### PR DESCRIPTION
## Summary

Image generation could continue after cancellation, send invalid requests to providers, overwrite symlink targets, or return misleading results for provider failures and requested aspect ratios. This change fixes those request and output boundaries and bumps the package and MCP registry versions to 0.13.2.

- Forward MCP cancellation through prompt enhancement and image generation, and stop subsequent stages and saving when cancellation is observed.
- Validate runtime arguments and known output/provider restrictions before API calls; reject final output symlinks while preserving ordinary file overwrite behavior.
- Map OpenAI image dimensions to the requested aspect ratio within provider limits. Fall back to the original prompt when Gemini enhancement is truncated, reject empty Gemini image data, and handle blocked prompts without candidates.
- Encode file resource URIs correctly and preserve available upstream HTTP status codes in public errors.

## User-visible changes

OpenAI output dimensions now follow supported aspect ratios, rounded to 16-pixel increments. Near-square 4K requests are reduced to fit the pixel limit. OpenAI ratios `1:4`, `1:8`, `4:1`, and `8:1` now fail before generation instead of silently producing a different ratio.

## Validation

- `pnpm run check:all`: passed, including 340 tests across 20 files, TypeScript build, lint, unused-code checks, and circular-dependency checks.
- Added integration coverage using the real MCP/provider SDKs with mocked HTTP responses and real filesystem operations, including cancellation, image editing, error responses, URI encoding, overwrite behavior, and symlink protection.
- User-reported live MCP smoke test: OpenAI / `gpt-image-2`, `4:5` and `4K`, successfully saved a 2560 × 3216 PNG, matching the expected mapped dimensions.
- Confirmed package.json, server.json, and its npm package entry all declare 0.13.2.

Live-client cancellation was not manually verified; automated coverage verifies propagation and suppression of late output. The existing `processingTime: 0` metadata remains unchanged.

