### PR TITLE
chore: revert version bump to 0.13.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.13.3",
+  "version": "0.13.2",
   "packageManager": "pnpm@11.24.0",
   "description": "MCP server for AI image generation",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.13.3",
+  "version": "0.13.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.13.3",
+      "version": "0.13.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Reverts the `0.13.2` → `0.13.3` bump introduced in #132.

That change tightened the Biome ruleset and resolved every resulting violation. It has no user-facing effect: the `generate_image` input schema is byte-identical, and success and error responses are unchanged. A patch release therefore has nothing to deliver, and publishing one would only add a version that is indistinguishable from `0.13.2` for anyone consuming this server.

The bump was originally justified on the grounds that the compiled `dist/` output changes with the new ES2022 target. That is a constraint on *how* to publish, not a reason *to* publish.

`0.13.3` was never published to npm, so the version number is free to reclaim for a change that actually reaches users.

## Test plan

- `pnpm run check:all` passes (biome check, circular dependency check, knip, `tsc` build, 339 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
