### PR TITLE
chore: tighten Biome ruleset and resolve all violations

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.11/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "formatter": {
     "enabled": true,
@@ -12,29 +12,54 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "complexity": {
+        "useLiteralKeys": "off",
+        "noVoid": "error",
+        "useMaxParams": {
+          "level": "error",
+          "options": {
+            "max": 4
+          }
+        },
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        }
+      },
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "error",
+        "useBlockStatements": "error",
+        "noNestedTernary": "error",
+        "useErrorCause": "error",
+        "useThrowOnlyError": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn"
+        "noExplicitAny": "error",
+        "noUnnecessaryConditions": "error",
+        "noShadow": "error",
+        "noEvolvingTypes": "error",
+        "noImplicitAnyLet": "error",
+        "noTsIgnore": "error",
+        "useErrorMessage": "error"
       },
-      "complexity": {
-        "useLiteralKeys": "off"
+      "correctness": {
+        "noUndeclaredDependencies": "error"
+      },
+      "nursery": {
+        "noFloatingPromises": "error",
+        "noMisusedPromises": "error",
+        "useAwaitThenable": "error",
+        "useExplicitReturnType": "error",
+        "useExhaustiveSwitchCases": "error",
+        "noUnsafeTypeAssertion": "error",
+        "noBaseToString": "error",
+        "noMisleadingReturnType": "off",
+        "noExcessiveNestedCallbacks": "error"
       }
     }
   },
-  "overrides": [
-    {
-      "includes": ["**/__tests__/**/*.ts", "**/*.test.ts", "**/*.spec.ts"],
-      "linter": {
-        "rules": {
-          "suspicious": {
-            "noExplicitAny": "off"
-          }
-        }
-      }
-    }
-  ],
   "javascript": {
     "formatter": {
       "semicolons": "asNeeded",
@@ -43,6 +68,6 @@
     }
   },
   "files": {
-    "includes": ["**/src/**/*.ts", "**/src/**/*.js", "!**/node_modules/**", "!**/dist/**"]
+    "includes": ["**/src/**/*.ts", "**/src/**/*.js", "!**/node_modules", "!**/dist"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "packageManager": "pnpm@11.24.0",
   "description": "MCP server for AI image generation",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.13.2",
+  "version": "0.13.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/api/__tests__/geminiClient.test.ts
+++ b/src/api/__tests__/geminiClient.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { errorWithCode } from '../../tests/helpers/inspect'
 import type { Config } from '../../utils/config'
 import { GeminiAPIError, NetworkError } from '../../utils/errors'
 import { createGeminiClient } from '../geminiClient'
@@ -19,7 +20,7 @@ vi.mock('@google/genai', async (importActual) => {
     ...actual,
     GoogleGenAI: class {
       models = mockGeminiClientInstance.models
-      constructor(...args: any[]) {
+      constructor(...args: unknown[]) {
         mockGoogleGenAI(...args)
       }
     },
@@ -89,7 +90,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -130,7 +133,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const inputImageBuffer = Buffer.from('fake-input-image-data')
@@ -157,7 +162,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -173,14 +180,15 @@ describe('geminiClient', () => {
     })
 
     it('should return NetworkError for network-related failures', async () => {
-      const networkError = new Error('ECONNRESET') as Error & { code: string }
-      networkError.code = 'ECONNRESET'
+      const networkError = errorWithCode('ECONNRESET', 'ECONNRESET')
       mockGeminiClientInstance.models.generateContent = vi.fn().mockRejectedValue(networkError)
 
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -208,7 +216,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -247,7 +257,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -300,7 +312,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -342,7 +356,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -379,7 +395,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -425,7 +443,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -470,7 +490,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -482,8 +504,7 @@ describe('geminiClient', () => {
         expect(result.data.imageData).toBeInstanceOf(Buffer)
         expect(result.data.metadata.prompt).toBe('test prompt without aspect ratio')
       }
-      const request = (mockGeminiClientInstance.models.generateContent as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0]
+      const request = vi.mocked(mockGeminiClientInstance.models.generateContent).mock.calls[0][0]
       expect(request.config.imageConfig).toBeUndefined()
     })
   })
@@ -514,7 +535,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -528,8 +551,7 @@ describe('geminiClient', () => {
         expect(result.data.metadata.prompt).toBe('Generate current 2025 weather map of Tokyo')
       }
 
-      const callArgs = (mockGeminiClientInstance.models.generateContent as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0]
+      const callArgs = vi.mocked(mockGeminiClientInstance.models.generateContent).mock.calls[0][0]
       expect(callArgs.config.tools).toEqual([
         { googleSearch: { searchTypes: { webSearch: {}, imageSearch: {} } } },
       ])
@@ -560,7 +582,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -574,8 +598,7 @@ describe('geminiClient', () => {
         expect(result.data.metadata.prompt).toBe('Generate creative fantasy landscape')
       }
 
-      const callArgs = (mockGeminiClientInstance.models.generateContent as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0]
+      const callArgs = vi.mocked(mockGeminiClientInstance.models.generateContent).mock.calls[0][0]
       expect(callArgs.config.tools).toBeUndefined()
     })
 
@@ -604,7 +627,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -617,8 +642,7 @@ describe('geminiClient', () => {
         expect(result.data.metadata.prompt).toBe('Generate image without grounding')
       }
 
-      const callArgs = (mockGeminiClientInstance.models.generateContent as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0]
+      const callArgs = vi.mocked(mockGeminiClientInstance.models.generateContent).mock.calls[0][0]
       expect(callArgs.config.tools).toBeUndefined()
     })
 
@@ -647,7 +671,9 @@ describe('geminiClient', () => {
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
 
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -663,8 +689,7 @@ describe('geminiClient', () => {
         expect(result.data.metadata.prompt).toBe('Generate 2025 Japan foodtech industry chaos map')
       }
 
-      const callArgs = (mockGeminiClientInstance.models.generateContent as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0]
+      const callArgs = vi.mocked(mockGeminiClientInstance.models.generateContent).mock.calls[0][0]
       expect(callArgs.config.tools).toEqual([
         { googleSearch: { searchTypes: { webSearch: {}, imageSearch: {} } } },
       ])
@@ -699,7 +724,9 @@ describe('geminiClient', () => {
 
       const clientResult = createGeminiClient(testConfig) // testConfig has imageQuality: 'fast'
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({ prompt: 'test fast preset' })
@@ -726,7 +753,9 @@ describe('geminiClient', () => {
       const balancedConfig: Config = { ...testConfig, imageQuality: 'balanced' }
       const clientResult = createGeminiClient(balancedConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({ prompt: 'test balanced preset' })
@@ -753,7 +782,9 @@ describe('geminiClient', () => {
       const qualityConfig: Config = { ...testConfig, imageQuality: 'quality' }
       const clientResult = createGeminiClient(qualityConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({ prompt: 'test quality preset' })
@@ -779,7 +810,9 @@ describe('geminiClient', () => {
 
       const clientResult = createGeminiClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({
@@ -806,7 +839,9 @@ describe('geminiClient', () => {
       const balancedConfig: Config = { ...testConfig, imageQuality: 'balanced' }
       const clientResult = createGeminiClient(balancedConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
       const client = clientResult.data
 
       const result = await client.generateImage({ prompt: 'test default fallback' })

--- a/src/api/__tests__/geminiTextClient.test.ts
+++ b/src/api/__tests__/geminiTextClient.test.ts
@@ -32,10 +32,6 @@ mockGenerateContent.mockImplementation((params: { contents: string }) => {
 
   return Promise.resolve({
     text: 'Enhanced: test prompt with professional lighting, 85mm lens, dramatic composition',
-    response: {
-      text: () =>
-        'Enhanced: test prompt with professional lighting, 85mm lens, dramatic composition',
-    },
   })
 })
 

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { asUntypedCaller, errorWithCode, expectDefined } from '../../tests/helpers/inspect'
 import type { Config } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
 import { createOpenAIImageClient } from '../openaiImageClient'
@@ -17,11 +18,11 @@ vi.mock('openai', () => ({
       edit: mockEdit,
     }
 
-    constructor(...args: any[]) {
+    constructor(...args: unknown[]) {
       mockOpenAI(...args)
     }
   },
-  toFile: (...args: any[]) => mockToFile(...args),
+  toFile: (...args: unknown[]) => mockToFile(...args),
 }))
 
 describe('openaiImageClient', () => {
@@ -74,14 +75,16 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate a beautiful landscape',
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate.mock.calls[0]![0]).toEqual({
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual({
         model: 'gpt-image-2',
         prompt: 'Generate a beautiful landscape',
         n: 1,
@@ -109,7 +112,9 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const inputImage = Buffer.from('input-image-data').toString('base64')
       const result = await clientResult.data.generateImage({
@@ -122,7 +127,7 @@ describe('openaiImageClient', () => {
       expect(mockToFile).toHaveBeenCalledWith(Buffer.from('input-image-data'), 'input.png', {
         type: 'image/png',
       })
-      expect(mockEdit.mock.calls[0]![0]).toEqual({
+      expect(expectDefined(mockEdit.mock.calls[0], 'images.edit call')[0]).toEqual({
         model: 'gpt-image-2',
         prompt: 'Make this image warmer',
         image: { name: 'input.png', type: 'image/png' },
@@ -140,14 +145,16 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       await clientResult.data.generateImage({
         prompt: 'Generate an image',
         quality: 'balanced',
       })
 
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({
           quality: 'medium',
         })
@@ -161,14 +168,16 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       await clientResult.data.generateImage({
         prompt: 'Generate an image',
         quality: 'quality',
       })
 
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({
           quality: 'high',
         })
@@ -182,14 +191,16 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       await clientResult.data.generateImage({
         prompt: 'Generate a landscape image',
         aspectRatio: '16:9',
       })
 
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({
           size: '1536x864',
         })
@@ -203,11 +214,13 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
-      const result = await clientResult.data.generateImage({
+      const result = await asUntypedCaller(clientResult.data).generateImage({
         prompt: 'Generate an image',
-        aspectRatio: 'abc:1' as unknown as never,
+        aspectRatio: 'abc:1',
       })
 
       expect(result.success).toBe(false)
@@ -226,16 +239,20 @@ describe('openaiImageClient', () => {
       async (aspectRatio, imageSize) => {
         mockGenerate.mockResolvedValue({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })
         const clientResult = createOpenAIImageClient(testConfig)
-        if (!clientResult.success) throw clientResult.error
+        if (!clientResult.success) {
+          throw clientResult.error
+        }
         const result = await clientResult.data.generateImage({
           prompt: 'test',
           aspectRatio,
           imageSize,
         })
         expect(result.success).toBe(true)
-        const [width, height] = mockGenerate.mock.calls[0]![0].size.split('x').map(Number)
-        const [ratioWidth, ratioHeight] = aspectRatio.split(':').map(Number)
-        expect(Math.abs(width / height - ratioWidth! / ratioHeight!)).toBeLessThan(0.025)
+        const [width, height] = expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]
+          .size.split('x')
+          .map(Number)
+        const [ratioWidth = 1, ratioHeight = 1] = aspectRatio.split(':').map(Number)
+        expect(Math.abs(width / height - ratioWidth / ratioHeight)).toBeLessThan(0.025)
         expect(width % 16).toBe(0)
         expect(height % 16).toBe(0)
         expect(Math.max(width, height)).toBeLessThanOrEqual(3840)
@@ -249,7 +266,9 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate image',
@@ -265,7 +284,9 @@ describe('openaiImageClient', () => {
     it('should reject useGoogleSearch because OpenAI image generation does not support Google Search grounding', async () => {
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate a current event image',
@@ -287,7 +308,9 @@ describe('openaiImageClient', () => {
       })
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate a JPEG image',
@@ -295,7 +318,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({ output_format: 'jpeg' })
       )
       if (result.success) {
@@ -310,7 +333,9 @@ describe('openaiImageClient', () => {
       })
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Edit as JPEG',
@@ -320,7 +345,9 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockEdit.mock.calls[0]![0]).toEqual(expect.objectContaining({ output_format: 'jpeg' }))
+      expect(expectDefined(mockEdit.mock.calls[0], 'images.edit call')[0]).toEqual(
+        expect.objectContaining({ output_format: 'jpeg' })
+      )
     })
 
     it('should reject bytes that contradict the requested format', async () => {
@@ -329,7 +356,9 @@ describe('openaiImageClient', () => {
       })
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({ prompt: 'Generate PNG' })
 
@@ -347,7 +376,9 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate a 2K product photo',
@@ -356,7 +387,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({
           size: '2048x1152',
         })
@@ -370,7 +401,9 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate a 4K portrait poster',
@@ -379,7 +412,7 @@ describe('openaiImageClient', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockGenerate.mock.calls[0]![0]).toEqual(
+      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
         expect.objectContaining({
           size: '2160x3840',
         })
@@ -393,7 +426,9 @@ describe('openaiImageClient', () => {
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate image',
@@ -407,13 +442,14 @@ describe('openaiImageClient', () => {
     })
 
     it('should return NetworkError for network failures', async () => {
-      const networkError = new Error('ECONNRESET') as Error & { code: string }
-      networkError.code = 'ECONNRESET'
+      const networkError = errorWithCode('ECONNRESET', 'ECONNRESET')
       mockGenerate.mockRejectedValue(networkError)
 
       const clientResult = createOpenAIImageClient(testConfig)
       expect(clientResult.success).toBe(true)
-      if (!clientResult.success) return
+      if (!clientResult.success) {
+        return
+      }
 
       const result = await clientResult.data.generateImage({
         prompt: 'Generate image',

--- a/src/api/__tests__/openaiTextClient.test.ts
+++ b/src/api/__tests__/openaiTextClient.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { errorWithCode } from '../../tests/helpers/inspect'
 import type { Config } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
 import { createOpenAITextClient } from '../openaiTextClient'
@@ -12,7 +13,7 @@ vi.mock('openai', () => ({
       create: mockResponsesCreate,
     }
 
-    constructor(...args: any[]) {
+    constructor(...args: unknown[]) {
       mockOpenAI(...args)
     }
   },
@@ -46,7 +47,9 @@ describe('openaiTextClient', () => {
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const result = await clientResult.data.generateText('make a product photo', {
       systemInstruction: 'Enhance image prompts',
@@ -78,7 +81,9 @@ describe('openaiTextClient', () => {
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     await clientResult.data.generateText('make the lighting warmer', {
       inputImage: Buffer.from('image-bytes').toString('base64'),
@@ -113,7 +118,9 @@ describe('openaiTextClient', () => {
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const result = await clientResult.data.generateText('make a product photo')
 
@@ -133,7 +140,9 @@ describe('openaiTextClient', () => {
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const result = await clientResult.data.generateText('make a product photo', {
       maxTokens: 1000,
@@ -149,7 +158,9 @@ describe('openaiTextClient', () => {
   it('should reject prompts that exceed the 100k character cap', async () => {
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const overLimitPrompt = 'a'.repeat(100_001)
     const result = await clientResult.data.generateText(overLimitPrompt)
@@ -167,7 +178,9 @@ describe('openaiTextClient', () => {
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const atLimitPrompt = 'a'.repeat(100_000)
     const result = await clientResult.data.generateText(atLimitPrompt)
@@ -176,13 +189,14 @@ describe('openaiTextClient', () => {
   })
 
   it('should return NetworkError for network failures', async () => {
-    const networkError = new Error('ECONNRESET') as Error & { code: string }
-    networkError.code = 'ECONNRESET'
+    const networkError = errorWithCode('ECONNRESET', 'ECONNRESET')
     mockResponsesCreate.mockRejectedValue(networkError)
 
     const clientResult = createOpenAITextClient(testConfig)
     expect(clientResult.success).toBe(true)
-    if (!clientResult.success) return
+    if (!clientResult.success) {
+      return
+    }
 
     const result = await clientResult.data.generateText('make a product photo')
 

--- a/src/api/__tests__/seedreamImageClient.test.ts
+++ b/src/api/__tests__/seedreamImageClient.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { asUntypedCaller, expectRecord, parseJsonObject } from '../../tests/helpers/inspect'
 import { type Config, getConfig } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
-import type { ImageApiParams, ImageClient } from '../imageClient'
+import type { ImageClient } from '../imageClient'
 import { createSeedreamImageClient, validateSeedreamCapabilities } from '../seedreamImageClient'
 
 const API_ENDPOINT = 'https://ark.ap-southeast.bytepluses.com/api/v3/images/generations'
@@ -84,7 +85,7 @@ function readRequest(callIndex = -1): {
   const init = rawInit ?? {}
   expect(typeof init.body).toBe('string')
   return {
-    body: JSON.parse(String(init.body)) as Record<string, unknown>,
+    body: parseJsonObject(String(init.body), 'request body'),
     headers: new Headers(init.headers),
     init,
     url: String(url),
@@ -140,7 +141,7 @@ describe('seedreamImageClient', () => {
     expect(result.success).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
     const request = readRequest()
-    expect((request.init.headers as Record<string, string>).Authorization).toBe(
+    expect(expectRecord(request.init.headers, 'request headers')['Authorization']).toBe(
       `Bearer ${WRAPPED_DUMMY_API_KEY}`
     )
     expect(request.headers.get('authorization')).toBe(`Bearer  \t${DUMMY_API_KEY}`)
@@ -382,9 +383,9 @@ describe('seedreamImageClient', () => {
       params: { aspectRatio: '3:1' },
     },
   ])('rejects unsupported $name before transport without coercion', async ({ params }) => {
-    const result = await createClient().generateImage({
+    const result = await asUntypedCaller(createClient()).generateImage({
       prompt: PRIVATE_PROMPT,
-      ...(params as ImageApiParams),
+      ...params,
     })
 
     expect(result.success).toBe(false)

--- a/src/api/__tests__/seedreamTextClient.test.ts
+++ b/src/api/__tests__/seedreamTextClient.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { parseJsonObject } from '../../tests/helpers/inspect'
 import { type Config, getConfig } from '../../utils/config'
 import { ImageAPIError, NetworkError } from '../../utils/errors'
 import { createSeedreamTextClient } from '../seedreamTextClient'
+import type { TextClient } from '../textClient'
 
 const MODELARK_BASE_URL = 'https://ark.ap-southeast.bytepluses.com/api/v3'
 const DUMMY_API_KEY = 'ark-dummy-seedream-text-key'
@@ -27,10 +29,10 @@ function successfulResponse(outputText: string): Response {
 
 function readSerializedBody(init: RequestInit | undefined): Record<string, unknown> {
   expect(typeof init?.body).toBe('string')
-  return JSON.parse(String(init?.body)) as Record<string, unknown>
+  return parseJsonObject(String(init?.body), 'request body')
 }
 
-function createClient() {
+function createClient(): TextClient {
   const clientResult = createSeedreamTextClient(testConfig)
   expect(clientResult.success).toBe(true)
   if (!clientResult.success) {
@@ -198,10 +200,15 @@ describe('seedreamTextClient', () => {
     const result = await createClient().generateText(PRIVATE_PROMPT)
 
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
 
     expect(result.error).toBeInstanceOf(ImageAPIError)
-    expect((result.error as ImageAPIError & { statusCode?: number }).statusCode).toBe(401)
+    if (!(result.error instanceof ImageAPIError)) {
+      throw result.error
+    }
+    expect(result.error.statusCode).toBe(401)
 
     const disclosed = JSON.stringify({
       message: result.error.message,
@@ -227,7 +234,9 @@ describe('seedreamTextClient', () => {
     const result = await createClient().generateText(PRIVATE_PROMPT, { timeout: 1 })
 
     expect(result.success).toBe(false)
-    if (result.success) return
+    if (result.success) {
+      return
+    }
 
     expect(result.error).toBeInstanceOf(NetworkError)
     const disclosed = JSON.stringify({

--- a/src/api/errorClassification.ts
+++ b/src/api/errorClassification.ts
@@ -1,22 +1,23 @@
-interface ErrorWithCode extends Error {
-  code?: string
-  status?: number
-}
-
 const NETWORK_ERROR_CODES = ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND'] as const
+
+function extractErrorCode(error: Error): string | undefined {
+  if ('code' in error && typeof error.code === 'string') {
+    return error.code
+  }
+  return undefined
+}
 
 export function isNetworkError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false
   }
-  return NETWORK_ERROR_CODES.some(
-    (code) => error.message.includes(code) || (error as ErrorWithCode).code === code
-  )
+  const errorCode = extractErrorCode(error)
+  return NETWORK_ERROR_CODES.some((code) => error.message.includes(code) || errorCode === code)
 }
 
 export function extractStatusCode(error: unknown): number | undefined {
   if (error && typeof error === 'object' && 'status' in error) {
-    const status = (error as ErrorWithCode).status
+    const { status } = error
     return typeof status === 'number' ? status : undefined
   }
   return undefined

--- a/src/api/geminiClient.ts
+++ b/src/api/geminiClient.ts
@@ -11,8 +11,9 @@ import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
 import { GeminiAPIError, NetworkError } from '../utils/errors.js'
-import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+import { DEFAULT_MIME_TYPE } from '../utils/mimeUtils.js'
 import { extractStatusCode, isNetworkError } from './errorClassification.js'
+import { interpretGeminiImageResponse } from './geminiImageResponse.js'
 import type {
   GeneratedImageResult,
   ImageApiParams,
@@ -20,94 +21,14 @@ import type {
   ImageGenerationMetadata,
 } from './imageClient.js'
 
-interface ContentPart {
-  inlineData?: {
-    data: string
-    mimeType: string
-  }
-  text?: string
-}
-
-interface GeminiResponse {
-  candidates?: Array<{
-    content?: {
-      parts?: ContentPart[]
-    }
-    finishReason?: string
-  }>
-  modelVersion?: string
-  responseId?: string
-  sdkHttpResponse?: unknown
-  usageMetadata?: unknown
-}
-
 interface GeminiClientInstance {
   models: {
     // Request is typed against the SDK contract so misplaced parameters (e.g.
     // tools nested under config) are caught at compile time. The response is
-    // validated at runtime with type guards, so it stays intentionally `unknown`.
+    // validated at runtime by `interpretGeminiImageResponse`, so it stays
+    // intentionally `unknown`.
     generateContent(params: GenerateContentParameters): Promise<unknown>
   }
-}
-
-function analyzeResponseStructure(obj: unknown): Record<string, unknown> {
-  if (!obj || typeof obj !== 'object') {
-    return { type: typeof obj, value: obj }
-  }
-
-  const seen = new WeakSet()
-
-  const sanitize = (value: unknown, depth = 0): unknown => {
-    if (depth > 3) return '[max depth]'
-
-    if (value === null || value === undefined) return value
-    if (typeof value !== 'object')
-      return typeof value === 'string' && value.length > 100
-        ? `[string length: ${value.length}]`
-        : value
-
-    if (seen.has(value)) return '[circular]'
-    seen.add(value)
-
-    if (Array.isArray(value)) {
-      return value.slice(0, 3).map((v) => sanitize(v, depth + 1))
-    }
-
-    const record = value as Record<string, unknown>
-    const result: Record<string, unknown> = {}
-
-    for (const [key, val] of Object.entries(record)) {
-      if (/apikey|token|secret|password|credential/i.test(key)) {
-        result[key] = '[REDACTED]'
-      } else if (key === 'data' && typeof val === 'string' && val.length > 100) {
-        result[key] = `[base64 data, length: ${val.length}]`
-      } else {
-        result[key] = sanitize(val, depth + 1)
-      }
-    }
-
-    return result
-  }
-
-  return sanitize(obj) as Record<string, unknown>
-}
-
-function isGeminiResponse(obj: unknown): obj is GeminiResponse {
-  if (!obj || typeof obj !== 'object') return false
-  const response = obj as Record<string, unknown>
-
-  if ('response' in response && response['response'] && typeof response['response'] === 'object') {
-    return isGeminiResponse(response['response'])
-  }
-
-  const feedback = response['promptFeedback']
-  return (
-    Array.isArray(response['candidates']) ||
-    (typeof feedback === 'object' &&
-      feedback !== null &&
-      'blockReason' in feedback &&
-      typeof feedback.blockReason === 'string')
-  )
 }
 
 class GeminiClientImpl implements ImageClient {
@@ -178,164 +99,11 @@ class GeminiClientImpl implements ImageClient {
         config,
       })
 
-      if (!isGeminiResponse(rawResponse)) {
-        const responseStructure = analyzeResponseStructure(rawResponse)
-
-        const asRecord = rawResponse as Record<string, unknown>
-        if (asRecord['error']) {
-          const error = asRecord['error'] as Record<string, unknown>
-          return Err(
-            new GeminiAPIError('Gemini API returned an error response', {
-              provider: 'gemini',
-              stage: 'api_error',
-              upstreamMessage:
-                typeof error['message'] === 'string' ? error['message'] : 'Unknown error',
-              statusCode: typeof error['status'] === 'number' ? error['status'] : undefined,
-              rawErrorCode: error['code'],
-              rawDetails: error['details'] || responseStructure,
-            })
-          )
-        }
-
-        return Err(
-          new GeminiAPIError('Invalid response structure from Gemini API', {
-            message: 'The API returned an unexpected response format',
-            responseStructure: responseStructure,
-            stage: 'response_validation',
-            suggestion: 'Check if the API endpoint or model configuration is correct',
-          })
-        )
+      const interpreted = interpretGeminiImageResponse(rawResponse)
+      if (!interpreted.success) {
+        return Err(interpreted.error)
       }
-
-      const responseData = (rawResponse as Record<string, unknown>)['response']
-        ? ((rawResponse as Record<string, unknown>)['response'] as GeminiResponse)
-        : (rawResponse as GeminiResponse)
-
-      const responseAsRecord = responseData as Record<string, unknown>
-      if (responseAsRecord['promptFeedback']) {
-        const promptFeedback = responseAsRecord['promptFeedback'] as Record<string, unknown>
-        if (promptFeedback['blockReason'] === 'SAFETY') {
-          return Err(
-            new GeminiAPIError('Image generation blocked for safety reasons', {
-              stage: 'prompt_analysis',
-              blockReason: promptFeedback['blockReason'],
-              suggestion: 'Rephrase your prompt to avoid potentially sensitive content',
-            })
-          )
-        }
-        if (
-          promptFeedback['blockReason'] === 'OTHER' ||
-          promptFeedback['blockReason'] === 'PROHIBITED_CONTENT'
-        ) {
-          return Err(
-            new GeminiAPIError('Image generation blocked due to prohibited content', {
-              stage: 'prompt_analysis',
-              blockReason: promptFeedback['blockReason'],
-              suggestion: 'Remove any prohibited content from your prompt and try again',
-            })
-          )
-        }
-      }
-
-      if (!responseData.candidates || responseData.candidates.length === 0) {
-        return Err(
-          new GeminiAPIError('No image generated: Content may have been filtered', {
-            stage: 'generation',
-            candidatesCount: 0,
-            suggestion: 'Try rephrasing your prompt to avoid potentially sensitive content',
-          })
-        )
-      }
-
-      const candidate = responseData.candidates[0]
-      if (!candidate?.content?.parts) {
-        return Err(
-          new GeminiAPIError('No valid content in response', {
-            stage: 'candidate_extraction',
-            suggestion: 'The API response was incomplete. Please try again',
-          })
-        )
-      }
-
-      const parts = candidate.content.parts
-
-      if (candidate.finishReason) {
-        const finishReason = candidate.finishReason
-
-        if (finishReason === 'IMAGE_SAFETY') {
-          return Err(
-            new GeminiAPIError('Image generation stopped for safety reasons', {
-              finishReason,
-              stage: 'generation_stopped',
-              suggestion: 'Modify your prompt to avoid potentially sensitive content',
-              safetyRatings: (candidate as Record<string, unknown>)['safetyRatings']
-                ? (
-                    (candidate as Record<string, unknown>)['safetyRatings'] as Record<
-                      string,
-                      unknown
-                    >[]
-                  )
-                    ?.map((rating: Record<string, unknown>) => {
-                      const category = (rating['category'] as string)
-                        .replace('HARM_CATEGORY_', '')
-                        .split('_')
-                        .map((word: string) => word.charAt(0) + word.slice(1).toLowerCase())
-                        .join(' ')
-                      return `${category} (${rating['blocked'] ? 'BLOCKED' : 'ALLOWED'})`
-                    })
-                    .join(', ')
-                : undefined,
-            })
-          )
-        }
-
-        if (finishReason === 'MAX_TOKENS') {
-          return Err(
-            new GeminiAPIError('Maximum token limit reached during generation', {
-              finishReason,
-              stage: 'generation_stopped',
-              suggestion: 'Try using a shorter or simpler prompt',
-            })
-          )
-        }
-      }
-
-      if (parts.length === 0) {
-        return Err(
-          new GeminiAPIError('No content parts in response', {
-            stage: 'content_extraction',
-            suggestion: 'The generation was incomplete. Please try again',
-          })
-        )
-      }
-
-      const imagePart = parts.find((part) => part.inlineData?.data)
-      const textPart = parts.find((part) => part.text)
-
-      if (!imagePart?.inlineData) {
-        const errorMessage = textPart?.text || 'Image generation failed'
-
-        return Err(
-          new GeminiAPIError('Image generation failed due to content filtering', {
-            reason: errorMessage,
-            stage: 'image_extraction',
-            suggestion:
-              'The prompt was blocked by safety filters. Try rephrasing your prompt to avoid potentially sensitive content.',
-          })
-        )
-      }
-
-      const imageBuffer = Buffer.from(imagePart.inlineData.data, 'base64')
-      if (imageBuffer.length === 0) {
-        return Err(
-          new GeminiAPIError('Gemini returned empty image data', {
-            provider: 'gemini',
-            stage: 'image_extraction',
-            suggestion: 'Retry the request; the provider returned no image bytes',
-          })
-        )
-      }
-      const mimeType = normalizeMimeType(imagePart.inlineData.mimeType || DEFAULT_MIME_TYPE)
+      const { imageData, mimeType, modelVersion, responseId } = interpreted.data
 
       const metadata: ImageGenerationMetadata = {
         model: modelName,
@@ -343,12 +111,12 @@ class GeminiClientImpl implements ImageClient {
         mimeType,
         timestamp: new Date(),
         inputImageProvided: !!params.inputImage,
-        ...(responseData.modelVersion && { modelVersion: responseData.modelVersion }),
-        ...(responseData.responseId && { responseId: responseData.responseId }),
+        ...(modelVersion && { modelVersion }),
+        ...(responseId && { responseId }),
       }
 
       return Ok({
-        imageData: imageBuffer,
+        imageData,
         metadata,
       })
     } catch (error) {
@@ -431,9 +199,9 @@ class GeminiClientImpl implements ImageClient {
 
 export function createGeminiClient(config: Config): Result<ImageClient, GeminiAPIError> {
   try {
-    const genai = new GoogleGenAI({
+    const genai: GeminiClientInstance = new GoogleGenAI({
       apiKey: config.geminiApiKey,
-    }) as unknown as GeminiClientInstance
+    })
     return Ok(new GeminiClientImpl(genai, config.imageQuality))
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error'

--- a/src/api/geminiImageResponse.ts
+++ b/src/api/geminiImageResponse.ts
@@ -1,0 +1,340 @@
+import type { Result } from '../types/result.js'
+import { Err, Ok } from '../types/result.js'
+import { GeminiAPIError } from '../utils/errors.js'
+import { DEFAULT_MIME_TYPE, normalizeMimeType } from '../utils/mimeUtils.js'
+
+/**
+ * Image payload extracted from a validated Gemini response.
+ *
+ * Interpreting the response is kept separate from issuing the request so the
+ * mapping from an untrusted `unknown` payload to either image bytes or a
+ * classified `GeminiAPIError` can be read and exercised on its own.
+ */
+export interface GeminiImagePayload {
+  imageData: Buffer
+  mimeType: string
+  modelVersion?: string
+  responseId?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function readString(source: Record<string, unknown>, key: string): string | undefined {
+  const value = source[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Some SDK versions wrap the payload in a `response` property. Only an object
+ * is unwrapped; any other value is treated as the payload itself.
+ */
+function unwrapResponsePayload(rawResponse: unknown): unknown {
+  if (isRecord(rawResponse) && isRecord(rawResponse['response'])) {
+    return rawResponse['response']
+  }
+  return rawResponse
+}
+
+function hasBlockReason(payload: Record<string, unknown>): boolean {
+  const feedback = payload['promptFeedback']
+  return isRecord(feedback) && typeof feedback['blockReason'] === 'string'
+}
+
+function isImagePayload(payload: unknown): payload is Record<string, unknown> {
+  if (!isRecord(payload)) {
+    return false
+  }
+  return Array.isArray(payload['candidates']) || hasBlockReason(payload)
+}
+
+/**
+ * Disclosure policy for one property of an error payload. Returns the
+ * replacement text when the value must not be disclosed, or `undefined` when
+ * the value may be traversed normally.
+ */
+function redactEntry(key: string, value: unknown): string | undefined {
+  if (/apikey|token|secret|password|credential/i.test(key)) {
+    return '[REDACTED]'
+  }
+  if (key === 'data' && typeof value === 'string' && value.length > 100) {
+    return `[base64 data, length: ${value.length}]`
+  }
+  return undefined
+}
+
+/** Long strings are reported by length only, so payload text is never echoed. */
+function elideLongString(value: unknown): unknown {
+  return typeof value === 'string' && value.length > 100
+    ? `[string length: ${value.length}]`
+    : value
+}
+
+/**
+ * Reduce an arbitrary payload to a shape safe to attach to an error context:
+ * bounded depth, bounded array length, redacted credentials and elided blobs.
+ */
+function analyzeResponseStructure(obj: unknown): Record<string, unknown> {
+  if (!isRecord(obj)) {
+    return { type: typeof obj, value: obj }
+  }
+
+  const seen = new WeakSet()
+
+  const sanitize = (value: unknown, depth = 0): unknown => {
+    if (depth > 3) {
+      return '[max depth]'
+    }
+    if (value === null || value === undefined) {
+      return value
+    }
+    if (typeof value !== 'object') {
+      return elideLongString(value)
+    }
+    if (seen.has(value)) {
+      return '[circular]'
+    }
+    seen.add(value)
+
+    if (Array.isArray(value)) {
+      return value.slice(0, 3).map((entry) => sanitize(entry, depth + 1))
+    }
+
+    const result: Record<string, unknown> = {}
+    for (const [key, entry] of Object.entries(value)) {
+      result[key] = redactEntry(key, entry) ?? sanitize(entry, depth + 1)
+    }
+    return result
+  }
+
+  const sanitized = sanitize(obj)
+  return isRecord(sanitized) ? sanitized : { type: typeof obj }
+}
+
+function formatHarmCategory(category: string): string {
+  return category
+    .replace('HARM_CATEGORY_', '')
+    .split('_')
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+function formatSafetyRatings(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+  return value
+    .map((rating) => {
+      const category = isRecord(rating) ? readString(rating, 'category') : undefined
+      const blocked = isRecord(rating) && rating['blocked'] ? 'BLOCKED' : 'ALLOWED'
+      return `${formatHarmCategory(category ?? '')} (${blocked})`
+    })
+    .join(', ')
+}
+
+function upstreamErrorFrom(rawResponse: unknown): GeminiAPIError | undefined {
+  if (!isRecord(rawResponse) || !isRecord(rawResponse['error'])) {
+    return undefined
+  }
+  const error = rawResponse['error']
+  const status = error['status']
+  return new GeminiAPIError('Gemini API returned an error response', {
+    provider: 'gemini',
+    stage: 'api_error',
+    upstreamMessage: readString(error, 'message') ?? 'Unknown error',
+    statusCode: typeof status === 'number' ? status : undefined,
+    rawErrorCode: error['code'],
+    rawDetails: error['details'] || analyzeResponseStructure(rawResponse),
+  })
+}
+
+function blockedPromptError(payload: Record<string, unknown>): GeminiAPIError | undefined {
+  const feedback = payload['promptFeedback']
+  if (!isRecord(feedback)) {
+    return undefined
+  }
+  const blockReason = feedback['blockReason']
+
+  if (blockReason === 'SAFETY') {
+    return new GeminiAPIError('Image generation blocked for safety reasons', {
+      stage: 'prompt_analysis',
+      blockReason,
+      suggestion: 'Rephrase your prompt to avoid potentially sensitive content',
+    })
+  }
+
+  if (blockReason === 'OTHER' || blockReason === 'PROHIBITED_CONTENT') {
+    return new GeminiAPIError('Image generation blocked due to prohibited content', {
+      stage: 'prompt_analysis',
+      blockReason,
+      suggestion: 'Remove any prohibited content from your prompt and try again',
+    })
+  }
+
+  return undefined
+}
+
+function stoppedGenerationError(candidate: Record<string, unknown>): GeminiAPIError | undefined {
+  const finishReason = readString(candidate, 'finishReason')
+  if (!finishReason) {
+    return undefined
+  }
+
+  if (finishReason === 'IMAGE_SAFETY') {
+    return new GeminiAPIError('Image generation stopped for safety reasons', {
+      finishReason,
+      stage: 'generation_stopped',
+      suggestion: 'Modify your prompt to avoid potentially sensitive content',
+      safetyRatings: formatSafetyRatings(candidate['safetyRatings']),
+    })
+  }
+
+  if (finishReason === 'MAX_TOKENS') {
+    return new GeminiAPIError('Maximum token limit reached during generation', {
+      finishReason,
+      stage: 'generation_stopped',
+      suggestion: 'Try using a shorter or simpler prompt',
+    })
+  }
+
+  return undefined
+}
+
+interface ContentPart {
+  inlineData?: { data: string; mimeType?: string }
+  text?: string
+}
+
+function readContentParts(candidate: Record<string, unknown>): ContentPart[] | undefined {
+  const content = candidate['content']
+  if (!isRecord(content) || !Array.isArray(content['parts'])) {
+    return undefined
+  }
+  return content['parts'].map((part): ContentPart => {
+    if (!isRecord(part)) {
+      return {}
+    }
+    const inlineData = part['inlineData']
+    const data = isRecord(inlineData) ? readString(inlineData, 'data') : undefined
+    const mimeType = isRecord(inlineData) ? readString(inlineData, 'mimeType') : undefined
+    const text = readString(part, 'text')
+    const contentPart: ContentPart = {}
+    if (data !== undefined) {
+      contentPart.inlineData = mimeType === undefined ? { data } : { data, mimeType }
+    }
+    if (text !== undefined) {
+      contentPart.text = text
+    }
+    return contentPart
+  })
+}
+
+/**
+ * An upstream `error` object is reported as such; anything else is reported as
+ * an unrecognized response shape.
+ */
+function invalidPayloadError(rawResponse: unknown): GeminiAPIError {
+  return (
+    upstreamErrorFrom(rawResponse) ??
+    new GeminiAPIError('Invalid response structure from Gemini API', {
+      message: 'The API returned an unexpected response format',
+      responseStructure: analyzeResponseStructure(rawResponse),
+      stage: 'response_validation',
+      suggestion: 'Check if the API endpoint or model configuration is correct',
+    })
+  )
+}
+
+/**
+ * Convert an untrusted Gemini `generateContent` result into image bytes or a
+ * classified error. Only sanitized details reach the error context.
+ */
+export function interpretGeminiImageResponse(
+  rawResponse: unknown
+): Result<GeminiImagePayload, GeminiAPIError> {
+  const payload = unwrapResponsePayload(rawResponse)
+
+  if (!isImagePayload(payload)) {
+    return Err(invalidPayloadError(rawResponse))
+  }
+
+  const blockedError = blockedPromptError(payload)
+  if (blockedError) {
+    return Err(blockedError)
+  }
+
+  const candidates = payload['candidates']
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    return Err(
+      new GeminiAPIError('No image generated: Content may have been filtered', {
+        stage: 'generation',
+        candidatesCount: 0,
+        suggestion: 'Try rephrasing your prompt to avoid potentially sensitive content',
+      })
+    )
+  }
+
+  const candidate = candidates[0]
+  const parts = isRecord(candidate) ? readContentParts(candidate) : undefined
+  if (!isRecord(candidate) || !parts) {
+    return Err(
+      new GeminiAPIError('No valid content in response', {
+        stage: 'candidate_extraction',
+        suggestion: 'The API response was incomplete. Please try again',
+      })
+    )
+  }
+
+  const stoppedError = stoppedGenerationError(candidate)
+  if (stoppedError) {
+    return Err(stoppedError)
+  }
+
+  if (parts.length === 0) {
+    return Err(
+      new GeminiAPIError('No content parts in response', {
+        stage: 'content_extraction',
+        suggestion: 'The generation was incomplete. Please try again',
+      })
+    )
+  }
+
+  const imagePart = parts.find((part) => part.inlineData?.data)
+  if (!imagePart?.inlineData) {
+    const textPart = parts.find((part) => part.text)
+    return Err(
+      new GeminiAPIError('Image generation failed due to content filtering', {
+        reason: textPart?.text || 'Image generation failed',
+        stage: 'image_extraction',
+        suggestion:
+          'The prompt was blocked by safety filters. Try rephrasing your prompt to avoid potentially sensitive content.',
+      })
+    )
+  }
+
+  const imageData = Buffer.from(imagePart.inlineData.data, 'base64')
+  if (imageData.length === 0) {
+    return Err(
+      new GeminiAPIError('Gemini returned empty image data', {
+        provider: 'gemini',
+        stage: 'image_extraction',
+        suggestion: 'Retry the request; the provider returned no image bytes',
+      })
+    )
+  }
+
+  const modelVersion = readString(payload, 'modelVersion')
+  const responseId = readString(payload, 'responseId')
+  const result: GeminiImagePayload = {
+    imageData,
+    mimeType: normalizeMimeType(imagePart.inlineData.mimeType || DEFAULT_MIME_TYPE),
+  }
+  if (modelVersion !== undefined) {
+    result.modelVersion = modelVersion
+  }
+  if (responseId !== undefined) {
+    result.responseId = responseId
+  }
+  return Ok(result)
+}

--- a/src/api/geminiTextClient.ts
+++ b/src/api/geminiTextClient.ts
@@ -15,6 +15,15 @@ const DEFAULT_GENERATION_CONFIG = {
   timeout: 15000,
 } as const
 
+/**
+ * Response contract of `@google/genai` v2 `models.generateContent`: the text is
+ * exposed directly and may be absent when generation produced no content.
+ */
+interface GeminiTextResponse {
+  text: string | undefined
+  candidates?: Array<{ finishReason?: string }> | undefined
+}
+
 interface GeminiAIInstance {
   models: {
     generateContent(params: {
@@ -36,20 +45,35 @@ interface GeminiAIInstance {
         }
         abortSignal?: AbortSignal
       }
-    }): Promise<{
-      text: string
-      candidates?: Array<{ finishReason?: string }>
-      response?: {
-        text?: () => string
-        candidates?: Array<{
-          finishReason?: string
-          content: {
-            parts: Array<{ text: string }>
-          }
-        }>
-      }
-    }>
+    }): Promise<GeminiTextResponse>
   }
+}
+
+type RequestContents =
+  | string
+  | Array<{
+      role?: string
+      parts: Array<{ text?: string; inlineData?: { data: string; mimeType: string } }>
+    }>
+
+/** A bare prompt, or an image part followed by the prompt when editing. */
+function buildRequestContents(prompt: string, config: GenerationConfig): RequestContents {
+  if (!config.inputImage) {
+    return prompt
+  }
+  return [
+    {
+      parts: [
+        {
+          inlineData: {
+            data: config.inputImage,
+            mimeType: config.inputImageMimeType ?? DEFAULT_MIME_TYPE,
+          },
+        },
+        { text: prompt },
+      ],
+    },
+  ]
 }
 
 class GeminiTextClientImpl implements GeminiTextClient {
@@ -59,7 +83,7 @@ class GeminiTextClientImpl implements GeminiTextClient {
   constructor(config: Config) {
     this.genai = new GoogleGenAI({
       apiKey: config.geminiApiKey,
-    }) as unknown as GeminiAIInstance
+    })
   }
 
   async generateText(
@@ -87,36 +111,10 @@ class GeminiTextClientImpl implements GeminiTextClient {
   private async callGeminiAPI(prompt: string, config: GenerationConfig): Promise<string> {
     try {
       const timeoutSignal = AbortSignal.timeout(config.timeout || 15000)
-      let contents:
-        | string
-        | Array<{
-            role?: string
-            parts: Array<{ text?: string; inlineData?: { data: string; mimeType: string } }>
-          }>
-
-      if (config.inputImage) {
-        contents = [
-          {
-            parts: [
-              {
-                inlineData: {
-                  data: config.inputImage,
-                  mimeType: config.inputImageMimeType ?? DEFAULT_MIME_TYPE,
-                },
-              },
-              {
-                text: prompt,
-              },
-            ],
-          },
-        ]
-      } else {
-        contents = prompt
-      }
 
       const response = await this.genai.models.generateContent({
         model: this.modelName,
-        contents,
+        contents: buildRequestContents(prompt, config),
         config: {
           ...(config.systemInstruction !== undefined && {
             systemInstruction: config.systemInstruction,
@@ -134,30 +132,25 @@ class GeminiTextClientImpl implements GeminiTextClient {
         },
       })
 
-      const candidate = response.candidates?.[0] ?? response.response?.candidates?.[0]
+      const candidate = response.candidates?.[0]
       if (candidate?.finishReason === 'MAX_TOKENS') {
         throw new Error('Gemini text generation was truncated at the token limit')
       }
 
-      let responseText: string
-      if (typeof response.text === 'string') {
-        responseText = response.text
-      } else if (response.response?.text && typeof response.response.text === 'function') {
-        responseText = response.response.text()
-      } else if (response.response?.candidates?.[0]?.content?.parts?.[0]?.text) {
-        responseText = response.response.candidates[0].content.parts[0].text
-      } else {
+      const responseText = response.text
+      if (responseText === undefined) {
         throw new Error('Unable to extract text from API response')
       }
 
-      if (!responseText || responseText.trim().length === 0) {
+      if (responseText.trim().length === 0) {
         throw new Error('Empty response from Gemini API')
       }
 
       return responseText.trim()
     } catch (error) {
       throw new Error(
-        `Gemini API call failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Gemini API call failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       )
     }
   }

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -22,9 +22,22 @@ import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageC
 type OpenAIImageSize = `${number}x${number}`
 type OpenAIImageQuality = 'low' | 'medium' | 'high'
 // The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
-// enumerate the older fixed GPT image sizes. Keep the request cast local to this file.
-type OpenAIImageGenerateRequest = ImageGenerateParamsNonStreaming
-type OpenAIImageEditRequest = ImageEditParamsNonStreaming
+// enumerate the older fixed GPT image sizes. The widened `size` is confined to
+// this file through `OpenAIImagesApi`, which the SDK's images resource satisfies.
+type OpenAIImageGenerateRequest = Omit<ImageGenerateParamsNonStreaming, 'size'> & {
+  size: OpenAIImageSize
+}
+type OpenAIImageEditRequest = Omit<ImageEditParamsNonStreaming, 'size'> & {
+  size: OpenAIImageSize
+}
+
+interface OpenAIImagesApi {
+  generate(
+    body: OpenAIImageGenerateRequest,
+    options?: { signal?: AbortSignal }
+  ): Promise<ImagesResponse>
+  edit(body: OpenAIImageEditRequest, options?: { signal?: AbortSignal }): Promise<ImagesResponse>
+}
 type ImageEditApiParams = ImageApiParams & { inputImage: string }
 
 function mapQuality(quality: ImageQuality): OpenAIImageQuality {
@@ -38,11 +51,20 @@ function mapQuality(quality: ImageQuality): OpenAIImageQuality {
   }
 }
 
+function requestedLongEdge(imageSize: ImageApiParams['imageSize'], ratio: number): number {
+  if (imageSize === '4K') {
+    return 3840
+  }
+  if (imageSize === '2K') {
+    return 2048
+  }
+  return ratio === 1 ? 1024 : 1536
+}
+
 function mapSize(params: ImageApiParams): OpenAIImageSize {
   const [width = 1, height = 1] = (params.aspectRatio ?? '1:1').split(':').map(Number)
   const ratio = Math.max(width, height) / Math.min(width, height)
-  const requestedEdge =
-    params.imageSize === '4K' ? 3840 : params.imageSize === '2K' ? 2048 : ratio === 1 ? 1024 : 1536
+  const requestedEdge = requestedLongEdge(params.imageSize, ratio)
   // GPT Image 2: 16px increments, at most 3840px per edge and 8,294,400 pixels.
   // Flooring keeps the pixel cap intact even for near-square 4K requests.
   const longEdge = Math.floor(Math.min(requestedEdge, Math.sqrt(8_294_400 * ratio)) / 16) * 16
@@ -180,7 +202,8 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return await this.client.images.generate(request as unknown as OpenAIImageGenerateRequest, {
+    const images: OpenAIImagesApi = this.client.images
+    return await images.generate(request, {
       ...(params.signal && { signal: params.signal }),
     })
   }
@@ -208,7 +231,8 @@ class OpenAIImageClientImpl implements ImageClient {
       size,
     }
 
-    return await this.client.images.edit(request as unknown as OpenAIImageEditRequest, {
+    const images: OpenAIImagesApi = this.client.images
+    return await images.edit(request, {
       ...(params.signal && { signal: params.signal }),
     })
   }

--- a/src/api/openaiTextClient.ts
+++ b/src/api/openaiTextClient.ts
@@ -1,4 +1,8 @@
 import OpenAI from 'openai'
+import type {
+  Response as OpenAIResponse,
+  ResponseCreateParamsNonStreaming,
+} from 'openai/resources/responses/responses'
 import type { Result } from '../types/result.js'
 import { Err, Ok } from '../types/result.js'
 import type { Config } from '../utils/config.js'
@@ -10,18 +14,15 @@ import {
 } from './openaiCompatibleText.js'
 import type { GenerationConfig, TextClient } from './textClient.js'
 
-interface OpenAITextResponse {
-  output_text?: string
-  status?: 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete'
-  incomplete_details?: {
-    reason?: 'max_output_tokens' | 'content_filter'
-  } | null
-  output?: Array<{
-    content?: Array<{
-      type?: string
-      text?: string
-    }>
-  }>
+/**
+ * Minimal view of `client.responses` used here. Declaring it locally keeps the
+ * narrowing to the fields this client reads without asserting over the SDK type.
+ */
+interface OpenAIResponsesApi {
+  create(
+    body: ResponseCreateParamsNonStreaming,
+    options: { signal: AbortSignal }
+  ): Promise<OpenAIResponse>
 }
 
 const OPENAI_TEXT_MODEL = 'gpt-5.4-nano'
@@ -49,7 +50,8 @@ class OpenAITextClientImpl implements TextClient {
 
     try {
       const timeoutSignal = AbortSignal.timeout(timeout)
-      const response = (await this.client.responses.create(
+      const responses: OpenAIResponsesApi = this.client.responses
+      const response = await responses.create(
         {
           model: this.modelName,
           input: buildOpenAICompatibleInput(prompt, config),
@@ -59,7 +61,7 @@ class OpenAITextClientImpl implements TextClient {
           top_p: config.topP ?? 0.95,
         },
         { signal: config.signal ? AbortSignal.any([config.signal, timeoutSignal]) : timeoutSignal }
-      )) as OpenAITextResponse
+      )
 
       if (response.status === 'incomplete') {
         const reason = response.incomplete_details?.reason ?? 'unknown reason'
@@ -83,19 +85,16 @@ class OpenAITextClientImpl implements TextClient {
     }
   }
 
-  private extractResponseText(response: OpenAITextResponse): string {
+  private extractResponseText(response: OpenAIResponse): string {
     if (typeof response.output_text === 'string') {
       return response.output_text
     }
 
-    const textParts =
-      response.output?.flatMap((item) =>
-        item.content
-          ?.filter((content) => content.type === 'output_text' && typeof content.text === 'string')
-          .map((content) => content.text ?? '')
-      ) ?? []
-
-    return textParts.join('')
+    return response.output
+      .flatMap((item) => (item.type === 'message' ? item.content : []))
+      .filter((content) => content.type === 'output_text')
+      .map((content) => content.text)
+      .join('')
   }
 
   private handleError(

--- a/src/api/seedreamImageClient.ts
+++ b/src/api/seedreamImageClient.ts
@@ -105,13 +105,19 @@ function responseContractError(): ImageAPIError {
   })
 }
 
+function base64PaddingLength(value: string): number {
+  if (value.endsWith('==')) {
+    return 2
+  }
+  return value.endsWith('=') ? 1 : 0
+}
+
 function isStrictBase64(value: string): boolean {
   if (value.length === 0 || value.length % 4 !== 0) {
     return false
   }
 
-  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0
-  const contentLength = value.length - padding
+  const contentLength = value.length - base64PaddingLength(value)
 
   for (let index = 0; index < contentLength; index += 1) {
     const code = value.charCodeAt(index)
@@ -247,7 +253,7 @@ async function readBoundedJson(response: Response): Promise<Result<unknown, Imag
   const chunks: Uint8Array[] = []
   let totalBytes = 0
 
-  while (true) {
+  for (;;) {
     const { done, value } = await reader.read()
     if (done) {
       break
@@ -280,8 +286,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function calculateDecodedSize(base64: string): number {
-  const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0
-  return (base64.length / 4) * 3 - padding
+  return (base64.length / 4) * 3 - base64PaddingLength(base64)
 }
 
 function parseImagePayload(

--- a/src/business/__tests__/inputValidator.test.ts
+++ b/src/business/__tests__/inputValidator.test.ts
@@ -146,9 +146,9 @@ describe('inputValidator', () => {
     })
 
     it('should return error for invalid new feature parameters', () => {
-      const invalidParams: GenerateImageParams = {
+      const invalidParams = {
         prompt: 'Generate a beautiful landscape',
-        blendImages: 'true' as any,
+        blendImages: 'true',
       }
 
       const result = validateGenerateImageParams(invalidParams)
@@ -202,7 +202,7 @@ describe('inputValidator', () => {
       const params = {
         prompt: 'Generate a beautiful landscape',
         useGoogleSearch,
-      } as unknown as GenerateImageParams
+      }
 
       const result = validateGenerateImageParams(params)
 
@@ -243,9 +243,9 @@ describe('inputValidator', () => {
     })
 
     it('should reject invalid aspect ratio "7:3"', () => {
-      const invalidParams: GenerateImageParams = {
+      const invalidParams = {
         prompt: 'test',
-        aspectRatio: '7:3' as AspectRatio,
+        aspectRatio: '7:3',
       }
 
       const result = validateGenerateImageParams(invalidParams)
@@ -275,7 +275,7 @@ describe('inputValidator', () => {
     it('should reject invalid quality value', () => {
       const result = validateGenerateImageParams({
         prompt: 'test',
-        quality: 'ultra' as any,
+        quality: 'ultra',
       })
 
       expect(result.success).toBe(false)
@@ -304,7 +304,7 @@ describe('inputValidator', () => {
     it('should reject invalid provider value', () => {
       const result = validateGenerateImageParams({
         prompt: 'test',
-        provider: 'midjourney' as any,
+        provider: 'midjourney',
       })
 
       expect(result.success).toBe(false)

--- a/src/business/__tests__/responseBuilder.test.ts
+++ b/src/business/__tests__/responseBuilder.test.ts
@@ -48,12 +48,11 @@ describe('ResponseBuilder', () => {
       ['image/jpeg', '/path/to/image.jpg', 'image/jpeg'],
       ['image/webp', '/path/to/image.webp', 'image/webp'],
       ['image/png', '/path/to/image.png', 'image/png'],
-      [undefined, '/path/to/image.webp', 'image/webp'],
       ['', '/path/to/image.jpg', 'image/jpeg'],
       ['image/tiff', '/path/to/image.tiff', 'image/png'],
     ])('resolves metadata MIME %s and path %s to %s', (metadataMime, filePath, expectedMime) => {
       const response = responseBuilder.buildSuccessResponse(
-        makeGenerationResult(metadataMime as string),
+        makeGenerationResult(metadataMime),
         filePath
       )
       const contentData = JSON.parse(response.content[0].text)
@@ -154,7 +153,7 @@ describe('ResponseBuilder', () => {
     })
 
     it('should handle unknown errors gracefully', () => {
-      const error = new Error('Unknown error') as any
+      const error = new Error('Unknown error')
 
       const response = responseBuilder.buildErrorResponse(error)
 

--- a/src/business/__tests__/structuredPromptGenerator.test.ts
+++ b/src/business/__tests__/structuredPromptGenerator.test.ts
@@ -13,7 +13,7 @@ describe('StructuredPromptGenerator', () => {
     vi.clearAllMocks()
   })
 
-  function createGenerator(maxTokens = 1000) {
+  function createGenerator(maxTokens = 1000): StructuredPromptGeneratorImpl {
     return new StructuredPromptGeneratorImpl(mockGeminiTextClient, maxTokens)
   }
 
@@ -63,7 +63,7 @@ describe('StructuredPromptGenerator', () => {
         Ok('A warrior with detailed character features in the forest')
       )
 
-      const result = await generator.generateStructuredPrompt(userPrompt, features)
+      const result = await generator.generateStructuredPrompt(userPrompt, { features })
 
       expect(result.success).toBe(true)
       expect(mockGeminiTextClient.generateText).toHaveBeenCalledWith(
@@ -115,7 +115,7 @@ describe('StructuredPromptGenerator', () => {
       const structuredPrompt = 'Professional food photography of artfully plated pasta'
       vi.mocked(mockGeminiTextClient.generateText).mockResolvedValue(Ok(structuredPrompt))
 
-      const result = await generator.generateStructuredPrompt(userPrompt, {}, undefined, purpose)
+      const result = await generator.generateStructuredPrompt(userPrompt, { purpose })
 
       expect(result.success).toBe(true)
       if (result.success) {

--- a/src/business/fileManager.ts
+++ b/src/business/fileManager.ts
@@ -51,8 +51,8 @@ export async function readInputImage(inputPath: string): Promise<InputImage> {
   let realPath: string
   try {
     realPath = await fs.realpath(path.resolve(inputPath))
-  } catch {
-    throw new SecurityError('File path cannot be resolved')
+  } catch (error) {
+    throw new SecurityError('File path cannot be resolved', { cause: error })
   }
 
   const extension = path.extname(realPath).toLowerCase()
@@ -78,7 +78,9 @@ export async function readInputImage(inputPath: string): Promise<InputImage> {
     while (observedBytes < boundedBuffer.length) {
       const readLength = Math.min(64 * 1024, boundedBuffer.length - observedBytes)
       const { bytesRead } = await fileHandle.read(boundedBuffer, observedBytes, readLength, null)
-      if (bytesRead === 0) break
+      if (bytesRead === 0) {
+        break
+      }
 
       observedBytes += bytesRead
       if (observedBytes > MAX_IMAGE_SIZE) {

--- a/src/business/inputValidator.ts
+++ b/src/business/inputValidator.ts
@@ -1,6 +1,12 @@
 import { existsSync } from 'node:fs'
 import { extname } from 'node:path'
-import type { GenerateImageParams } from '../types/mcp.js'
+import type {
+  AspectRatio,
+  GenerateImageParams,
+  ImageProvider,
+  ImageQuality,
+  ImageSize,
+} from '../types/mcp.js'
 import {
   ASPECT_RATIO_VALUES,
   IMAGE_PROVIDER_VALUES,
@@ -137,10 +143,173 @@ function validateImagePath(imagePath?: string): Result<string | undefined, Input
   return Ok(imagePath)
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readOptionalString(input: Record<string, unknown>, field: string): string | undefined {
+  const value = input[field]
+  return typeof value === 'string' ? value : undefined
+}
+
+function readOptionalBoolean(input: Record<string, unknown>, field: string): boolean | undefined {
+  const value = input[field]
+  return typeof value === 'boolean' ? value : undefined
+}
+
+/** Fields whose only shared requirement is being a string when present. */
+const OPTIONAL_STRING_FIELDS = [
+  'fileName',
+  'inputImagePath',
+  'purpose',
+  'inputImage',
+  'inputImageMimeType',
+  'aspectRatio',
+  'imageSize',
+  'quality',
+  'provider',
+] as const
+
+/** Flags whose only shared requirement is being a boolean when present. */
+const OPTIONAL_BOOLEAN_FIELDS = [
+  {
+    name: 'blendImages',
+    suggestion:
+      'Use true or false for blendImages parameter to enable/disable multi-image blending',
+  },
+  {
+    name: 'maintainCharacterConsistency',
+    suggestion:
+      'Use true or false for maintainCharacterConsistency parameter to enable/disable character consistency',
+  },
+  {
+    name: 'useWorldKnowledge',
+    suggestion:
+      'Use true or false for useWorldKnowledge parameter to enable/disable world knowledge integration',
+  },
+  {
+    name: 'useGoogleSearch',
+    suggestion:
+      'Use true or false for useGoogleSearch parameter to enable/disable Google Search grounding',
+  },
+] as const
+
+function checkOptionalStringFields(
+  input: Record<string, unknown>
+): InputValidationError | undefined {
+  for (const field of OPTIONAL_STRING_FIELDS) {
+    const value = input[field]
+    if (value !== undefined && typeof value !== 'string') {
+      return new InputValidationError(
+        `${field} must be a string`,
+        `Provide a string for ${field} or omit it`
+      )
+    }
+  }
+  return undefined
+}
+
+function checkOptionalBooleanFields(
+  input: Record<string, unknown>
+): InputValidationError | undefined {
+  for (const { name, suggestion } of OPTIONAL_BOOLEAN_FIELDS) {
+    const value = input[name]
+    if (value !== undefined && typeof value !== 'boolean') {
+      return new InputValidationError(`${name} must be a boolean value`, suggestion)
+    }
+  }
+  return undefined
+}
+
+function isMemberOf<T extends string>(values: readonly T[], value: string): value is T {
+  return values.some((candidate) => candidate === value)
+}
+
+interface EnumFields {
+  aspectRatio?: AspectRatio
+  imageSize?: ImageSize
+  quality?: ImageQuality
+  provider?: ImageProvider
+}
+
+/**
+ * Validate the four enum-valued fields. Each keeps its own message; only the
+ * membership check is shared.
+ */
+function validateEnumFields(
+  input: Record<string, unknown>
+): Result<EnumFields, InputValidationError> {
+  const fields: EnumFields = {}
+
+  const imageSize = readOptionalString(input, 'imageSize')
+  if (imageSize !== undefined) {
+    if (!isMemberOf(IMAGE_SIZE_VALUES, imageSize)) {
+      return Err(
+        new InputValidationError(
+          `Invalid image size: ${imageSize}`,
+          `Use one of: ${IMAGE_SIZE_VALUES.join(', ')}`
+        )
+      )
+    }
+    fields.imageSize = imageSize
+  }
+
+  const aspectRatio = readOptionalString(input, 'aspectRatio')
+  if (aspectRatio !== undefined) {
+    if (!isMemberOf(SUPPORTED_ASPECT_RATIOS, aspectRatio)) {
+      return Err(
+        new InputValidationError(
+          `Invalid aspect ratio: ${aspectRatio}. Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`,
+          `Please use one of the supported aspect ratios: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`
+        )
+      )
+    }
+    fields.aspectRatio = aspectRatio
+  }
+
+  const quality = readOptionalString(input, 'quality')
+  if (quality !== undefined) {
+    if (!isMemberOf(SUPPORTED_QUALITY_VALUES, quality)) {
+      return Err(
+        new InputValidationError(
+          `Invalid quality value: "${quality}". Supported values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`,
+          `Please use one of the supported quality values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`
+        )
+      )
+    }
+    fields.quality = quality
+  }
+
+  const provider = readOptionalString(input, 'provider')
+  if (provider !== undefined) {
+    if (!isMemberOf(SUPPORTED_PROVIDER_VALUES, provider)) {
+      return Err(
+        new InputValidationError(
+          `Invalid provider value: "${provider}". Supported values: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`,
+          `Please use one of the supported providers: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`
+        )
+      )
+    }
+    fields.provider = provider
+  }
+
+  return Ok(fields)
+}
+
+function assignOptional<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: T[K] | undefined
+): void {
+  if (value !== undefined) {
+    target[key] = value
+  }
+}
+
 export function validateGenerateImageParams(
   input: unknown
 ): Result<GenerateImageParams, InputValidationError> {
-  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+  if (!isPlainObject(input)) {
     return Err(
       new InputValidationError(
         'Tool arguments must be an object',
@@ -148,119 +317,50 @@ export function validateGenerateImageParams(
       )
     )
   }
-  for (const field of [
-    'fileName',
-    'inputImagePath',
-    'purpose',
-    'inputImage',
-    'inputImageMimeType',
-    'aspectRatio',
-    'imageSize',
-    'quality',
-    'provider',
-  ] as const) {
-    const value = (input as Record<string, unknown>)[field]
-    if (value !== undefined && typeof value !== 'string') {
-      return Err(
-        new InputValidationError(
-          `${field} must be a string`,
-          `Provide a string for ${field} or omit it`
-        )
-      )
-    }
+
+  const stringFieldError = checkOptionalStringFields(input)
+  if (stringFieldError) {
+    return Err(stringFieldError)
   }
-  // The remaining required string, boolean, and enum fields are checked below.
-  const params = input as GenerateImageParams
-  const promptResult = validatePrompt(params.prompt)
+
+  const promptResult = validatePrompt(input['prompt'])
   if (!promptResult.success) {
     return Err(promptResult.error)
   }
 
-  const imagePathResult = validateImagePath(params.inputImagePath)
+  const inputImagePath = readOptionalString(input, 'inputImagePath')
+  const imagePathResult = validateImagePath(inputImagePath)
   if (!imagePathResult.success) {
     return Err(imagePathResult.error)
   }
 
-  if (params.blendImages !== undefined && typeof params.blendImages !== 'boolean') {
-    return Err(
-      new InputValidationError(
-        'blendImages must be a boolean value',
-        'Use true or false for blendImages parameter to enable/disable multi-image blending'
-      )
-    )
+  const booleanFieldError = checkOptionalBooleanFields(input)
+  if (booleanFieldError) {
+    return Err(booleanFieldError)
   }
 
-  if (
-    params.maintainCharacterConsistency !== undefined &&
-    typeof params.maintainCharacterConsistency !== 'boolean'
-  ) {
-    return Err(
-      new InputValidationError(
-        'maintainCharacterConsistency must be a boolean value',
-        'Use true or false for maintainCharacterConsistency parameter to enable/disable character consistency'
-      )
-    )
-  }
-
-  if (params.useWorldKnowledge !== undefined && typeof params.useWorldKnowledge !== 'boolean') {
-    return Err(
-      new InputValidationError(
-        'useWorldKnowledge must be a boolean value',
-        'Use true or false for useWorldKnowledge parameter to enable/disable world knowledge integration'
-      )
-    )
-  }
-
-  if (params.useGoogleSearch !== undefined && typeof params.useGoogleSearch !== 'boolean') {
-    return Err(
-      new InputValidationError(
-        'useGoogleSearch must be a boolean value',
-        'Use true or false for useGoogleSearch parameter to enable/disable Google Search grounding'
-      )
-    )
-  }
-
-  if (params.inputImage || params.inputImageMimeType) {
-    const imageResult = validateBase64Image(params.inputImage, params.inputImageMimeType)
+  const inputImage = readOptionalString(input, 'inputImage')
+  const inputImageMimeType = readOptionalString(input, 'inputImageMimeType')
+  if (inputImage || inputImageMimeType) {
+    const imageResult = validateBase64Image(inputImage, inputImageMimeType)
     if (!imageResult.success) {
       return Err(imageResult.error)
     }
   }
 
-  if (params.imageSize !== undefined && !IMAGE_SIZE_VALUES.includes(params.imageSize)) {
-    return Err(
-      new InputValidationError(
-        `Invalid image size: ${params.imageSize}`,
-        `Use one of: ${IMAGE_SIZE_VALUES.join(', ')}`
-      )
-    )
+  const enumFieldsResult = validateEnumFields(input)
+  if (!enumFieldsResult.success) {
+    return Err(enumFieldsResult.error)
   }
 
-  if (params.aspectRatio !== undefined && !SUPPORTED_ASPECT_RATIOS.includes(params.aspectRatio)) {
-    return Err(
-      new InputValidationError(
-        `Invalid aspect ratio: ${params.aspectRatio}. Supported values: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`,
-        `Please use one of the supported aspect ratios: ${SUPPORTED_ASPECT_RATIOS.join(', ')}`
-      )
-    )
-  }
-
-  if (params.quality !== undefined && !SUPPORTED_QUALITY_VALUES.includes(params.quality)) {
-    return Err(
-      new InputValidationError(
-        `Invalid quality value: "${params.quality}". Supported values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`,
-        `Please use one of the supported quality values: ${SUPPORTED_QUALITY_VALUES.join(', ')}`
-      )
-    )
-  }
-
-  if (params.provider !== undefined && !SUPPORTED_PROVIDER_VALUES.includes(params.provider)) {
-    return Err(
-      new InputValidationError(
-        `Invalid provider value: "${params.provider}". Supported values: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`,
-        `Please use one of the supported providers: ${SUPPORTED_PROVIDER_VALUES.join(', ')}`
-      )
-    )
+  const params: GenerateImageParams = { prompt: promptResult.data, ...enumFieldsResult.data }
+  assignOptional(params, 'fileName', readOptionalString(input, 'fileName'))
+  assignOptional(params, 'inputImagePath', inputImagePath)
+  assignOptional(params, 'inputImage', inputImage)
+  assignOptional(params, 'inputImageMimeType', inputImageMimeType)
+  assignOptional(params, 'purpose', readOptionalString(input, 'purpose'))
+  for (const { name } of OPTIONAL_BOOLEAN_FIELDS) {
+    assignOptional(params, name, readOptionalBoolean(input, name))
   }
 
   return Ok(params)

--- a/src/business/responseBuilder.ts
+++ b/src/business/responseBuilder.ts
@@ -55,7 +55,7 @@ function buildPublicDetails(error: BaseError): Record<string, unknown> | undefin
   return Object.keys(details).length > 0 ? details : undefined
 }
 
-function resolveMimeType(metadataMimeType: string | undefined, filePath: string): string {
+function resolveMimeType(metadataMimeType: string, filePath: string): string {
   if (metadataMimeType && SUPPORTED_MIME_TYPES.includes(metadataMimeType)) {
     return metadataMimeType
   }

--- a/src/business/structuredPromptGenerator.ts
+++ b/src/business/structuredPromptGenerator.ts
@@ -44,14 +44,20 @@ export interface FeatureFlags {
   useWorldKnowledge?: boolean
 }
 
+export interface StructuredPromptOptions {
+  /** Defaults to no feature flags. */
+  features?: FeatureFlags
+  /** Base64 image data; when present the editing system instruction is used. */
+  inputImageData?: string
+  purpose?: string
+  inputImageMimeType?: string
+  signal?: AbortSignal
+}
+
 export interface StructuredPromptGenerator {
   generateStructuredPrompt(
     userPrompt: string,
-    features?: FeatureFlags,
-    inputImageData?: string,
-    purpose?: string,
-    inputImageMimeType?: string,
-    signal?: AbortSignal
+    options?: StructuredPromptOptions
   ): Promise<Result<string, Error>>
 }
 
@@ -63,12 +69,9 @@ export class StructuredPromptGeneratorImpl implements StructuredPromptGenerator 
 
   async generateStructuredPrompt(
     userPrompt: string,
-    features: FeatureFlags = {},
-    inputImageData?: string,
-    purpose?: string,
-    inputImageMimeType?: string,
-    signal?: AbortSignal
+    options: StructuredPromptOptions = {}
   ): Promise<Result<string, Error>> {
+    const { features = {}, inputImageData, purpose, inputImageMimeType, signal } = options
     try {
       if (!userPrompt || userPrompt.trim().length === 0) {
         return Err(new GeminiAPIError('User prompt cannot be empty'))

--- a/src/server-main.ts
+++ b/src/server-main.ts
@@ -1,5 +1,6 @@
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { MCPServerImpl } from './server/mcpServer.js'
+import { toError } from './utils/errors.js'
 import { Logger } from './utils/logger.js'
 
 const logger = new Logger()
@@ -22,15 +23,16 @@ async function main(): Promise<void> {
 
     logger.info('mcp-startup', 'Image Generator MCP Server started successfully')
   } catch (error) {
-    logger.error('mcp-startup', 'Failed to start MCP server', error as Error, {
-      errorType: (error as Error)?.constructor?.name,
-      stack: (error as Error)?.stack,
+    const startupError = toError(error)
+    logger.error('mcp-startup', 'Failed to start MCP server', startupError, {
+      errorType: startupError.constructor.name,
+      stack: startupError.stack,
     })
     process.exit(1)
   }
 }
 
-main().catch((error) => {
-  logger.error('mcp-startup', 'Fatal error during startup', error as Error)
+main().catch((error: unknown) => {
+  logger.error('mcp-startup', 'Fatal error during startup', toError(error))
   process.exit(1)
 })

--- a/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
+++ b/src/server/__tests__/byteplusSeedreamProvider.int.test.ts
@@ -3,23 +3,43 @@ import { constants as fsConstants } from 'node:fs'
 import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { MAX_IMAGE_SIZE } from '../../business/inputValidator.js'
+import { isRecord, parseJsonObject, recordOrEmpty } from '../../tests/helpers/inspect.js'
 import { createMCPServer } from '../mcpServer.js'
 
-const fileSystem = vi.hoisted(() => ({
-  actualOpen: undefined as typeof import('node:fs/promises').open | undefined,
+interface FileSystemStub {
+  actualOpen: typeof import('node:fs/promises').open | undefined
+  open: Mock
+}
+
+const fileSystem: FileSystemStub = vi.hoisted(() => ({
+  actualOpen: undefined,
   open: vi.fn(),
 }))
 
-const transports = vi.hoisted(() => ({
+interface TransportStubs {
+  fetch: Mock<(input: unknown, init?: RequestInit) => unknown>
+  googleConstructor: Mock
+  googleEnhancedText: string
+  googleGenerateContent: Mock
+  googleTextError: Error | undefined
+  openAIConstructorError: Error | undefined
+  openAIConstructorOptions: unknown[]
+  openAIImageEdit: Mock
+  openAIImageGenerate: Mock
+  openAIResponsesCreate: Mock
+  toFile: Mock
+}
+
+const transports: TransportStubs = vi.hoisted(() => ({
   fetch: vi.fn(),
   googleConstructor: vi.fn(),
   googleEnhancedText: '',
   googleGenerateContent: vi.fn(),
-  googleTextError: undefined as Error | undefined,
-  openAIConstructorError: undefined as Error | undefined,
-  openAIConstructorOptions: [] as unknown[],
+  googleTextError: undefined,
+  openAIConstructorError: undefined,
+  openAIConstructorOptions: [],
   openAIImageEdit: vi.fn(),
   openAIImageGenerate: vi.fn(),
   openAIResponsesCreate: vi.fn(),
@@ -258,13 +278,13 @@ function configureGemini(outputDirectory: string): void {
 
 function parsePublicResponse(
   result: Awaited<ReturnType<ReturnType<typeof createMCPServer>['callTool']>>
-) {
+): Record<string, unknown> {
   const firstContent = result.content.at(0)
   if (firstContent?.type !== 'text') {
     return {}
   }
 
-  return JSON.parse(firstContent.text) as Record<string, unknown>
+  return parseJsonObject(firstContent.text, 'public tool response')
 }
 
 function observeLastImageRequest(): {
@@ -275,12 +295,12 @@ function observeLastImageRequest(): {
 } {
   const lastCall = transports.fetch.mock.calls.at(-1)
   const url = lastCall?.[0]
-  const init = lastCall?.[1] as RequestInit | undefined
+  const init = lastCall?.[1]
   let body: Record<string, unknown> = {}
 
   if (typeof init?.body === 'string') {
     try {
-      body = JSON.parse(init.body) as Record<string, unknown>
+      body = parseJsonObject(init.body, 'image request body')
     } catch {
       body = {}
     }
@@ -303,15 +323,16 @@ function extractTextInput(request: Record<string, unknown>): string {
   }
 
   for (const item of request.input) {
-    if (!item || typeof item !== 'object') continue
-    const content = (item as { content?: unknown }).content
-    if (!Array.isArray(content)) continue
-    const textPart = content.find(
-      (part) =>
-        part && typeof part === 'object' && (part as { type?: unknown }).type === 'input_text'
-    ) as { text?: unknown } | undefined
-    if (typeof textPart?.text === 'string') {
-      return textPart.text
+    if (!isRecord(item)) {
+      continue
+    }
+    const content = item['content']
+    if (!Array.isArray(content)) {
+      continue
+    }
+    const textPart = content.find((part) => isRecord(part) && part['type'] === 'input_text')
+    if (isRecord(textPart) && typeof textPart['text'] === 'string') {
+      return textPart['text']
     }
   }
 
@@ -325,13 +346,789 @@ function capturedLogs(): string {
     .join('\n')
 }
 
+type FailureRow = {
+  args?: Record<string, unknown>
+  arkApiKey?: string
+  deleteArkApiKey?: boolean
+  expectedCode: string
+  expectedDecodeCalls: number
+  expectedImageCalls: number
+  expectedParseCalls: number
+  expectedTextCalls: number
+  fetchError?: Error
+  name: string
+  responseFactory?: (responseSentinel: string, imageSentinel: string) => Response
+  sensitiveValues?: string[]
+  skipPromptEnhancement?: boolean
+}
+
+/** Every failure this provider must contain before the next side effect. */
+function buildFailureRows(): FailureRow[] {
+  return [
+    {
+      name: 'missing-key',
+      deleteArkApiKey: true,
+      expectedCode: 'CONFIG_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'empty-key',
+      arkApiKey: '   ',
+      expectedCode: 'CONFIG_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'google-search',
+      args: { useGoogleSearch: true },
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'google-search-string',
+      args: { useGoogleSearch: 'private-invalid-google-search-string' },
+      expectedCode: 'INPUT_VALIDATION_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      sensitiveValues: ['private-invalid-google-search-string'],
+    },
+    {
+      name: 'google-search-number',
+      args: { useGoogleSearch: 8675309 },
+      expectedCode: 'INPUT_VALIDATION_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      sensitiveValues: ['8675309'],
+    },
+    {
+      name: 'google-search-null',
+      args: { useGoogleSearch: null },
+      expectedCode: 'INPUT_VALIDATION_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'google-search-object',
+      args: { useGoogleSearch: { marker: 'private-invalid-google-search-object' } },
+      expectedCode: 'INPUT_VALIDATION_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      sensitiveValues: ['private-invalid-google-search-object'],
+    },
+    {
+      name: 'fast-pro-4k',
+      args: { imageSize: '4K', quality: 'fast' },
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'pro-4k',
+      args: { imageSize: '4K', quality: 'quality' },
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'unsupported-editing-input',
+      args: { inputImagePath: '__CREATE_UNSUPPORTED_INPUT__' },
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 0,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+    },
+    {
+      name: 'missing-data',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse({
+          response_sentinel: responseSentinel,
+          image_sentinel: imageSentinel,
+        }),
+    },
+    {
+      name: 'extra-images',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel): Response => {
+        const imageBytes = createPngFixture(imageSentinel)
+        return createJsonResponse({
+          response_sentinel: responseSentinel,
+          data: [
+            { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
+            { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
+          ],
+        })
+      },
+    },
+    {
+      name: 'url-only',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse({
+          response_sentinel: responseSentinel,
+          image_sentinel: imageSentinel,
+          data: [{ url: `https://attacker.invalid/${imageSentinel}.png` }],
+        }),
+    },
+    {
+      name: 'stream-event',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        new Response(
+          `data: ${JSON.stringify({
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            data: [],
+          })}\n\n`,
+          {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          }
+        ),
+    },
+    {
+      name: 'malformed-base64',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel): Response => {
+        const validBase64 = createPngFixture(imageSentinel).toString('base64')
+        return createJsonResponse({
+          response_sentinel: responseSentinel,
+          data: [
+            {
+              b64_json: `${validBase64.slice(0, -1)}*`,
+              mime_type: 'image/png',
+            },
+          ],
+        })
+      },
+    },
+    {
+      name: 'empty-base64',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse({
+          response_sentinel: responseSentinel,
+          image_sentinel: imageSentinel,
+          data: [{ b64_json: '', mime_type: 'image/png' }],
+        }),
+    },
+    {
+      name: 'content-length-over-48-mib',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        new Response(`${responseSentinel}:${imageSentinel}`, {
+          status: 200,
+          headers: {
+            'content-length': String(48 * 1024 * 1024 + 1),
+            'content-type': 'application/json',
+          },
+        }),
+    },
+    {
+      name: 'chunked-body-over-48-mib',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+    },
+    {
+      name: 'decoded-size-over-32-mib',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse({
+          response_sentinel: responseSentinel,
+          image_sentinel: imageSentinel,
+          data: [
+            {
+              b64_json: 'A'.repeat(Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)),
+              mime_type: 'image/png',
+            },
+          ],
+        }),
+    },
+    {
+      name: 'non-png-magic',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 1,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse({
+          response_sentinel: responseSentinel,
+          data: [
+            {
+              b64_json: Buffer.from(`not-a-png:${imageSentinel}`).toString('base64'),
+              mime_type: 'image/png',
+            },
+          ],
+        }),
+    },
+    {
+      name: 'wrong-mime',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 1,
+      expectedImageCalls: 1,
+      expectedParseCalls: 1,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel): Response => {
+        const imageBytes = createPngFixture(imageSentinel)
+        return createJsonResponse({
+          response_sentinel: responseSentinel,
+          data: [{ b64_json: imageBytes.toString('base64'), mime_type: 'image/jpeg' }],
+        })
+      },
+    },
+    {
+      name: 'abort-timeout',
+      expectedCode: 'NETWORK_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      fetchError: new DOMException('synthetic timeout', 'AbortError'),
+    },
+    {
+      name: 'http-401',
+      expectedCode: 'IMAGE_API_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse(
+          {
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            error: { message: RAW_BODY_MARKER },
+          },
+          401
+        ),
+    },
+    {
+      name: 'http-500',
+      expectedCode: 'NETWORK_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      responseFactory: (responseSentinel, imageSentinel) =>
+        createJsonResponse(
+          {
+            response_sentinel: responseSentinel,
+            image_sentinel: imageSentinel,
+            error: { message: RAW_BODY_MARKER },
+          },
+          500
+        ),
+    },
+    {
+      name: 'network-failure',
+      expectedCode: 'NETWORK_ERROR',
+      expectedDecodeCalls: 0,
+      expectedImageCalls: 1,
+      expectedParseCalls: 0,
+      expectedTextCalls: 0,
+      skipPromptEnhancement: true,
+      fetchError: new TypeError(`fetch failed: ${RAW_BODY_MARKER}`),
+    },
+  ]
+}
+
+const PUBLIC_ERROR_KEYS = ['code', 'details', 'message', 'suggestion', 'timestamp']
+const PUBLIC_DETAIL_KEYS = ['provider', 'stage', 'statusCode', 'upstreamMessage']
+
+/** A contained failure exposes only the allow-listed error and detail keys. */
+function assertPublicErrorShape(
+  result: Awaited<ReturnType<ReturnType<typeof createMCPServer>['callTool']>>,
+  row: FailureRow
+): void {
+  const publicResponse = parsePublicResponse(result)
+  const publicError = recordOrEmpty(publicResponse['error'])
+
+  expect.soft(result.isError, row.name).toBe(true)
+  expect.soft(publicError['code'], row.name).toBe(row.expectedCode)
+  expect.soft(Object.keys(result).sort(), row.name).toEqual(['content', 'isError'])
+  expect.soft(Object.keys(publicResponse), row.name).toEqual(['error'])
+  expect
+    .soft(
+      Object.keys(publicError).every((key) => PUBLIC_ERROR_KEYS.includes(key)),
+      row.name
+    )
+    .toBe(true)
+
+  const publicDetails = isRecord(publicError['details']) ? publicError['details'] : undefined
+  if (!publicDetails) {
+    return
+  }
+  expect
+    .soft(
+      Object.keys(publicDetails).every((key) => PUBLIC_DETAIL_KEYS.includes(key)),
+      row.name
+    )
+    .toBe(true)
+}
+
+interface RowSentinels {
+  responseSentinel: string
+  imageSentinel: string
+}
+
+/**
+ * Arrange the fetch double for one failure row. Returns the stream `cancel`
+ * spy when the row streams a body, so the caller can assert it was cancelled.
+ */
+function arrangeFailureTransport(
+  row: FailureRow,
+  sentinels: RowSentinels
+): ReturnType<typeof vi.fn> | undefined {
+  const { responseSentinel, imageSentinel } = sentinels
+
+  if (row.name === 'chunked-body-over-48-mib') {
+    const chunkedCancel = vi.fn()
+    transports.fetch.mockImplementation(async () =>
+      createChunkedResponse(`${responseSentinel}:${imageSentinel}`, chunkedCancel)
+    )
+    return chunkedCancel
+  }
+
+  if (row.fetchError) {
+    const message = `${row.fetchError.message}:${responseSentinel}:${imageSentinel}`
+    transports.fetch.mockRejectedValue(
+      row.fetchError instanceof DOMException
+        ? new DOMException(message, row.fetchError.name)
+        : new TypeError(message)
+    )
+    return undefined
+  }
+
+  if (row.responseFactory) {
+    transports.fetch.mockImplementation(async () =>
+      row.responseFactory?.(responseSentinel, imageSentinel)
+    )
+  }
+  return undefined
+}
+
+/** A JSON response whose body is streamed past the accepted size limit. */
+function createChunkedResponse(marker: string, cancel: () => void): Response {
+  let emittedChunks = 0
+  const markerChunk = new TextEncoder().encode(marker)
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        if (emittedChunks === 0) {
+          controller.enqueue(markerChunk)
+          emittedChunks += 1
+        } else if (emittedChunks < 50) {
+          controller.enqueue(new Uint8Array(1024 * 1024))
+          emittedChunks += 1
+        } else {
+          controller.close()
+        }
+      },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } }
+  )
+}
+
+/** Tool arguments for one failure row, creating an unsupported input file on demand. */
+async function buildFailureArgs(
+  row: FailureRow,
+  index: number,
+  outputDirectory: string,
+  requestSentinel: string
+): Promise<Record<string, unknown>> {
+  const args: Record<string, unknown> = {
+    prompt: requestSentinel,
+    fileName: `failure-${index}.png`,
+    ...row.args,
+  }
+
+  if (row.args?.['inputImagePath'] !== '__CREATE_UNSUPPORTED_INPUT__') {
+    return args
+  }
+
+  const unsupportedInputPath = join(outputDirectory, 'unsupported.gif')
+  await writeFile(unsupportedInputPath, `${INPUT_IMAGE_MARKER}:${row.name}`)
+  return { ...args, inputImagePath: unsupportedInputPath }
+}
+
+/** The base64 payload this failure row is expected to attempt to decode, if any. */
+function expectedDecodePayload(row: FailureRow, imageSentinel: string): string | undefined {
+  const pngBase64 = createPngFixture(imageSentinel).toString('base64')
+  switch (row.name) {
+    case 'extra-images':
+    case 'wrong-mime':
+      return pngBase64
+    case 'malformed-base64':
+      return `${pngBase64.slice(0, -1)}*`
+    case 'empty-base64':
+      return ''
+    case 'non-png-magic':
+      return Buffer.from(`not-a-png:${imageSentinel}`).toString('base64')
+    default:
+      return undefined
+  }
+}
+
+interface SavedPngExpectation {
+  outputDirectory: string
+  fileName: string
+  expectedBytes: Buffer
+  expectedModel: string
+}
+
+type SupportedRow = {
+  args: Record<string, unknown>
+  expectedAspectRatio: (typeof ALL_ASPECT_RATIOS)[number]
+  expectedModel: 'dola-seedream-5-0-pro-260628'
+  expectedQuality: 'fast' | 'balanced' | 'quality'
+  expectedResolution: '1K' | '2K'
+  inputImage?: boolean
+  name: string
+  skipPromptEnhancement?: boolean
+  textFailure?: boolean
+}
+
+/** The full matrix of supported request shapes this provider must honour. */
+function buildSupportedRows(): SupportedRow[] {
+  return [
+    {
+      name: 'prompt-baseline',
+      args: {},
+      expectedAspectRatio: '1:1',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'fast',
+      expectedResolution: '1K',
+    },
+    {
+      name: 'enhancement-failure-original-fallback',
+      args: { aspectRatio: '4:3', quality: 'balanced' },
+      expectedAspectRatio: '4:3',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'balanced',
+      expectedResolution: '1K',
+      textFailure: true,
+    },
+    {
+      name: 'enhancement-skip',
+      args: { aspectRatio: '9:16', imageSize: '2K', quality: 'quality' },
+      expectedAspectRatio: '9:16',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'quality',
+      expectedResolution: '2K',
+      skipPromptEnhancement: true,
+    },
+    {
+      name: 'fast-route',
+      args: { quality: 'fast' },
+      expectedAspectRatio: '1:1',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'fast',
+      expectedResolution: '1K',
+    },
+    {
+      name: 'balanced-route',
+      args: { quality: 'balanced' },
+      expectedAspectRatio: '1:1',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'balanced',
+      expectedResolution: '1K',
+    },
+    {
+      name: 'quality-request-overrides-captured-fast',
+      args: { quality: 'quality' },
+      expectedAspectRatio: '1:1',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'quality',
+      expectedResolution: '1K',
+    },
+    {
+      name: 'single-input-image',
+      args: { quality: 'quality' },
+      expectedAspectRatio: '1:1',
+      expectedModel: 'dola-seedream-5-0-pro-260628',
+      expectedQuality: 'quality',
+      expectedResolution: '1K',
+      inputImage: true,
+    },
+    ...ALL_ASPECT_RATIOS.map(
+      (aspectRatio): SupportedRow => ({
+        name: `aspect-${aspectRatio}`,
+        args: { aspectRatio, imageSize: '2K', quality: 'fast' },
+        expectedAspectRatio: aspectRatio,
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'fast',
+        expectedResolution: '2K',
+      })
+    ),
+    ...['blendImages', 'maintainCharacterConsistency', 'useWorldKnowledge', 'useGoogleSearch'].map(
+      (flag): SupportedRow => ({
+        name: `false-${flag}`,
+        args: { [flag]: false },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'fast',
+        expectedResolution: '1K',
+      })
+    ),
+    ...[
+      ['blendImages', true],
+      ['maintainCharacterConsistency', true],
+      ['useWorldKnowledge', true],
+      ['purpose', 'cookbook cover'],
+    ].map(
+      ([flag, value]): SupportedRow => ({
+        name: `prompt-only-${String(flag)}`,
+        args: { [String(flag)]: value },
+        expectedAspectRatio: '1:1',
+        expectedModel: 'dola-seedream-5-0-pro-260628',
+        expectedQuality: 'fast',
+        expectedResolution: '1K',
+      })
+    ),
+  ]
+}
+
+interface SupportedRowFixture {
+  outputDirectory: string
+  fileName: string
+  requestPrompt: string
+  enhancedPrompt: string
+  responseSentinel: string
+  imageSentinel: string
+  expectedImageBytes: Buffer
+  inputImageBytes: Buffer | undefined
+  inputImagePath: string | undefined
+}
+
+/** Per-row directories, prompts and image bytes, each carrying a unique sentinel. */
+async function prepareSupportedRowFixture(
+  row: SupportedRow,
+  index: number
+): Promise<SupportedRowFixture> {
+  const imageSentinel = `${row.name}:decoded-image-sentinel`
+  const fixture: SupportedRowFixture = {
+    outputDirectory: await createOutputDirectory(),
+    fileName: `supported-${index}.png`,
+    requestPrompt: `${ORIGINAL_PROMPT}:${row.name}:request-body-sentinel`,
+    enhancedPrompt: `${ENHANCED_PROMPT}:${row.name}:image-body-sentinel`,
+    responseSentinel: `${row.name}:response-body-sentinel`,
+    imageSentinel,
+    expectedImageBytes: createPngFixture(imageSentinel),
+    inputImageBytes: undefined,
+    inputImagePath: undefined,
+  }
+
+  if (row.inputImage) {
+    fixture.inputImageBytes = createPngFixture(`${row.name}:input-image-sentinel`)
+    fixture.inputImagePath = join(await createOutputDirectory(), `${row.name}-input.png`)
+    await writeFile(fixture.inputImagePath, fixture.inputImageBytes)
+  }
+
+  return fixture
+}
+
+/** The exact Seedream image request body one supported row must produce. */
+function buildExpectedImageRequest(
+  row: SupportedRow,
+  finalPrompt: string,
+  inputImageBytes: Buffer | undefined
+): Record<string, unknown> {
+  return {
+    model: row.expectedModel,
+    prompt: finalPrompt,
+    size: row.expectedResolution,
+    response_format: 'b64_json',
+    output_format: 'png',
+    stream: false,
+    watermark: false,
+    optimize_prompt_options: {
+      mode: row.expectedQuality === 'fast' ? 'fast' : 'standard',
+    },
+    ...(inputImageBytes && {
+      image: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
+    }),
+  }
+}
+
+/** Point every transport double at this row's fixtures. */
+function arrangeSupportedRow(row: SupportedRow, fixture: SupportedRowFixture): void {
+  configureSeedream(fixture.outputDirectory, {
+    imageQuality: 'fast',
+    skipPromptEnhancement: row.skipPromptEnhancement,
+  })
+  transports.googleEnhancedText = fixture.enhancedPrompt
+  transports.openAIResponsesCreate.mockResolvedValue({ output_text: fixture.enhancedPrompt })
+  transports.fetch.mockImplementation(async () =>
+    createSuccessfulImageResponse(fixture.expectedImageBytes, fixture.responseSentinel)
+  )
+
+  if (!row.textFailure) {
+    return
+  }
+
+  const enhancementError = new Error('synthetic enhancement failure')
+  transports.openAIResponsesCreate.mockRejectedValue(enhancementError)
+  transports.googleTextError = enhancementError
+}
+
+interface EnhancementExpectation {
+  label: string
+  requestPrompt: string
+  args: Record<string, unknown>
+  inputImageBytes: Buffer | undefined
+}
+
+/**
+ * Every expectation the Seedream text-enhancement request must satisfy for one
+ * table row: shape, sampling parameters, feature instructions and image part.
+ */
+function assertEnhancementRequest(
+  textRequest: Record<string, unknown>,
+  expectation: EnhancementExpectation
+): void {
+  const { label, requestPrompt, args, inputImageBytes } = expectation
+  const textInput = extractTextInput(textRequest)
+
+  expect
+    .soft(Object.keys(textRequest).sort(), label)
+    .toEqual([
+      'input',
+      'instructions',
+      'max_output_tokens',
+      'model',
+      'temperature',
+      'thinking',
+      'top_p',
+    ])
+  expect.soft(textRequest['model'], label).toBe('seed-2-0-lite-260428')
+  expect.soft(textRequest['thinking'], label).toEqual({ type: 'disabled' })
+  expect.soft(textRequest['max_output_tokens'], label).toBe(384)
+  expect.soft(textRequest['temperature'], label).toBe(0.7)
+  expect.soft(textRequest['top_p'], label).toBe(0.95)
+  expect.soft(typeof textRequest['instructions'], label).toBe('string')
+  expect.soft(countOccurrences(textInput, requestPrompt), label).toBe(1)
+
+  for (const [flag, instruction] of Object.entries(FEATURE_INSTRUCTIONS)) {
+    expect.soft(textInput.includes(instruction), `${label}:${flag}`).toBe(args[flag] === true)
+  }
+
+  const purpose = typeof args['purpose'] === 'string' ? args['purpose'] : undefined
+  const purposeInstruction = purpose
+    ? `INTENDED USE: ${purpose}\nTailor the visual style, quality level, and details to match this purpose.`
+    : 'INTENDED USE:'
+  expect.soft(textInput.includes(purposeInstruction), `${label}:purpose`).toBe(Boolean(purpose))
+
+  if (!inputImageBytes) {
+    expect.soft(textRequest['input'], label).toBe(textInput)
+    return
+  }
+
+  expect.soft(textRequest['input'], label).toEqual([
+    {
+      role: 'user',
+      content: [
+        { type: 'input_text', text: textInput },
+        {
+          type: 'input_image',
+          image_url: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
+          detail: 'auto',
+        },
+      ],
+    },
+  ])
+}
+
+/** No secret, prompt or image byte may appear in what the caller can observe. */
+function assertNoSensitiveDisclosure(
+  label: string,
+  observable: string,
+  values: Array<string | undefined>
+): void {
+  for (const value of values) {
+    if (!value) {
+      continue
+    }
+    expect.soft(observable, `${label}:${value}`).not.toContain(value)
+  }
+}
+
 async function assertSavedPng(
   result: Awaited<ReturnType<ReturnType<typeof createMCPServer>['callTool']>>,
-  outputDirectory: string,
-  fileName: string,
-  expectedBytes: Buffer,
-  expectedModel: string
+  expectation: SavedPngExpectation
 ): Promise<void> {
+  const { outputDirectory, fileName, expectedBytes, expectedModel } = expectation
   const files = await readdir(outputDirectory)
   const expectedPath = join(outputDirectory, fileName)
   const bytes = files[0] ? await readFile(expectedPath) : Buffer.alloc(0)
@@ -475,7 +1272,7 @@ describe('BytePlus Seedream integration', () => {
     expect.soft(transports.openAIResponsesCreate).not.toHaveBeenCalled()
     expect.soft(transports.fetch).not.toHaveBeenCalled()
     expect
-      .soft((failedPublicResponse.error as { message?: string } | undefined)?.message)
+      .soft(recordOrEmpty(failedPublicResponse.error)['message'])
       .toContain('synthetic Seedream factory failure')
     expect.soft(await readdir(failureOutput)).toEqual([])
     expect.soft(failureExposure).not.toContain(ARK_DUMMY_KEY)
@@ -486,156 +1283,26 @@ describe('BytePlus Seedream integration', () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
     const jsonParseSpy = vi.spyOn(JSON, 'parse')
     const bufferFromSpy = vi.spyOn(Buffer, 'from')
-    type SupportedRow = {
-      args: Record<string, unknown>
-      expectedAspectRatio: (typeof ALL_ASPECT_RATIOS)[number]
-      expectedModel: 'dola-seedream-5-0-pro-260628'
-      expectedQuality: 'fast' | 'balanced' | 'quality'
-      expectedResolution: '1K' | '2K'
-      inputImage?: boolean
-      name: string
-      skipPromptEnhancement?: boolean
-      textFailure?: boolean
-    }
-
-    const supportedRows: SupportedRow[] = [
-      {
-        name: 'prompt-baseline',
-        args: {},
-        expectedAspectRatio: '1:1',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'fast',
-        expectedResolution: '1K',
-      },
-      {
-        name: 'enhancement-failure-original-fallback',
-        args: { aspectRatio: '4:3', quality: 'balanced' },
-        expectedAspectRatio: '4:3',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'balanced',
-        expectedResolution: '1K',
-        textFailure: true,
-      },
-      {
-        name: 'enhancement-skip',
-        args: { aspectRatio: '9:16', imageSize: '2K', quality: 'quality' },
-        expectedAspectRatio: '9:16',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'quality',
-        expectedResolution: '2K',
-        skipPromptEnhancement: true,
-      },
-      {
-        name: 'fast-route',
-        args: { quality: 'fast' },
-        expectedAspectRatio: '1:1',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'fast',
-        expectedResolution: '1K',
-      },
-      {
-        name: 'balanced-route',
-        args: { quality: 'balanced' },
-        expectedAspectRatio: '1:1',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'balanced',
-        expectedResolution: '1K',
-      },
-      {
-        name: 'quality-request-overrides-captured-fast',
-        args: { quality: 'quality' },
-        expectedAspectRatio: '1:1',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'quality',
-        expectedResolution: '1K',
-      },
-      {
-        name: 'single-input-image',
-        args: { quality: 'quality' },
-        expectedAspectRatio: '1:1',
-        expectedModel: 'dola-seedream-5-0-pro-260628',
-        expectedQuality: 'quality',
-        expectedResolution: '1K',
-        inputImage: true,
-      },
-      ...ALL_ASPECT_RATIOS.map(
-        (aspectRatio): SupportedRow => ({
-          name: `aspect-${aspectRatio}`,
-          args: { aspectRatio, imageSize: '2K', quality: 'fast' },
-          expectedAspectRatio: aspectRatio,
-          expectedModel: 'dola-seedream-5-0-pro-260628',
-          expectedQuality: 'fast',
-          expectedResolution: '2K',
-        })
-      ),
-      ...[
-        'blendImages',
-        'maintainCharacterConsistency',
-        'useWorldKnowledge',
-        'useGoogleSearch',
-      ].map(
-        (flag): SupportedRow => ({
-          name: `false-${flag}`,
-          args: { [flag]: false },
-          expectedAspectRatio: '1:1',
-          expectedModel: 'dola-seedream-5-0-pro-260628',
-          expectedQuality: 'fast',
-          expectedResolution: '1K',
-        })
-      ),
-      ...[
-        ['blendImages', true],
-        ['maintainCharacterConsistency', true],
-        ['useWorldKnowledge', true],
-        ['purpose', 'cookbook cover'],
-      ].map(
-        ([flag, value]): SupportedRow => ({
-          name: `prompt-only-${String(flag)}`,
-          args: { [String(flag)]: value },
-          expectedAspectRatio: '1:1',
-          expectedModel: 'dola-seedream-5-0-pro-260628',
-          expectedQuality: 'fast',
-          expectedResolution: '1K',
-        })
-      ),
-    ]
+    const supportedRows = buildSupportedRows()
 
     for (const [index, row] of supportedRows.entries()) {
       resetTransportDoubles()
       vi.mocked(console.error).mockClear()
-      const outputDirectory = await createOutputDirectory()
-      const fileName = `supported-${index}.png`
-      const requestPrompt = `${ORIGINAL_PROMPT}:${row.name}:request-body-sentinel`
-      const enhancedPrompt = `${ENHANCED_PROMPT}:${row.name}:image-body-sentinel`
-      const responseSentinel = `${row.name}:response-body-sentinel`
-      const imageSentinel = `${row.name}:decoded-image-sentinel`
-      const expectedImageBytes = createPngFixture(imageSentinel)
+      const fixture = await prepareSupportedRowFixture(row, index)
+      const {
+        outputDirectory,
+        fileName,
+        requestPrompt,
+        enhancedPrompt,
+        responseSentinel,
+        imageSentinel,
+        expectedImageBytes,
+        inputImageBytes,
+        inputImagePath,
+      } = fixture
       const expectedBase64 = expectedImageBytes.toString('base64')
-      const inputImageBytes = row.inputImage
-        ? createPngFixture(`${row.name}:input-image-sentinel`)
-        : undefined
-      const inputDirectory = row.inputImage ? await createOutputDirectory() : undefined
-      const inputImagePath =
-        inputDirectory && row.inputImage ? join(inputDirectory, `${row.name}-input.png`) : undefined
-      if (inputImagePath && inputImageBytes) {
-        await writeFile(inputImagePath, inputImageBytes)
-      }
 
-      configureSeedream(outputDirectory, {
-        imageQuality: 'fast',
-        skipPromptEnhancement: row.skipPromptEnhancement,
-      })
-      transports.googleEnhancedText = enhancedPrompt
-      transports.openAIResponsesCreate.mockResolvedValue({ output_text: enhancedPrompt })
-      transports.fetch.mockImplementation(async () =>
-        createSuccessfulImageResponse(expectedImageBytes, responseSentinel)
-      )
-
-      if (row.textFailure) {
-        const enhancementError = new Error('synthetic enhancement failure')
-        transports.openAIResponsesCreate.mockRejectedValue(enhancementError)
-        transports.googleTextError = enhancementError
-      }
+      arrangeSupportedRow(row, fixture)
 
       const server = createMCPServer()
       const beforeTimeoutCalls = timeoutSpy.mock.calls.length
@@ -658,33 +1325,15 @@ describe('BytePlus Seedream integration', () => {
         .slice(beforeDecodeCalls)
         .filter(([value, encoding]) => value === expectedBase64 && encoding === 'base64').length
       const imageRequest = observeLastImageRequest()
-      const textRequest =
-        (transports.openAIResponsesCreate.mock.calls.at(-1)?.[0] as
-          | Record<string, unknown>
-          | undefined) ?? {}
+      const textRequest = recordOrEmpty(transports.openAIResponsesCreate.mock.calls.at(-1)?.[0])
       const selectedPrompt =
         row.skipPromptEnhancement || row.textFailure ? requestPrompt : enhancedPrompt
       const finalPrompt = `${selectedPrompt}\n\nOutput aspect ratio: ${row.expectedAspectRatio}.`
       const rowTimeouts = timeoutSpy.mock.calls
         .slice(beforeTimeoutCalls)
         .map(([timeout]) => timeout)
-      const expectedImageRequest = {
-        model: row.expectedModel,
-        prompt: finalPrompt,
-        size: row.expectedResolution,
-        response_format: 'b64_json',
-        output_format: 'png',
-        stream: false,
-        watermark: false,
-        optimize_prompt_options: {
-          mode: row.expectedQuality === 'fast' ? 'fast' : 'standard',
-        },
-        ...(inputImageBytes && {
-          image: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
-        }),
-      }
+      const expectedImageRequest = buildExpectedImageRequest(row, finalPrompt, inputImageBytes)
       const expectedImageKeys = Object.keys(expectedImageRequest).sort()
-      const textInput = extractTextInput(textRequest)
 
       expect.soft(transports.googleConstructor, row.name).not.toHaveBeenCalled()
       expect
@@ -703,72 +1352,31 @@ describe('BytePlus Seedream integration', () => {
       if (row.skipPromptEnhancement) {
         expect.soft(textRequest, row.name).toEqual({})
       } else {
-        expect
-          .soft(Object.keys(textRequest).sort(), row.name)
-          .toEqual([
-            'input',
-            'instructions',
-            'max_output_tokens',
-            'model',
-            'temperature',
-            'thinking',
-            'top_p',
-          ])
-        expect.soft(textRequest.model, row.name).toBe('seed-2-0-lite-260428')
-        expect.soft(textRequest.thinking, row.name).toEqual({ type: 'disabled' })
-        expect.soft(textRequest.max_output_tokens, row.name).toBe(384)
-        expect.soft(textRequest.temperature, row.name).toBe(0.7)
-        expect.soft(textRequest.top_p, row.name).toBe(0.95)
-        expect.soft(typeof textRequest.instructions, row.name).toBe('string')
-        expect.soft(countOccurrences(textInput, requestPrompt), row.name).toBe(1)
-
-        for (const [flag, instruction] of Object.entries(FEATURE_INSTRUCTIONS)) {
-          expect
-            .soft(textInput.includes(instruction), `${row.name}:${flag}`)
-            .toBe(row.args[flag] === true)
-        }
-
-        const purpose = typeof row.args.purpose === 'string' ? row.args.purpose : undefined
-        const purposeInstruction = purpose
-          ? `INTENDED USE: ${purpose}\nTailor the visual style, quality level, and details to match this purpose.`
-          : 'INTENDED USE:'
-        expect
-          .soft(textInput.includes(purposeInstruction), `${row.name}:purpose`)
-          .toBe(Boolean(purpose))
-
-        if (inputImageBytes) {
-          expect.soft(textRequest.input, row.name).toEqual([
-            {
-              role: 'user',
-              content: [
-                { type: 'input_text', text: textInput },
-                {
-                  type: 'input_image',
-                  image_url: `data:image/png;base64,${inputImageBytes.toString('base64')}`,
-                  detail: 'auto',
-                },
-              ],
-            },
-          ])
-        } else {
-          expect.soft(textRequest.input, row.name).toBe(textInput)
-        }
+        assertEnhancementRequest(textRequest, {
+          label: row.name,
+          requestPrompt,
+          args: row.args,
+          inputImageBytes,
+        })
       }
 
-      await assertSavedPng(result, outputDirectory, fileName, expectedImageBytes, row.expectedModel)
+      await assertSavedPng(result, {
+        outputDirectory,
+        fileName,
+        expectedBytes: expectedImageBytes,
+        expectedModel: row.expectedModel,
+      })
 
       const publicAndLogs = `${JSON.stringify(parsePublicResponse(result))}\n${capturedLogs()}`
-      for (const sensitiveValue of [
+      assertNoSensitiveDisclosure(row.name, publicAndLogs, [
         ARK_DUMMY_KEY,
         AUTHORIZATION_VALUE,
         requestPrompt,
         enhancedPrompt,
         responseSentinel,
         imageSentinel,
-        inputImageBytes?.toString('base64') ?? '',
-      ].filter(Boolean)) {
-        expect.soft(publicAndLogs, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
-      }
+        inputImageBytes?.toString('base64'),
+      ])
     }
   })
 
@@ -910,10 +1518,7 @@ describe('BytePlus Seedream integration', () => {
     const oversizedBase64Calls = bufferToStringSpy.mock.calls
       .slice(beforeOversizedBase64Calls)
       .filter(([encoding]) => encoding === 'base64')
-    const oversizedError = (parsePublicResponse(oversizedResult).error ?? {}) as Record<
-      string,
-      unknown
-    >
+    const oversizedError = recordOrEmpty(parsePublicResponse(oversizedResult).error)
 
     expect.soft(oversizedResult.isError, 'over-limit').toBe(true)
     expect.soft(oversizedError.code, 'over-limit').toBe('INPUT_VALIDATION_ERROR')
@@ -980,7 +1585,7 @@ describe('BytePlus Seedream integration', () => {
     const growthBase64Calls = bufferToStringSpy.mock.calls
       .slice(beforeGrowthBase64Calls)
       .filter(([encoding]) => encoding === 'base64')
-    const growthError = (parsePublicResponse(growthResult).error ?? {}) as Record<string, unknown>
+    const growthError = recordOrEmpty(parsePublicResponse(growthResult).error)
 
     expect.soft(growthResult.isError, 'growth').toBe(true)
     expect.soft(growthError.code, 'growth').toBe('INPUT_VALIDATION_ERROR')
@@ -1042,10 +1647,7 @@ describe('BytePlus Seedream integration', () => {
     const nonRegularBase64Calls = bufferToStringSpy.mock.calls
       .slice(beforeNonRegularBase64Calls)
       .filter(([encoding]) => encoding === 'base64')
-    const nonRegularError = (parsePublicResponse(nonRegularResult).error ?? {}) as Record<
-      string,
-      unknown
-    >
+    const nonRegularError = recordOrEmpty(parsePublicResponse(nonRegularResult).error)
 
     expect.soft(nonRegularResult.isError, 'non-regular').toBe(true)
     expect.soft(nonRegularError.code, 'non-regular').toBe('INPUT_VALIDATION_ERROR')
@@ -1065,8 +1667,11 @@ describe('BytePlus Seedream integration', () => {
       const fifoInputPath = join(inputDirectory, 'named-pipe.png')
       await new Promise<void>((resolve, reject) => {
         execFile('/usr/bin/mkfifo', [fifoInputPath], (error) => {
-          if (error) reject(error)
-          else resolve()
+          if (error) {
+            reject(error)
+          } else {
+            resolve()
+          }
         })
       })
       const sanitizedFifoInputPath = await realpath(fifoInputPath)
@@ -1116,7 +1721,7 @@ describe('BytePlus Seedream integration', () => {
       const fifoBase64Calls = bufferToStringSpy.mock.calls
         .slice(beforeFifoBase64Calls)
         .filter(([encoding]) => encoding === 'base64')
-      const fifoError = (parsePublicResponse(fifoResult).error ?? {}) as Record<string, unknown>
+      const fifoError = recordOrEmpty(parsePublicResponse(fifoResult).error)
 
       expect.soft(completionState, 'fifo:deadline').toBe('completed')
       expect.soft(fifoResult.isError, 'fifo').toBe(true)
@@ -1139,359 +1744,7 @@ describe('BytePlus Seedream integration', () => {
     const timeoutSpy = vi.spyOn(AbortSignal, 'timeout')
     const jsonParseSpy = vi.spyOn(JSON, 'parse')
     const bufferFromSpy = vi.spyOn(Buffer, 'from')
-    type FailureRow = {
-      args?: Record<string, unknown>
-      arkApiKey?: string
-      deleteArkApiKey?: boolean
-      expectedCode: string
-      expectedDecodeCalls: number
-      expectedImageCalls: number
-      expectedParseCalls: number
-      expectedTextCalls: number
-      fetchError?: Error
-      name: string
-      responseFactory?: (responseSentinel: string, imageSentinel: string) => Response
-      sensitiveValues?: string[]
-      skipPromptEnhancement?: boolean
-    }
-
-    const failureRows: FailureRow[] = [
-      {
-        name: 'missing-key',
-        deleteArkApiKey: true,
-        expectedCode: 'CONFIG_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'empty-key',
-        arkApiKey: '   ',
-        expectedCode: 'CONFIG_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'google-search',
-        args: { useGoogleSearch: true },
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'google-search-string',
-        args: { useGoogleSearch: 'private-invalid-google-search-string' },
-        expectedCode: 'INPUT_VALIDATION_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        sensitiveValues: ['private-invalid-google-search-string'],
-      },
-      {
-        name: 'google-search-number',
-        args: { useGoogleSearch: 8675309 },
-        expectedCode: 'INPUT_VALIDATION_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        sensitiveValues: ['8675309'],
-      },
-      {
-        name: 'google-search-null',
-        args: { useGoogleSearch: null },
-        expectedCode: 'INPUT_VALIDATION_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'google-search-object',
-        args: { useGoogleSearch: { marker: 'private-invalid-google-search-object' } },
-        expectedCode: 'INPUT_VALIDATION_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        sensitiveValues: ['private-invalid-google-search-object'],
-      },
-      {
-        name: 'fast-pro-4k',
-        args: { imageSize: '4K', quality: 'fast' },
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'pro-4k',
-        args: { imageSize: '4K', quality: 'quality' },
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'unsupported-editing-input',
-        args: { inputImagePath: '__CREATE_UNSUPPORTED_INPUT__' },
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 0,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-      },
-      {
-        name: 'missing-data',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
-            response_sentinel: responseSentinel,
-            image_sentinel: imageSentinel,
-          }),
-      },
-      {
-        name: 'extra-images',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) => {
-          const imageBytes = createPngFixture(imageSentinel)
-          return createJsonResponse({
-            response_sentinel: responseSentinel,
-            data: [
-              { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
-              { b64_json: imageBytes.toString('base64'), mime_type: 'image/png' },
-            ],
-          })
-        },
-      },
-      {
-        name: 'url-only',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
-            response_sentinel: responseSentinel,
-            image_sentinel: imageSentinel,
-            data: [{ url: `https://attacker.invalid/${imageSentinel}.png` }],
-          }),
-      },
-      {
-        name: 'stream-event',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          new Response(
-            `data: ${JSON.stringify({
-              response_sentinel: responseSentinel,
-              image_sentinel: imageSentinel,
-              data: [],
-            })}\n\n`,
-            {
-              status: 200,
-              headers: { 'content-type': 'text/event-stream' },
-            }
-          ),
-      },
-      {
-        name: 'malformed-base64',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) => {
-          const validBase64 = createPngFixture(imageSentinel).toString('base64')
-          return createJsonResponse({
-            response_sentinel: responseSentinel,
-            data: [
-              {
-                b64_json: `${validBase64.slice(0, -1)}*`,
-                mime_type: 'image/png',
-              },
-            ],
-          })
-        },
-      },
-      {
-        name: 'empty-base64',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
-            response_sentinel: responseSentinel,
-            image_sentinel: imageSentinel,
-            data: [{ b64_json: '', mime_type: 'image/png' }],
-          }),
-      },
-      {
-        name: 'content-length-over-48-mib',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          new Response(`${responseSentinel}:${imageSentinel}`, {
-            status: 200,
-            headers: {
-              'content-length': String(48 * 1024 * 1024 + 1),
-              'content-type': 'application/json',
-            },
-          }),
-      },
-      {
-        name: 'chunked-body-over-48-mib',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-      },
-      {
-        name: 'decoded-size-over-32-mib',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
-            response_sentinel: responseSentinel,
-            image_sentinel: imageSentinel,
-            data: [
-              {
-                b64_json: 'A'.repeat(Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)),
-                mime_type: 'image/png',
-              },
-            ],
-          }),
-      },
-      {
-        name: 'non-png-magic',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 1,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse({
-            response_sentinel: responseSentinel,
-            data: [
-              {
-                b64_json: Buffer.from(`not-a-png:${imageSentinel}`).toString('base64'),
-                mime_type: 'image/png',
-              },
-            ],
-          }),
-      },
-      {
-        name: 'wrong-mime',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 1,
-        expectedImageCalls: 1,
-        expectedParseCalls: 1,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) => {
-          const imageBytes = createPngFixture(imageSentinel)
-          return createJsonResponse({
-            response_sentinel: responseSentinel,
-            data: [{ b64_json: imageBytes.toString('base64'), mime_type: 'image/jpeg' }],
-          })
-        },
-      },
-      {
-        name: 'abort-timeout',
-        expectedCode: 'NETWORK_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        fetchError: new DOMException('synthetic timeout', 'AbortError'),
-      },
-      {
-        name: 'http-401',
-        expectedCode: 'IMAGE_API_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse(
-            {
-              response_sentinel: responseSentinel,
-              image_sentinel: imageSentinel,
-              error: { message: RAW_BODY_MARKER },
-            },
-            401
-          ),
-      },
-      {
-        name: 'http-500',
-        expectedCode: 'NETWORK_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        responseFactory: (responseSentinel, imageSentinel) =>
-          createJsonResponse(
-            {
-              response_sentinel: responseSentinel,
-              image_sentinel: imageSentinel,
-              error: { message: RAW_BODY_MARKER },
-            },
-            500
-          ),
-      },
-      {
-        name: 'network-failure',
-        expectedCode: 'NETWORK_ERROR',
-        expectedDecodeCalls: 0,
-        expectedImageCalls: 1,
-        expectedParseCalls: 0,
-        expectedTextCalls: 0,
-        skipPromptEnhancement: true,
-        fetchError: new TypeError(`fetch failed: ${RAW_BODY_MARKER}`),
-      },
-    ]
+    const failureRows = buildFailureRows()
 
     for (const [index, row] of failureRows.entries()) {
       resetTransportDoubles()
@@ -1508,56 +1761,8 @@ describe('BytePlus Seedream integration', () => {
         delete process.env.ARK_API_KEY
       }
 
-      let chunkedCancel: ReturnType<typeof vi.fn> | undefined
-      if (row.name === 'chunked-body-over-48-mib') {
-        chunkedCancel = vi.fn()
-        transports.fetch.mockImplementation(async () => {
-          let emittedChunks = 0
-          const markerChunk = new TextEncoder().encode(`${responseSentinel}:${imageSentinel}`)
-          return new Response(
-            new ReadableStream<Uint8Array>({
-              cancel: chunkedCancel,
-              pull(controller) {
-                if (emittedChunks === 0) {
-                  controller.enqueue(markerChunk)
-                  emittedChunks += 1
-                } else if (emittedChunks < 50) {
-                  controller.enqueue(new Uint8Array(1024 * 1024))
-                  emittedChunks += 1
-                } else {
-                  controller.close()
-                }
-              },
-            }),
-            { status: 200, headers: { 'content-type': 'application/json' } }
-          )
-        })
-      } else if (row.fetchError) {
-        const message = `${row.fetchError.message}:${responseSentinel}:${imageSentinel}`
-        const error =
-          row.fetchError instanceof DOMException
-            ? new DOMException(message, row.fetchError.name)
-            : new TypeError(message)
-        transports.fetch.mockRejectedValue(error)
-      } else if (row.responseFactory) {
-        transports.fetch.mockImplementation(async () =>
-          row.responseFactory?.(responseSentinel, imageSentinel)
-        )
-      }
-
-      let args: Record<string, unknown> = {
-        prompt: requestSentinel,
-        fileName: `failure-${index}.png`,
-        ...row.args,
-      }
-      if (row.args?.inputImagePath === '__CREATE_UNSUPPORTED_INPUT__') {
-        const unsupportedInputPath = join(outputDirectory, 'unsupported.gif')
-        await writeFile(unsupportedInputPath, `${INPUT_IMAGE_MARKER}:${row.name}`)
-        args = {
-          ...args,
-          inputImagePath: unsupportedInputPath,
-        }
-      }
+      const chunkedCancel = arrangeFailureTransport(row, { responseSentinel, imageSentinel })
+      const args = await buildFailureArgs(row, index, outputDirectory, requestSentinel)
 
       const beforeFiles = await readdir(outputDirectory)
       const beforeTimeoutCalls = timeoutSpy.mock.calls.length
@@ -1569,38 +1774,20 @@ describe('BytePlus Seedream integration', () => {
       const parseCount = jsonParseSpy.mock.calls
         .slice(beforeParseCalls)
         .filter(([value]) => typeof value === 'string' && value.includes(responseSentinel)).length
-      const pngBase64 = createPngFixture(imageSentinel).toString('base64')
-      const malformedBase64 = `${pngBase64.slice(0, -1)}*`
-      const nonPngBase64 = Buffer.from(`not-a-png:${imageSentinel}`).toString('base64')
       const oversizedBase64Length = Math.ceil(((32 * 1024 * 1024 + 1) * 4) / 3)
+      const expectedPayload = expectedDecodePayload(row, imageSentinel)
       const decodeCount = bufferFromSpy.mock.calls
         .slice(beforeDecodeCalls)
         .filter(([value, encoding]) => {
           if (encoding !== 'base64' || typeof value !== 'string') {
             return false
           }
-
-          if (row.name === 'extra-images' || row.name === 'wrong-mime') {
-            return value === pngBase64
-          }
-          if (row.name === 'malformed-base64') {
-            return value === malformedBase64
-          }
-          if (row.name === 'empty-base64') {
-            return value === ''
-          }
           if (row.name === 'decoded-size-over-32-mib') {
             return value.length === oversizedBase64Length && value.startsWith('A')
           }
-          if (row.name === 'non-png-magic') {
-            return value === nonPngBase64
-          }
-
-          return false
+          return expectedPayload !== undefined && value === expectedPayload
         }).length
-      const publicResponse = parsePublicResponse(result)
-      const publicError = (publicResponse.error ?? {}) as Record<string, unknown>
-      const exposed = `${JSON.stringify(publicResponse)}\n${capturedLogs()}`
+      const exposed = `${JSON.stringify(parsePublicResponse(result))}\n${capturedLogs()}`
       const rowTimeouts = timeoutSpy.mock.calls
         .slice(beforeTimeoutCalls)
         .map(([timeout]) => timeout)
@@ -1611,29 +1798,7 @@ describe('BytePlus Seedream integration', () => {
           row.name
         )
         .toEqual([])
-      expect.soft(result.isError, row.name).toBe(true)
-      expect.soft(publicError.code, row.name).toBe(row.expectedCode)
-      expect.soft(Object.keys(result).sort(), row.name).toEqual(['content', 'isError'])
-      expect.soft(Object.keys(publicResponse), row.name).toEqual(['error'])
-      expect
-        .soft(
-          Object.keys(publicError).every((key) => {
-            return ['code', 'details', 'message', 'suggestion', 'timestamp'].includes(key)
-          }),
-          row.name
-        )
-        .toBe(true)
-      const publicDetails = publicError.details as Record<string, unknown> | undefined
-      if (publicDetails) {
-        expect
-          .soft(
-            Object.keys(publicDetails).every((key) => {
-              return ['provider', 'stage', 'statusCode', 'upstreamMessage'].includes(key)
-            }),
-            row.name
-          )
-          .toBe(true)
-      }
+      assertPublicErrorShape(result, row)
       expect.soft(transports.googleConstructor, row.name).not.toHaveBeenCalled()
       expect
         .soft(transports.openAIResponsesCreate, row.name)
@@ -1661,7 +1826,7 @@ describe('BytePlus Seedream integration', () => {
         expect.soft(chunkedCancel?.mock.calls.length ?? 0, row.name).toBe(1)
       }
 
-      for (const sensitiveValue of [
+      assertNoSensitiveDisclosure(row.name, exposed, [
         ARK_DUMMY_KEY,
         AUTHORIZATION_VALUE,
         requestSentinel,
@@ -1670,9 +1835,7 @@ describe('BytePlus Seedream integration', () => {
         responseSentinel,
         imageSentinel,
         ...(row.sensitiveValues ?? []),
-      ]) {
-        expect.soft(exposed, `${row.name}:${sensitiveValue}`).not.toContain(sensitiveValue)
-      }
+      ])
     }
   })
 })

--- a/src/server/__tests__/mcpServer.test.ts
+++ b/src/server/__tests__/mcpServer.test.ts
@@ -1,16 +1,39 @@
 import { readFileSync } from 'node:fs'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { generateFileName, saveImage } from '../../business/fileManager.js'
+import {
+  expectDefined,
+  expectRecord,
+  expectString,
+  parseJsonObject,
+  readPath,
+} from '../../tests/helpers/inspect'
 import { Logger } from '../../utils/logger.js'
 import { createMCPServer, MCPServerImpl } from '../mcpServer'
 
-const packageVersion = (
-  JSON.parse(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')) as {
-    version: string
+const packageVersion = expectString(
+  readPath(
+    parseJsonObject(readFileSync(new URL('../../../package.json', import.meta.url), 'utf8')),
+    'version'
+  ),
+  'package.json version'
+)
+
+/**
+ * The `generateImage` mock of a client produced by a mocked provider factory,
+ * verified at runtime rather than asserted over.
+ */
+function createdImageClientMock(creation: unknown, what: string): Mock {
+  const result = expectRecord(expectRecord(creation, what)['value'], `${what} result`)
+  const client = expectRecord(result['data'], `${what} client`)
+  const generateImage = client['generateImage']
+  if (!vi.isMockFunction(generateImage)) {
+    throw new Error(`Expected ${what} to expose a mocked generateImage`)
   }
-).version
+  return generateImage
+}
 
 vi.mock('../../api/geminiClient', () => {
   return {
@@ -86,8 +109,12 @@ vi.mock('../../business/fileManager', () => {
       data: './test-output/test-image.png',
     }),
     generateFileName: vi.fn().mockImplementation((mimeType?: string) => {
-      if (mimeType === 'image/jpeg') return 'test-image.jpg'
-      if (mimeType === 'image/webp') return 'test-image.webp'
+      if (mimeType === 'image/jpeg') {
+        return 'test-image.jpg'
+      }
+      if (mimeType === 'image/webp') {
+        return 'test-image.webp'
+      }
       return 'test-image.png'
     }),
   }
@@ -354,8 +381,7 @@ describe('MCP Server', () => {
       fileName: 'my-photo',
     })
 
-    const saveImageCall = vi.mocked(saveImage).mock.calls[0]
-    const savedPath = saveImageCall[1] as string
+    const savedPath = expectDefined(vi.mocked(saveImage).mock.calls[0], 'saveImage call')[1]
     expect(savedPath).toMatch(/my-photo\.png$/)
   })
 
@@ -370,8 +396,7 @@ describe('MCP Server', () => {
       fileName: 'my-photo.jpg',
     })
 
-    const saveImageCall = vi.mocked(saveImage).mock.calls[0]
-    const savedPath = saveImageCall[1] as string
+    const savedPath = expectDefined(vi.mocked(saveImage).mock.calls[0], 'saveImage call')[1]
     expect(savedPath).toMatch(/my-photo\.jpg$/)
   })
 
@@ -410,8 +435,7 @@ describe('MCP Server', () => {
       fileName: '...my-photo\x00',
     })
 
-    const saveImageCall = vi.mocked(saveImage).mock.calls[0]
-    const savedPath = saveImageCall[1] as string
+    const savedPath = expectDefined(vi.mocked(saveImage).mock.calls[0], 'saveImage call')[1]
     expect(savedPath).toMatch(/my-photo\.png$/)
   })
 
@@ -594,9 +618,11 @@ describe('MCP Server', () => {
 
     expect(result.isError).toBe(false)
     const { createOpenAIImageClient } = await import('../../api/openaiImageClient')
-    const imageClient = (createOpenAIImageClient as ReturnType<typeof vi.fn>).mock.results[0].value
-      .data
-    expect(imageClient.generateImage).toHaveBeenCalledWith(
+    const generateImage = createdImageClientMock(
+      vi.mocked(createOpenAIImageClient).mock.results[0],
+      'openai image client creation'
+    )
+    expect(generateImage).toHaveBeenCalledWith(
       expect.objectContaining({ preferredOutputFormat: 'jpeg' })
     )
   })
@@ -618,12 +644,14 @@ describe('MCP Server', () => {
 
       expect(result.isError).toBe(false)
       const { createGeminiClient } = await import('../../api/geminiClient')
-      const imageClient = (createGeminiClient as ReturnType<typeof vi.fn>).mock.results.at(-1)
-        ?.value.data
-      const imageParams = imageClient.generateImage.mock.calls[0][0]
+      const generateImage = createdImageClientMock(
+        vi.mocked(createGeminiClient).mock.results.at(-1),
+        'gemini image client creation'
+      )
+      const imageParams = expectDefined(generateImage.mock.calls[0], 'generateImage call')[0]
       expect(imageParams).not.toHaveProperty('preferredOutputFormat')
 
-      const savedPath = vi.mocked(saveImage).mock.calls[0][1]
+      const savedPath = expectDefined(vi.mocked(saveImage).mock.calls[0], 'saveImage call')[1]
       expect(savedPath.endsWith(expectedSavedName)).toBe(true)
     }
   )
@@ -637,10 +665,14 @@ describe('MCP Server', () => {
     })
 
     const { createGeminiClient } = await import('../../api/geminiClient')
-    const imageClient = (createGeminiClient as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value
-      .data
+    const generateImage = createdImageClientMock(
+      vi.mocked(createGeminiClient).mock.results.at(-1),
+      'gemini image client creation'
+    )
     expect(result.isError).toBe(false)
-    expect(imageClient.generateImage.mock.calls[0][0]).not.toHaveProperty('preferredOutputFormat')
+    expect(expectDefined(generateImage.mock.calls[0], 'generateImage call')[0]).not.toHaveProperty(
+      'preferredOutputFormat'
+    )
   })
 
   it('should preserve tool execution errors across the MCP transport boundary', async () => {

--- a/src/server/__tests__/requestBoundaries.int.test.ts
+++ b/src/server/__tests__/requestBoundaries.int.test.ts
@@ -5,6 +5,16 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  expectArray,
+  expectDefined,
+  expectRecord,
+  expectString,
+  firstContentText,
+  parseJsonObject,
+  parseToolPayload,
+  readPath,
+} from '../../tests/helpers/inspect'
 import type { ImageProvider } from '../../types/mcp.js'
 import { MCPServerImpl } from '../mcpServer.js'
 
@@ -108,9 +118,7 @@ describe('request and output boundaries', () => {
   ])('rejects invalid arguments before any provider request: %j', async (args) => {
     const result = await client.callTool({ name: 'generate_image', arguments: args })
     expect(result.isError).toBe(true)
-    expect(JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error.code).toBe(
-      'INPUT_VALIDATION_ERROR'
-    )
+    expect(readPath(parseToolPayload(result), 'error', 'code')).toBe('INPUT_VALIDATION_ERROR')
     expect(fetchMock).not.toHaveBeenCalled()
     expect(await readdir(outputDir)).toEqual([])
   })
@@ -150,8 +158,17 @@ describe('request and output boundaries', () => {
     })
     expect(result.isError).toBe(false)
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    const imageRequest = JSON.parse(fetchMock.mock.calls[1]![1]!.body as string)
-    expect(imageRequest.contents[0].parts[0].text).toBe('complete original instructions')
+    const imageRequest = parseJsonObject(
+      expectString(
+        expectDefined(expectDefined(fetchMock.mock.calls[1], 'second fetch call')[1], 'fetch init')
+          .body,
+        'fetch request body'
+      ),
+      'image request body'
+    )
+    const contents = expectArray(imageRequest['contents'], 'request contents')
+    const parts = expectArray(readPath(contents[0], 'parts'), 'content parts')
+    expect(readPath(parts[0], 'text')).toBe('complete original instructions')
     expect(await readFile(resolve(outputDir, 'fallback.png'))).toEqual(PNG)
   })
 
@@ -180,10 +197,10 @@ describe('request and output boundaries', () => {
       name: 'generate_image',
       arguments: { provider: 'gemini', prompt: 'test' },
     })
-    const error = JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error
+    const error = expectRecord(readPath(parseToolPayload(result), 'error'), 'error payload')
     expect(result.isError).toBe(true)
-    expect(error.suggestion).toContain('Rephrase')
-    expect(error.details.stage).toBe('prompt_analysis')
+    expect(expectString(error['suggestion'], 'error suggestion')).toContain('Rephrase')
+    expect(readPath(error, 'details', 'stage')).toBe('prompt_analysis')
   })
 
   it.each([401, 429, 503])(
@@ -194,9 +211,9 @@ describe('request and output boundaries', () => {
         name: 'generate_image',
         arguments: { provider: 'seedream', prompt: 'private prompt' },
       })
-      const text = (result.content as Array<{ text: string }>)[0]!.text
+      const text = firstContentText(result)
       expect(result.isError).toBe(true)
-      expect(JSON.parse(text).error.details.statusCode).toBe(status)
+      expect(readPath(parseJsonObject(text), 'error', 'details', 'statusCode')).toBe(status)
       expect(text).not.toContain('private')
       expect(await readdir(outputDir)).toEqual([])
     }
@@ -209,7 +226,7 @@ describe('request and output boundaries', () => {
       arguments: { prompt: 'test', fileName },
     })
     expect(result.isError).toBe(false)
-    const uri = JSON.parse((result.content as Array<{ text: string }>)[0]!.text).resource.uri
+    const uri = expectString(readPath(parseToolPayload(result), 'resource', 'uri'), 'resource uri')
     expect(fileURLToPath(uri)).toBe(resolve(outputDir, fileName))
     expect(await readFile(fileURLToPath(uri))).toEqual(PNG)
   })
@@ -228,9 +245,7 @@ describe('request and output boundaries', () => {
         arguments: { provider, prompt: 'test' },
       })
       expect(result.isError).toBe(true)
-      expect(
-        JSON.parse((result.content as Array<{ text: string }>)[0]!.text).error.details.statusCode
-      ).toBe(503)
+      expect(readPath(parseToolPayload(result), 'error', 'details', 'statusCode')).toBe(503)
     }
   )
 
@@ -281,7 +296,7 @@ describe('request and output boundaries', () => {
     provider: ImageProvider,
     stage: 'text' | 'image',
     inputImagePath?: string
-  ) {
+  ): Promise<void> {
     vi.stubEnv('SKIP_PROMPT_ENHANCEMENT', String(stage !== 'text'))
     let release!: () => void
     let started!: () => void
@@ -294,7 +309,9 @@ describe('request and output boundaries', () => {
     })
     fetchMock.mockImplementation(async (url, options) => {
       // The installed OpenAI SDK checks FormData support with a local data URL.
-      if (String(url) === 'data:,') return new Response('')
+      if (String(url) === 'data:,') {
+        return new Response('')
+      }
       upstreamSignal = options?.signal
       started()
       await held
@@ -325,11 +342,13 @@ describe('request and output boundaries', () => {
       await new Promise<void>((done) => setImmediate(done))
       const forwarded = upstreamSignal?.aborted
       release()
-      await execution.mock.results[0]!.value
+      await expectDefined(execution.mock.results[0], 'first execution result').value
       expect(forwarded).toBe(true)
       const apiCalls = fetchMock.mock.calls.filter(([url]) => String(url) !== 'data:,')
       expect(apiCalls).toHaveLength(1)
-      if (inputImagePath) expect(String(apiCalls[0]![0])).toMatch(/\/images\/edits$/)
+      if (inputImagePath) {
+        expect(String(expectDefined(apiCalls[0], 'first api call')[0])).toMatch(/\/images\/edits$/)
+      }
       expect(await readdir(outputDir)).toEqual(inputImagePath ? ['input.png'] : [])
     } finally {
       release()

--- a/src/server/imageProviderRegistry.ts
+++ b/src/server/imageProviderRegistry.ts
@@ -34,22 +34,22 @@ function unwrap<T, E extends Error>(result: Result<T, E>): T {
 const IMAGE_PROVIDERS = {
   gemini: {
     promptGeneration: { maxTokens: 1000 },
-    createTextClient: (config) => unwrap(createGeminiTextClient(config)),
-    createImageClient: (config) => unwrap(createGeminiClient(config)),
+    createTextClient: (config): TextClient => unwrap(createGeminiTextClient(config)),
+    createImageClient: (config): ImageClient => unwrap(createGeminiClient(config)),
   },
   openai: {
     promptGeneration: { maxTokens: 1000 },
-    createTextClient: (config) => unwrap(createOpenAITextClient(config)),
-    createImageClient: (config) => unwrap(createOpenAIImageClient(config)),
-    validateImageOptions: (options) => {
+    createTextClient: (config): TextClient => unwrap(createOpenAITextClient(config)),
+    createImageClient: (config): ImageClient => unwrap(createOpenAIImageClient(config)),
+    validateImageOptions: (options): void => {
       unwrap(validateOpenAIOptions(options))
     },
   },
   seedream: {
     promptGeneration: { maxTokens: 384 },
-    createTextClient: (config) => unwrap(createSeedreamTextClient(config)),
-    createImageClient: (config) => unwrap(createSeedreamImageClient(config)),
-    validateImageOptions: (options, config) => {
+    createTextClient: (config): TextClient => unwrap(createSeedreamTextClient(config)),
+    createImageClient: (config): ImageClient => unwrap(createSeedreamImageClient(config)),
+    validateImageOptions: (options, config): void => {
       unwrap(validateSeedreamCapabilities(options, config.imageQuality))
     },
   },

--- a/src/server/mcpServer.ts
+++ b/src/server/mcpServer.ts
@@ -16,15 +16,22 @@ import {
   type FeatureFlags,
   type StructuredPromptGenerator,
 } from '../business/structuredPromptGenerator.js'
-import type { ImageProvider, MCPServerConfig } from '../types/mcp.js'
+import type {
+  GenerateImageParams,
+  ImageOutputFormat,
+  ImageProvider,
+  MCPServerConfig,
+  McpToolResponse,
+} from '../types/mcp.js'
 import {
   ASPECT_RATIO_VALUES,
   IMAGE_PROVIDER_VALUES,
   IMAGE_QUALITY_VALUES,
   IMAGE_SIZE_VALUES,
 } from '../types/mcp.js'
-
+import { unwrapOrThrow } from '../types/result.js'
 import { type Config, getConfig, validateProviderCredentials } from '../utils/config.js'
+import { toError } from '../utils/errors.js'
 import { Logger } from '../utils/logger.js'
 import {
   reconcileFileNameExtension,
@@ -38,11 +45,20 @@ import {
   type ImageProviderDefinition,
 } from './imageProviderRegistry.js'
 
-const PACKAGE_VERSION = (
-  JSON.parse(readFileSync(new URL('../../package.json', import.meta.url), 'utf8')) as {
-    version: string
+function readPackageVersion(): string {
+  const manifest: unknown = JSON.parse(
+    readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+  )
+  if (typeof manifest === 'object' && manifest !== null && 'version' in manifest) {
+    const { version } = manifest
+    if (typeof version === 'string') {
+      return version
+    }
   }
-).version
+  throw new Error('package.json does not declare a string version')
+}
+
+const PACKAGE_VERSION = readPackageVersion()
 
 const DEFAULT_CONFIG: MCPServerConfig = {
   name: 'mcp-image-server',
@@ -53,6 +69,61 @@ const DEFAULT_CONFIG: MCPServerConfig = {
 interface ProviderClients {
   imageClient: ImageClient
   structuredPromptGenerator: StructuredPromptGenerator | null
+}
+
+type ImageOptions = Omit<ImageApiParams, 'prompt'>
+
+/** Assemble the provider-facing image options from validated request params. */
+function buildImageOptions(
+  params: GenerateImageParams,
+  inputImage: { data?: string; mimeType?: string },
+  preferredOutputFormat: ImageOutputFormat | undefined
+): ImageOptions {
+  return {
+    ...(inputImage.data && { inputImage: inputImage.data }),
+    ...(inputImage.mimeType && { inputImageMimeType: inputImage.mimeType }),
+    ...(params.aspectRatio && { aspectRatio: params.aspectRatio }),
+    ...(params.imageSize && { imageSize: params.imageSize }),
+    ...(params.useGoogleSearch !== undefined && { useGoogleSearch: params.useGoogleSearch }),
+    ...(preferredOutputFormat && { preferredOutputFormat }),
+    ...(params.quality !== undefined && { quality: params.quality }),
+  } satisfies ImageOptions
+}
+
+/** Project the request's enhancement flags onto the prompt generator's contract. */
+function buildFeatureFlags(params: GenerateImageParams): FeatureFlags {
+  return {
+    ...(params.maintainCharacterConsistency !== undefined && {
+      maintainCharacterConsistency: params.maintainCharacterConsistency,
+    }),
+    ...(params.blendImages !== undefined && { blendImages: params.blendImages }),
+    ...(params.useWorldKnowledge !== undefined && { useWorldKnowledge: params.useWorldKnowledge }),
+  }
+}
+
+/**
+ * Decide the saved file name. A caller-supplied name keeps its stem but takes
+ * the extension of the image that was actually generated; `corrected` reports
+ * whether a supported requested extension was replaced.
+ */
+function resolveOutputFileName(
+  requestedFileName: string | undefined,
+  sanitizedFileName: string | undefined,
+  mimeType: string
+): { fileName: string; requestedExtension: string; corrected: boolean } {
+  const rawFileName = sanitizedFileName ?? generateFileName(mimeType)
+  const fileName = requestedFileName
+    ? reconcileFileNameExtension(rawFileName, mimeType)
+    : rawFileName
+  const requestedExtension = path.extname(rawFileName)
+  return {
+    fileName,
+    requestedExtension,
+    corrected:
+      sanitizedFileName !== undefined &&
+      fileName !== rawFileName &&
+      SUPPORTED_EXTENSIONS.includes(requestedExtension.toLowerCase()),
+  }
 }
 
 export class MCPServerImpl {
@@ -68,14 +139,14 @@ export class MCPServerImpl {
     this.securityManager = new SecurityManager()
   }
 
-  public getServerInfo() {
+  public getServerInfo(): { name: string; version: string } {
     return {
       name: this.config.name,
       version: this.config.version,
     }
   }
 
-  public getToolsList() {
+  public getToolsList(): ListToolsResult {
     return {
       tools: [
         {
@@ -157,15 +228,20 @@ export class MCPServerImpl {
     }
   }
 
-  public async callTool(name: string, args: unknown, signal?: AbortSignal) {
+  public async callTool(
+    name: string,
+    args: unknown,
+    signal?: AbortSignal
+  ): Promise<McpToolResponse> {
     try {
       if (name === 'generate_image') {
         return await this.handleGenerateImage(args, signal)
       }
       throw new Error(`Unknown tool: ${name}`)
     } catch (error) {
-      this.logger.error('mcp-server', 'Tool execution failed', error as Error)
-      return ErrorHandler.handleError(error as Error)
+      const toolError = toError(error)
+      this.logger.error('mcp-server', 'Tool execution failed', toolError)
+      return ErrorHandler.handleError(toolError)
     }
   }
 
@@ -204,159 +280,148 @@ export class MCPServerImpl {
     return clients
   }
 
-  private async handleGenerateImage(args: unknown, signal?: AbortSignal) {
-    const result = await ErrorHandler.wrapWithResultType(async () => {
-      signal?.throwIfAborted()
-      const validationResult = validateGenerateImageParams(args)
-      if (!validationResult.success) {
-        throw validationResult.error
-      }
-      const params = validationResult.data
+  /**
+   * Send the prompt for enhancement and report the outcome. A failed
+   * enhancement is not fatal: the original prompt is used instead.
+   */
+  private async enhancePrompt(
+    generator: StructuredPromptGenerator,
+    params: GenerateImageParams,
+    context: { inputImageData?: string; inputImageMimeType?: string; signal?: AbortSignal }
+  ): Promise<string> {
+    const promptResult = await generator.generateStructuredPrompt(params.prompt, {
+      features: buildFeatureFlags(params),
+      ...(context.inputImageData !== undefined && { inputImageData: context.inputImageData }),
+      ...(params.purpose !== undefined && { purpose: params.purpose }),
+      ...(context.inputImageMimeType !== undefined && {
+        inputImageMimeType: context.inputImageMimeType,
+      }),
+      ...(context.signal !== undefined && { signal: context.signal }),
+    })
+    context.signal?.throwIfAborted()
 
-      const sanitizedFileName = params.fileName
-        ? this.securityManager.sanitizeFilename(params.fileName)
-        : undefined
-      const preferredOutputFormat = resolvePreferredOutputFormat(sanitizedFileName)
-
-      const configResult = getConfig()
-      if (!configResult.success) {
-        throw configResult.error
-      }
-      const config = configResult.data
-
-      const outputPreflight = this.securityManager.sanitizeFilePath(
-        path.join(config.imageOutputDir, sanitizedFileName ?? 'image.png')
-      )
-      if (!outputPreflight.success) {
-        throw outputPreflight.error
-      }
-
-      const providerName = params.provider ?? config.imageProvider
-      const credentialsResult = validateProviderCredentials(config, providerName)
-      if (!credentialsResult.success) {
-        throw credentialsResult.error
-      }
-      const provider = getImageProviderDefinition(providerName)
-
-      const { imageClient, structuredPromptGenerator } = this.getProviderClients(
-        config,
-        providerName,
-        provider
-      )
-
-      let inputImageData: string | undefined
-      let inputImageMimeType: string | undefined
-      if (params.inputImagePath) {
-        const inputImage = await readInputImage(params.inputImagePath)
-        inputImageData = inputImage.data.toString('base64')
-        inputImageMimeType = inputImage.mimeType
-      }
-
-      const imageOptions = {
-        ...(inputImageData && { inputImage: inputImageData }),
-        ...(inputImageMimeType && { inputImageMimeType }),
-        ...(params.aspectRatio && { aspectRatio: params.aspectRatio }),
-        ...(params.imageSize && { imageSize: params.imageSize }),
-        ...(params.useGoogleSearch !== undefined && {
-          useGoogleSearch: params.useGoogleSearch,
-        }),
-        ...(preferredOutputFormat && { preferredOutputFormat }),
-        ...(params.quality !== undefined && { quality: params.quality }),
-      } satisfies Omit<ImageApiParams, 'prompt'>
-
-      provider.validateImageOptions?.(imageOptions, config)
-      signal?.throwIfAborted()
-
-      let structuredPrompt = params.prompt
-      if (!config.skipPromptEnhancement && structuredPromptGenerator) {
-        const features: FeatureFlags = {}
-        if (params.maintainCharacterConsistency !== undefined) {
-          features.maintainCharacterConsistency = params.maintainCharacterConsistency
-        }
-        if (params.blendImages !== undefined) {
-          features.blendImages = params.blendImages
-        }
-        if (params.useWorldKnowledge !== undefined) {
-          features.useWorldKnowledge = params.useWorldKnowledge
-        }
-        const promptResult = await structuredPromptGenerator.generateStructuredPrompt(
-          params.prompt,
-          features,
-          inputImageData,
-          params.purpose,
-          inputImageMimeType,
-          signal
-        )
-        signal?.throwIfAborted()
-
-        if (promptResult.success) {
-          structuredPrompt = promptResult.data
-
-          this.logger.info('mcp-server', 'Structured prompt generated', {
-            originalLength: params.prompt.length,
-            structuredLength: structuredPrompt.length,
-          })
-        } else {
-          this.logger.warn('mcp-server', 'Using original prompt', {
-            error: promptResult.error.message,
-          })
-        }
-      } else if (config.skipPromptEnhancement) {
-        this.logger.info('mcp-server', 'Prompt enhancement skipped (SKIP_PROMPT_ENHANCEMENT=true)')
-      }
-
-      const generationResult = await imageClient.generateImage({
-        prompt: structuredPrompt,
-        ...imageOptions,
-        ...(signal && { signal }),
+    if (!promptResult.success) {
+      this.logger.warn('mcp-server', 'Using original prompt', {
+        error: promptResult.error.message,
       })
-      signal?.throwIfAborted()
+      return params.prompt
+    }
 
-      if (!generationResult.success) {
-        throw generationResult.error
-      }
+    this.logger.info('mcp-server', 'Structured prompt generated', {
+      originalLength: params.prompt.length,
+      structuredLength: promptResult.data.length,
+    })
+    return promptResult.data
+  }
 
-      const mimeType = generationResult.data.metadata.mimeType
-      const rawFileName = sanitizedFileName ?? generateFileName(mimeType)
-      const fileName = params.fileName
-        ? reconcileFileNameExtension(rawFileName, mimeType)
-        : rawFileName
-      const requestedExtension = path.extname(rawFileName)
-      if (
-        sanitizedFileName &&
-        fileName !== rawFileName &&
-        SUPPORTED_EXTENSIONS.includes(requestedExtension.toLowerCase())
-      ) {
-        this.logger.warn(
-          'mcp-server',
-          'Output filename extension corrected to match generated MIME type',
-          {
-            requestedExtension,
-            savedExtension: path.extname(fileName),
-            mimeType,
-          }
-        )
-      }
-      const outputPath = path.join(config.imageOutputDir, fileName)
-
-      const sanitizedPath = this.securityManager.sanitizeFilePath(outputPath)
-      if (!sanitizedPath.success) {
-        throw sanitizedPath.error
-      }
-
-      const saveResult = await saveImage(generationResult.data.imageData, sanitizedPath.data)
-      if (!saveResult.success) {
-        throw saveResult.error
-      }
-
-      return buildSuccessResponse(generationResult.data, saveResult.data)
-    }, 'image-generation')
+  private async handleGenerateImage(args: unknown, signal?: AbortSignal): Promise<McpToolResponse> {
+    const result = await ErrorHandler.wrapWithResultType(
+      () => this.generateImage(args, signal),
+      'image-generation'
+    )
 
     if (result.success) {
       return result.data
     }
 
     return buildErrorResponse(result.error)
+  }
+
+  /**
+   * One image generation, in order: validate, resolve config and provider,
+   * load any input image, enhance the prompt, generate, then save. Runs inside
+   * the caller's error boundary, so a failed step throws.
+   */
+  private async generateImage(args: unknown, signal?: AbortSignal): Promise<McpToolResponse> {
+    signal?.throwIfAborted()
+    const params = unwrapOrThrow(validateGenerateImageParams(args))
+
+    const sanitizedFileName = params.fileName
+      ? this.securityManager.sanitizeFilename(params.fileName)
+      : undefined
+    const preferredOutputFormat = resolvePreferredOutputFormat(sanitizedFileName)
+
+    const config = unwrapOrThrow(getConfig())
+
+    // Reject an unusable output path before anything is sent upstream.
+    unwrapOrThrow(
+      this.securityManager.sanitizeFilePath(
+        path.join(config.imageOutputDir, sanitizedFileName ?? 'image.png')
+      )
+    )
+
+    const providerName = params.provider ?? config.imageProvider
+    unwrapOrThrow(validateProviderCredentials(config, providerName))
+    const provider = getImageProviderDefinition(providerName)
+
+    const { imageClient, structuredPromptGenerator } = this.getProviderClients(
+      config,
+      providerName,
+      provider
+    )
+
+    let inputImageData: string | undefined
+    let inputImageMimeType: string | undefined
+    if (params.inputImagePath) {
+      const inputImage = await readInputImage(params.inputImagePath)
+      inputImageData = inputImage.data.toString('base64')
+      inputImageMimeType = inputImage.mimeType
+    }
+
+    const imageOptions = buildImageOptions(
+      params,
+      {
+        ...(inputImageData && { data: inputImageData }),
+        ...(inputImageMimeType && { mimeType: inputImageMimeType }),
+      },
+      preferredOutputFormat
+    )
+
+    provider.validateImageOptions?.(imageOptions, config)
+    signal?.throwIfAborted()
+
+    let structuredPrompt = params.prompt
+    if (!config.skipPromptEnhancement && structuredPromptGenerator) {
+      structuredPrompt = await this.enhancePrompt(structuredPromptGenerator, params, {
+        ...(inputImageData !== undefined && { inputImageData }),
+        ...(inputImageMimeType !== undefined && { inputImageMimeType }),
+        ...(signal !== undefined && { signal }),
+      })
+    } else if (config.skipPromptEnhancement) {
+      this.logger.info('mcp-server', 'Prompt enhancement skipped (SKIP_PROMPT_ENHANCEMENT=true)')
+    }
+
+    const generationResult = await imageClient.generateImage({
+      prompt: structuredPrompt,
+      ...imageOptions,
+      ...(signal && { signal }),
+    })
+    signal?.throwIfAborted()
+
+    const generatedImage = unwrapOrThrow(generationResult)
+    const mimeType = generatedImage.metadata.mimeType
+    const { fileName, requestedExtension, corrected } = resolveOutputFileName(
+      params.fileName,
+      sanitizedFileName,
+      mimeType
+    )
+    if (corrected) {
+      this.logger.warn(
+        'mcp-server',
+        'Output filename extension corrected to match generated MIME type',
+        {
+          requestedExtension,
+          savedExtension: path.extname(fileName),
+          mimeType,
+        }
+      )
+    }
+    const outputPath = path.join(config.imageOutputDir, fileName)
+
+    const sanitizedPath = unwrapOrThrow(this.securityManager.sanitizeFilePath(outputPath))
+    const savedPath = unwrapOrThrow(await saveImage(generatedImage.imageData, sanitizedPath))
+
+    return buildSuccessResponse(generatedImage, savedPath)
   }
 
   public initialize(): Server {
@@ -401,6 +466,6 @@ export class MCPServerImpl {
   }
 }
 
-export function createMCPServer(config: Partial<MCPServerConfig> = {}) {
+export function createMCPServer(config: Partial<MCPServerConfig> = {}): MCPServerImpl {
   return new MCPServerImpl(config)
 }

--- a/src/tests/helpers/inspect.ts
+++ b/src/tests/helpers/inspect.ts
@@ -1,0 +1,98 @@
+import type { ImageClient } from '../../api/imageClient.js'
+
+/**
+ * Runtime-checked readers for test assertions. Each throws a descriptive error
+ * instead of asserting over a value, so a malformed subject fails the test at
+ * the point of inspection rather than silently type-checking.
+ */
+
+/** Runtime check for a plain object, usable as a type guard in filters. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/** The value when it is a plain object, otherwise an empty object. */
+export function recordOrEmpty(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {}
+}
+
+export function expectRecord(value: unknown, what: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Expected ${what} to be an object, received ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+export function expectString(value: unknown, what: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Expected ${what} to be a string, received ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+export function expectArray(value: unknown, what: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`Expected ${what} to be an array, received ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+export function expectDefined<T>(value: T | undefined | null, what: string): T {
+  if (value === undefined || value === null) {
+    throw new Error(`Expected ${what} to be defined`)
+  }
+  return value
+}
+
+/** Parse JSON that is expected to describe an object. */
+export function parseJsonObject(text: string, what = 'JSON payload'): Record<string, unknown> {
+  return expectRecord(JSON.parse(text), what)
+}
+
+/**
+ * Text of a tool result's first content entry. Accepts `unknown` so both the
+ * server's own `McpToolResponse` and an MCP client's `CallToolResult` can be
+ * inspected through one runtime-checked reader.
+ */
+export function firstContentText(result: unknown): string {
+  const content = expectRecord(result, 'tool result')['content']
+  if (!Array.isArray(content)) {
+    throw new Error('Expected tool result content to be an array')
+  }
+  const first = expectRecord(expectDefined(content[0], 'first content entry'), 'content entry')
+  return expectString(first['text'], 'first content entry text')
+}
+
+/** The first content entry of a tool result, parsed as a JSON object. */
+export function parseToolPayload(result: unknown): Record<string, unknown> {
+  return parseJsonObject(firstContentText(result), 'tool response payload')
+}
+
+/** Read a nested property path, checking that each step is an object. */
+export function readPath(source: unknown, ...path: string[]): unknown {
+  let current: unknown = source
+  const walked: string[] = []
+  for (const key of path) {
+    current = expectRecord(current, walked.length === 0 ? 'payload' : walked.join('.'))[key]
+    walked.push(key)
+  }
+  return current
+}
+
+/** Build an Error carrying a Node-style `code`, without asserting over it. */
+export function errorWithCode(message: string, code: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+/**
+ * View an image client the way an untyped upstream caller reaches it. Provider
+ * clients guard against values their parameter types forbid, and this lets a
+ * test exercise those guards without asserting over the client's own contract.
+ */
+export interface UntypedImageClient {
+  generateImage(params: unknown): ReturnType<ImageClient['generateImage']>
+}
+
+export function asUntypedCaller(client: ImageClient): UntypedImageClient {
+  return client
+}

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -21,3 +21,15 @@ export function Err<E extends Error>(error: E): Result<never, E> {
     error,
   }
 }
+
+/**
+ * Return the value of a successful result, or throw its error. Lets a caller
+ * that already runs inside an error boundary read a sequence of fallible steps
+ * as ordinary statements.
+ */
+export function unwrapOrThrow<T, E extends Error>(result: Result<T, E>): T {
+  if (!result.success) {
+    throw result.error
+  }
+  return result.data
+}

--- a/src/utils/__tests__/config.test.ts
+++ b/src/utils/__tests__/config.test.ts
@@ -67,7 +67,7 @@ describe('config', () => {
         arkApiKey: '',
         imageOutputDir: './output',
         skipPromptEnhancement: false,
-        imageQuality: 'invalid' as any,
+        imageQuality: 'invalid',
       }
 
       const result = validateConfig(config)

--- a/src/utils/__tests__/mimeUtils.test.ts
+++ b/src/utils/__tests__/mimeUtils.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { expectString } from '../../tests/helpers/inspect'
 import {
   getExtensionFromMimeType,
   getMimeTypeForOutputFormat,
@@ -50,7 +51,10 @@ describe('mimeUtils', () => {
 
       expect(result).toBe('.png')
       expect(consoleErrorSpy).toHaveBeenCalled()
-      const logOutput = consoleErrorSpy.mock.calls[0]?.[0] as string
+      const logOutput = expectString(
+        consoleErrorSpy.mock.calls[0]?.[0],
+        'first console.error argument'
+      )
       expect(logOutput).toContain('warn')
       expect(logOutput).toContain('image/tiff')
     })

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -14,6 +14,23 @@ export interface Config {
   imageQuality: ImageQuality
 }
 
+/**
+ * Environment-sourced shape before enum validation. `validateConfig` narrows
+ * `imageProvider` and `imageQuality` to their union types.
+ */
+export interface UnvalidatedConfig extends Omit<Config, 'imageProvider' | 'imageQuality'> {
+  imageProvider: string
+  imageQuality: string
+}
+
+function isImageProvider(value: string): value is ImageProvider {
+  return IMAGE_PROVIDER_VALUES.some((candidate) => candidate === value)
+}
+
+function isImageQuality(value: string): value is ImageQuality {
+  return IMAGE_QUALITY_VALUES.some((candidate) => candidate === value)
+}
+
 const DEFAULT_CONFIG = {
   imageProvider: 'gemini',
   imageOutputDir: './output',
@@ -72,8 +89,10 @@ export function validateProviderCredentials(
   return Ok(config)
 }
 
-export function validateConfig(config: Config): Result<Config, ConfigError> {
-  if (!IMAGE_PROVIDER_VALUES.includes(config.imageProvider)) {
+export function validateConfig(config: UnvalidatedConfig): Result<Config, ConfigError> {
+  const { imageProvider, imageQuality } = config
+
+  if (!isImageProvider(imageProvider)) {
     return Err(
       new ConfigError(
         `Invalid IMAGE_PROVIDER value: "${config.imageProvider}". Valid options: ${IMAGE_PROVIDER_VALUES.join(', ')}`,
@@ -91,7 +110,7 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  if (!IMAGE_QUALITY_VALUES.includes(config.imageQuality)) {
+  if (!isImageQuality(imageQuality)) {
     return Err(
       new ConfigError(
         `Invalid IMAGE_QUALITY value: "${config.imageQuality}". Valid options: ${IMAGE_QUALITY_VALUES.join(', ')}`,
@@ -100,18 +119,18 @@ export function validateConfig(config: Config): Result<Config, ConfigError> {
     )
   }
 
-  return Ok(config)
+  return Ok({ ...config, imageProvider, imageQuality })
 }
 
 export function getConfig(): Result<Config, ConfigError> {
-  const config: Config = {
-    imageProvider: (readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider) as ImageProvider,
+  const config: UnvalidatedConfig = {
+    imageProvider: readEnv('IMAGE_PROVIDER') || DEFAULT_CONFIG.imageProvider,
     geminiApiKey: readEnv('GEMINI_API_KEY') || '',
     openaiApiKey: readEnv('OPENAI_API_KEY') || '',
     arkApiKey: readEnv('ARK_API_KEY') || '',
     imageOutputDir: readEnv('IMAGE_OUTPUT_DIR') || DEFAULT_CONFIG.imageOutputDir,
     skipPromptEnhancement: readEnv('SKIP_PROMPT_ENHANCEMENT') === 'true',
-    imageQuality: (readEnv('IMAGE_QUALITY') || 'fast') as ImageQuality,
+    imageQuality: readEnv('IMAGE_QUALITY') || 'fast',
   }
 
   return validateConfig(config)

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -9,14 +9,19 @@ import { SUPPORTED_EXTENSIONS } from './mimeUtils.js'
  * in `context` and must be projected through a sanitizer (see
  * `responseBuilder.buildPublicDetails`) before being placed on the wire.
  */
+/** Narrow an unknown thrown value to an Error without asserting over it. */
+export function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value))
+}
+
 export abstract class BaseError extends Error {
   abstract readonly code: string
   abstract readonly suggestion: string
   readonly timestamp: string
   readonly context: Record<string, unknown> | undefined
 
-  constructor(message: string, context?: Record<string, unknown>) {
-    super(message)
+  constructor(message: string, context?: Record<string, unknown>, options?: ErrorOptions) {
+    super(message, options)
     this.name = this.constructor.name
     this.timestamp = new Date().toISOString()
     this.context = context
@@ -74,6 +79,8 @@ export class FileOperationError extends BaseError {
 
 export class GeminiAPIError extends BaseError {
   readonly code = 'GEMINI_API_ERROR'
+  /** Set via `Object.defineProperty` in the constructor; declared for the type only. */
+  declare readonly statusCode: number | undefined
   private customSuggestion?: string
 
   constructor(
@@ -137,6 +144,8 @@ export class GeminiAPIError extends BaseError {
 
 export class ImageAPIError extends BaseError {
   readonly code = 'IMAGE_API_ERROR'
+  /** Set via `Object.defineProperty` in the constructor; declared for the type only. */
+  declare readonly statusCode: number | undefined
   private customSuggestion: string | undefined
 
   constructor(
@@ -265,6 +274,10 @@ export class ConfigError extends BaseError {
 
 export class SecurityError extends BaseError {
   readonly code = 'SECURITY_ERROR'
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, undefined, options)
+  }
 
   get suggestion(): string {
     const message = this.message.toLowerCase()

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -38,6 +38,10 @@ const FILTER_PATTERNS = [
  * error handlers) can sanitize before placing values into caller-visible
  * fields without instantiating a Logger.
  */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 export function sanitizeText(input: string): string {
   let sanitized = input
 
@@ -77,14 +81,16 @@ export class Logger {
   ]
 
   private currentTraceId?: string
-  private currentSessionId?: string
+  private readonly currentSessionId: string
 
   constructor() {
-    this.currentSessionId = this.generateId()
+    this.currentSessionId = Logger.generateId()
   }
 
   debug(context: string, message: string, metadata?: Record<string, unknown>): void {
-    if (process.env['NODE_ENV'] === 'production') return
+    if (process.env['NODE_ENV'] === 'production') {
+      return
+    }
     this.writeLog('debug', context, message, metadata)
   }
 
@@ -143,8 +149,8 @@ export class Logger {
         sanitized[key] = '[REDACTED]'
       } else if (typeof value === 'string') {
         sanitized[key] = this.sanitizeString(value)
-      } else if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
-        sanitized[key] = this.sanitizeMetadata(value as Record<string, unknown>)
+      } else if (isPlainRecord(value)) {
+        sanitized[key] = this.sanitizeMetadata(value)
       } else {
         sanitized[key] = value
       }
@@ -157,18 +163,18 @@ export class Logger {
     return this.keyBasedSensitivePatterns.some((pattern) => pattern.test(key))
   }
 
-  private generateId(): string {
+  private static generateId(): string {
     return crypto.randomUUID().substring(0, 8)
   }
 
   private getCurrentTraceId(): string {
     if (!this.currentTraceId) {
-      this.currentTraceId = this.generateId()
+      this.currentTraceId = Logger.generateId()
     }
     return this.currentTraceId
   }
 
   private getCurrentSessionId(): string {
-    return this.currentSessionId!
+    return this.currentSessionId
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
     // Basic configuration
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "lib": ["ES2020"],
+    "lib": ["ES2022"],
     "types": ["node"],
 
     // Output configuration


### PR DESCRIPTION
## Summary

Enables a stricter Biome ruleset and fixes all **241** resulting violations. No rule was disabled, no file excluded, and no `biome-ignore` was added.

`pnpm run check:all` (biome check → circular deps → knip → tsc build → vitest) passes. Tests: **339 passing**.

### Rules enabled

| Group | Rules |
|---|---|
| `complexity` | `noVoid`, `useMaxParams` (max 4), `noExcessiveCognitiveComplexity` (max 15) |
| `style` | `noNonNullAssertion`, `useBlockStatements`, `noNestedTernary`, `useErrorCause`, `useThrowOnlyError` |
| `suspicious` | `noExplicitAny`, `noUnnecessaryConditions`, `noShadow`, `noEvolvingTypes`, `noImplicitAnyLet`, `noTsIgnore`, `useErrorMessage` |
| `correctness` | `noUndeclaredDependencies` |
| `nursery` | `noFloatingPromises`, `noMisusedPromises`, `useAwaitThenable`, `useExplicitReturnType`, `useExhaustiveSwitchCases`, `noUnsafeTypeAssertion`, `noBaseToString`, `noExcessiveNestedCallbacks` |

The per-test-file `noExplicitAny: off` override was removed; test code is held to the same rules as production code.

## Notable changes

### Gemini image response interpretation extracted (`src/api/geminiImageResponse.ts`)

`generateImage` mixed issuing the SDK request with mapping an untrusted `unknown` payload onto eight distinct `GeminiAPIError` classifications, and carried 17 type assertions applied *before* validation. Interpretation now lives behind one boundary that takes `unknown` and returns either image bytes or a classified error, with all narrowing done by runtime guards. Error classification and the disclosure limits on error context (depth, array length, redacted credential keys, elided base64) are unchanged. `geminiClient.ts` drops from 447 to ~200 lines.

### Dead SDK compatibility branches removed (`src/api/geminiTextClient.ts`)

The `response.response.text()` / `response.response.candidates[…]` fallbacks were verified against the actual dependency before removal:

- `node_modules/@google/genai/dist/genai.d.ts:10952` — `generateContent: (params) => Promise<GenerateContentResponse>`
- `GenerateContentResponse` has no `response` property; `text` is `string | undefined`
- `@google/generative-ai` (the older SDK that wrapped responses in `{ response }`) is not a dependency
- The wrapper shape appeared nowhere outside this repository's own test mocks

The local interface now matches the real SDK contract, which also removed its `as unknown as` cast. The mock was updated to the real shape.

### Input validation rebuilt without a final cast (`src/business/inputValidator.ts`)

Only fields with *identical* validation are table-driven (nine optional strings, four optional booleans). The four enum fields stay written out individually, because their messages differ per field and generalizing them would mean maintaining a small validation language. Validation order, messages, and omitted-value handling are preserved. The trailing `input as GenerateImageParams` is gone; the validated object is assembled from checked values.

### Named options for `generateStructuredPrompt`

Six positional parameters (four of them optional, plus an `AbortSignal`) became `(userPrompt, options)`. Interface, implementation, caller, and tests were updated together; defaults and omitted-value behaviour are unchanged. `StructuredPromptGenerator` is not exported from the package root and carries no documented external compatibility promise, so no compatibility layer was added.

### Complexity reductions

Extractions were limited to steps whose meaning is complete from their inputs and outputs. Cancellation checks, path validation, outbound requests, and save ordering remain readable in sequence at the call site; no per-stage classes and no shared context object were introduced.

- `handleGenerateImage` (46 → under 15): extracted `buildImageOptions`, `buildFeatureFlags`, `resolveOutputFileName`, and `enhancePrompt`; lifted the request body out of the `wrapWithResultType` closure that added a nesting level to every construct; replaced seven `if (!r.success) throw r.error` blocks with `unwrapOrThrow`.
- `sanitize` in the response sanitizer: extracted `redactEntry(key, value)`, which takes no recursion or cycle-detection state — disclosure policy separated from traversal. Depth limit, cycle detection, array cap, secret keys, and long-string elision all preserved.
- The two large integration-test blocks were decomposed into named assertion helpers (`assertEnhancementRequest`, `assertPublicErrorShape`, `assertNoSensitiveDisclosure`) and hoisted row tables.

### Test assertions

Added `src/tests/helpers/inspect.ts` with runtime-checked readers (`expectRecord`, `expectString`, `parseJsonObject`, `readPath`, `errorWithCode`, `asUntypedCaller`). Test-side `as` and `!` were replaced by checks that fail at the point of inspection instead of silently type-checking. Mock function narrowing uses `vi.isMockFunction()` as a real type guard.

## Build configuration

`tsconfig.json` `target`/`lib` raised **ES2020 → ES2022**. `useErrorCause` requires `Error.cause`, whose `ErrorOptions` type does not exist under `lib: ES2020`. `engines` already requires `node >=22`. ES2022 makes `useDefineForClassFields` default to true; the emitted error classes were inspected and the native class fields do not conflict with the constructor's `Object.defineProperty` calls.

## User-visible impact

The `generate_image` input schema is **byte-identical**. Success responses, error `code`/`suggestion`/allowed `details` keys, and configuration handling are unchanged.

Three behaviour deltas exist, all confined to malformed upstream responses:

1. When `candidates` is present but not an array, the message changes from `No valid content in response` to `No image generated: Content may have been filtered`.
2. When `safetyRatings` is truthy but not an array, the code previously threw a `TypeError` that surfaced through a different error path; it now omits `safetyRatings` from the `IMAGE_SAFETY` error.
3. The `response` wrapper is now unwrapped only when it is an object rather than any truthy value, which also fixes a latent case where a string `response` was treated as a payload.

The patch version is bumped in `package.json` and `server.json` because the published `dist/` output changes with the new compile target.

## Test plan

- `pnpm run check:all` — biome check, circular dependency check, knip, `tsc` build, and 339 vitest tests all pass
- One test case was intentionally removed: the `[undefined, …]` row in `responseBuilder.test.ts` constructed a state the type system forbids (`ImageGenerationMetadata.mimeType` is a required `string`) and required a cast to express. The `['', …]` row exercises the same branch. `resolveMimeType` was correspondingly narrowed to take `string`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
