### PR TITLE
Add GPT Image 2.5 support and release v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Changing the provider changes both prompt enhancement and image generation. The 
 IMAGE_QUALITY=balanced
 ```
 
-A request-level `quality` option takes precedence. Each provider maps the three values to its own image settings.
+Use `fast` to try ideas quickly, `balanced` for everyday use, and `quality` for complex scenes or images where small details matter. Higher settings can take longer and cost more; results vary by provider.
+
+All three providers support these presets for generation and editing. You can override the default with the `quality` option on each request.
 
 ### Environment variables
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-image",
   "mcpName": "io.github.shinpr/mcp-image",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "packageManager": "pnpm@11.24.0",
   "description": "MCP server for AI image generation",
   "type": "module",
@@ -20,7 +20,7 @@
     "gemini",
     "google-ai",
     "openai",
-    "gpt-image-2",
+    "gpt-image-2.5",
     "nano-banana",
     "claude-code",
     "cursor",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/shinpr/mcp-image",
     "source": "github"
   },
-  "version": "0.13.2",
+  "version": "0.14.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "mcp-image",
-      "version": "0.13.2",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },
@@ -35,7 +35,7 @@
         },
         {
           "name": "OPENAI_API_KEY",
-          "description": "OpenAI API key for image generation when IMAGE_PROVIDER=openai. Requires OpenAI organization verification to access gpt-image-2 (https://platform.openai.com/settings/organization/general)",
+          "description": "OpenAI API key for image generation when IMAGE_PROVIDER=openai. Requires OpenAI organization verification to access GPT Image 2.5 (https://platform.openai.com/settings/organization/general)",
           "isRequired": false,
           "format": "string",
           "isSecret": true
@@ -94,7 +94,7 @@
     "prompt-enhancement",
     "gemini",
     "openai",
-    "gpt-image-2",
+    "gpt-image-2.5",
     "byteplus",
     "modelark",
     "seedream",

--- a/src/api/__tests__/openaiImageClient.test.ts
+++ b/src/api/__tests__/openaiImageClient.test.ts
@@ -64,7 +64,7 @@ describe('openaiImageClient', () => {
   })
 
   describe('OpenAIImageClient.generateImage', () => {
-    it('should generate image successfully with gpt-image-2', async () => {
+    it('should generate image successfully with gpt-image-2.5-flare', async () => {
       mockGenerate.mockResolvedValue({
         data: [
           {
@@ -85,7 +85,7 @@ describe('openaiImageClient', () => {
 
       expect(result.success).toBe(true)
       expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual({
-        model: 'gpt-image-2',
+        model: 'gpt-image-2.5-flare',
         prompt: 'Generate a beautiful landscape',
         n: 1,
         output_format: 'png',
@@ -94,7 +94,7 @@ describe('openaiImageClient', () => {
       })
       if (result.success) {
         expect(result.data.imageData).toEqual(PNG_BYTES)
-        expect(result.data.metadata.model).toBe('gpt-image-2')
+        expect(result.data.metadata.model).toBe('gpt-image-2.5-flare')
         expect(result.data.metadata.provider).toBe('openai')
         expect(result.data.metadata.prompt).toBe('Generate a beautiful landscape')
         expect(result.data.metadata.mimeType).toBe('image/png')
@@ -128,7 +128,7 @@ describe('openaiImageClient', () => {
         type: 'image/png',
       })
       expect(expectDefined(mockEdit.mock.calls[0], 'images.edit call')[0]).toEqual({
-        model: 'gpt-image-2',
+        model: 'gpt-image-2.5-flare',
         prompt: 'Make this image warmer',
         image: { name: 'input.png', type: 'image/png' },
         n: 1,
@@ -138,50 +138,65 @@ describe('openaiImageClient', () => {
       })
     })
 
-    it('should map balanced quality to medium OpenAI quality', async () => {
-      mockGenerate.mockResolvedValue({
-        data: [{ b64_json: PNG_BYTES.toString('base64') }],
-      })
+    describe.each([
+      ['fast', 'gpt-image-2.5-flare', 'low'],
+      ['balanced', 'gpt-image-2.5-flare', 'high'],
+      ['quality', 'gpt-image-2.5-sunburst', 'max'],
+    ] as const)('%s preset', (preset, model, quality) => {
+      it.each([
+        ['generate', mockGenerate, mockEdit, undefined],
+        ['edit', mockEdit, mockGenerate, PNG_BYTES.toString('base64')],
+      ] as const)(
+        'routes %s requests and reports the selected model',
+        async (_operation, mock, unusedMock, inputImage) => {
+          mock.mockResolvedValue({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })
+          const client = createOpenAIImageClient({ ...testConfig, imageQuality: preset })
+          if (!client.success) {
+            throw client.error
+          }
 
-      const clientResult = createOpenAIImageClient(testConfig)
-      expect(clientResult.success).toBe(true)
-      if (!clientResult.success) {
-        return
-      }
+          const result = await client.data.generateImage({
+            prompt: 'Generate an image',
+            ...(inputImage && { inputImage }),
+          })
 
-      await clientResult.data.generateImage({
-        prompt: 'Generate an image',
-        quality: 'balanced',
-      })
-
-      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
-        expect.objectContaining({
-          quality: 'medium',
-        })
+          expect(result.success).toBe(true)
+          expect(mock).toHaveBeenCalledWith(
+            expect.objectContaining({ model, quality }),
+            expect.anything()
+          )
+          if (result.success) {
+            expect(result.data.metadata.model).toBe(model)
+          }
+          expect(unusedMock).not.toHaveBeenCalled()
+        }
       )
-    })
 
-    it('should map quality preset to high OpenAI quality', async () => {
-      mockGenerate.mockResolvedValue({
-        data: [{ b64_json: PNG_BYTES.toString('base64') }],
+      it('lets the request override the configured preset without changing the next request', async () => {
+        mockGenerate.mockResolvedValue({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })
+        const client = createOpenAIImageClient({ ...testConfig, imageQuality: 'quality' })
+        if (!client.success) {
+          throw client.error
+        }
+
+        const result = await client.data.generateImage({ prompt: 'Override', quality: preset })
+        expect(mockGenerate).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({ model, quality }),
+          expect.anything()
+        )
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.data.metadata.model).toBe(model)
+        }
+
+        await client.data.generateImage({ prompt: 'Default again' })
+        expect(mockGenerate).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ model: 'gpt-image-2.5-sunburst', quality: 'max' }),
+          expect.anything()
+        )
       })
-
-      const clientResult = createOpenAIImageClient(testConfig)
-      expect(clientResult.success).toBe(true)
-      if (!clientResult.success) {
-        return
-      }
-
-      await clientResult.data.generateImage({
-        prompt: 'Generate an image',
-        quality: 'quality',
-      })
-
-      expect(expectDefined(mockGenerate.mock.calls[0], 'images.generate call')[0]).toEqual(
-        expect.objectContaining({
-          quality: 'high',
-        })
-      )
     })
 
     it('should preserve a 16:9 aspect ratio at the default size', async () => {

--- a/src/api/openaiImageClient.ts
+++ b/src/api/openaiImageClient.ts
@@ -20,32 +20,37 @@ import { extractStatusCode, isNetworkError } from './errorClassification.js'
 import type { GeneratedImageResult, ImageApiParams, ImageClient } from './imageClient.js'
 
 type OpenAIImageSize = `${number}x${number}`
-type OpenAIImageQuality = 'low' | 'medium' | 'high'
-// The OpenAI guide documents flexible gpt-image-2 resolutions, while SDK types still
-// enumerate the older fixed GPT image sizes. The widened `size` is confined to
-// this file through `OpenAIImagesApi`, which the SDK's images resource satisfies.
-type OpenAIImageGenerateRequest = Omit<ImageGenerateParamsNonStreaming, 'size'> & {
+type OpenAIImageQuality = 'low' | 'high' | 'max'
+// GPT Image 2.5 supports flexible resolutions and max quality, while SDK types
+// still enumerate older sizes and quality settings. Keep this compatibility
+// boundary local: OpenAIImagesApi accepts SDK requests plus the documented 2.5 variant.
+type OpenAIImageGenerateRequest = Omit<ImageGenerateParamsNonStreaming, 'size' | 'quality'> & {
   size: OpenAIImageSize
+  quality: OpenAIImageQuality
 }
-type OpenAIImageEditRequest = Omit<ImageEditParamsNonStreaming, 'size'> & {
+type OpenAIImageEditRequest = Omit<ImageEditParamsNonStreaming, 'size' | 'quality'> & {
   size: OpenAIImageSize
+  quality: OpenAIImageQuality
 }
 
 interface OpenAIImagesApi {
   generate(
-    body: OpenAIImageGenerateRequest,
+    body: ImageGenerateParamsNonStreaming | OpenAIImageGenerateRequest,
     options?: { signal?: AbortSignal }
   ): Promise<ImagesResponse>
-  edit(body: OpenAIImageEditRequest, options?: { signal?: AbortSignal }): Promise<ImagesResponse>
+  edit(
+    body: ImageEditParamsNonStreaming | OpenAIImageEditRequest,
+    options?: { signal?: AbortSignal }
+  ): Promise<ImagesResponse>
 }
 type ImageEditApiParams = ImageApiParams & { inputImage: string }
 
 function mapQuality(quality: ImageQuality): OpenAIImageQuality {
   switch (quality) {
     case 'quality':
-      return 'high'
+      return 'max'
     case 'balanced':
-      return 'medium'
+      return 'high'
     case 'fast':
       return 'low'
   }
@@ -65,7 +70,7 @@ function mapSize(params: ImageApiParams): OpenAIImageSize {
   const [width = 1, height = 1] = (params.aspectRatio ?? '1:1').split(':').map(Number)
   const ratio = Math.max(width, height) / Math.min(width, height)
   const requestedEdge = requestedLongEdge(params.imageSize, ratio)
-  // GPT Image 2: 16px increments, at most 3840px per edge and 8,294,400 pixels.
+  // GPT Image 2.5: 16px increments, at most 3840px per edge and 8,294,400 pixels.
   // Flooring keeps the pixel cap intact even for near-square 4K requests.
   const longEdge = Math.floor(Math.min(requestedEdge, Math.sqrt(8_294_400 * ratio)) / 16) * 16
   const shortEdge = Math.floor(longEdge / ratio / 16) * 16
@@ -83,7 +88,10 @@ function mimeTypeToExtension(mimeType: string): string {
   }
 }
 
-const OPENAI_IMAGE_MODEL = 'gpt-image-2'
+const OPENAI_IMAGE_MODELS = {
+  FLARE: 'gpt-image-2.5-flare',
+  SUNBURST: 'gpt-image-2.5-sunburst',
+} as const
 
 function hasInputImage(params: ImageApiParams): params is ImageEditApiParams {
   return typeof params.inputImage === 'string' && params.inputImage.length > 0
@@ -120,8 +128,6 @@ export function validateOpenAIOptions(
 }
 
 class OpenAIImageClientImpl implements ImageClient {
-  private readonly modelName = OPENAI_IMAGE_MODEL
-
   constructor(
     private readonly client: OpenAI,
     private readonly defaultQuality: ImageQuality = 'fast'
@@ -136,20 +142,34 @@ class OpenAIImageClientImpl implements ImageClient {
         return optionsResult
       }
 
-      const quality = mapQuality(params.quality ?? this.defaultQuality)
+      const effectiveQuality = params.quality ?? this.defaultQuality
+      const modelName =
+        effectiveQuality === 'quality' ? OPENAI_IMAGE_MODELS.SUNBURST : OPENAI_IMAGE_MODELS.FLARE
+      const quality = mapQuality(effectiveQuality)
       const size = mapSize(params)
       const outputFormat: ImageOutputFormat = params.preferredOutputFormat ?? 'png'
 
+      const request: OpenAIImageGenerateRequest = {
+        model: modelName,
+        prompt: params.prompt,
+        n: 1,
+        output_format: outputFormat,
+        quality,
+        size,
+      }
+      const images: OpenAIImagesApi = this.client.images
       const response = hasInputImage(params)
-        ? await this.editImage(params, quality, size, outputFormat)
-        : await this.createImage(params, quality, size, outputFormat)
+        ? await this.editImage(params, request)
+        : await images.generate(request, {
+            ...(params.signal && { signal: params.signal }),
+          })
 
       const firstImage = response.data?.[0]
       if (!firstImage?.b64_json) {
         return Err(
           new ImageAPIError('No image data returned from OpenAI image API', {
             provider: 'openai',
-            model: this.modelName,
+            model: modelName,
             stage: 'image_extraction',
             suggestion:
               'Retry the request or verify that the selected model returns base64 image data',
@@ -163,7 +183,7 @@ class OpenAIImageClientImpl implements ImageClient {
         return Err(
           new ImageAPIError('OpenAI image response did not match the requested output format', {
             provider: 'openai',
-            model: this.modelName,
+            model: modelName,
             stage: 'image_response',
             suggestion: 'Retry the request; the provider returned unexpected image bytes',
           })
@@ -173,7 +193,7 @@ class OpenAIImageClientImpl implements ImageClient {
       return Ok({
         imageData,
         metadata: {
-          model: this.modelName,
+          model: modelName,
           provider: 'openai',
           prompt: params.prompt,
           mimeType,
@@ -187,32 +207,9 @@ class OpenAIImageClientImpl implements ImageClient {
     }
   }
 
-  private async createImage(
-    params: ImageApiParams,
-    quality: OpenAIImageQuality,
-    size: OpenAIImageSize,
-    outputFormat: ImageOutputFormat
-  ): Promise<ImagesResponse> {
-    const request = {
-      model: this.modelName,
-      prompt: params.prompt,
-      n: 1,
-      output_format: outputFormat,
-      quality,
-      size,
-    }
-
-    const images: OpenAIImagesApi = this.client.images
-    return await images.generate(request, {
-      ...(params.signal && { signal: params.signal }),
-    })
-  }
-
   private async editImage(
     params: ImageEditApiParams,
-    quality: OpenAIImageQuality,
-    size: OpenAIImageSize,
-    outputFormat: ImageOutputFormat
+    request: OpenAIImageGenerateRequest
   ): Promise<ImagesResponse> {
     const mimeType = normalizeMimeType(params.inputImageMimeType ?? DEFAULT_MIME_TYPE)
     const inputFile = await toFile(
@@ -221,20 +218,13 @@ class OpenAIImageClientImpl implements ImageClient {
       { type: mimeType }
     )
 
-    const request = {
-      model: this.modelName,
-      prompt: params.prompt,
-      image: inputFile,
-      n: 1,
-      output_format: outputFormat,
-      quality,
-      size,
-    }
-
     const images: OpenAIImagesApi = this.client.images
-    return await images.edit(request, {
-      ...(params.signal && { signal: params.signal }),
-    })
+    return await images.edit(
+      { ...request, image: inputFile },
+      {
+        ...(params.signal && { signal: params.signal }),
+      }
+    )
   }
 
   private handleError(error: unknown, prompt: string): Result<never, ImageAPIError | NetworkError> {
@@ -276,7 +266,7 @@ class OpenAIImageClientImpl implements ImageClient {
     }
 
     if (lowerMessage.includes('model') || lowerMessage.includes('not found')) {
-      return 'Verify your OpenAI organization has been verified to use gpt-image-2 (https://platform.openai.com/settings/organization/general)'
+      return 'Verify your OpenAI organization has access to GPT Image 2.5 and has completed verification (https://platform.openai.com/settings/organization/general)'
     }
 
     if (lowerMessage.includes('forbidden') || lowerMessage.includes('permission')) {


### PR DESCRIPTION
OpenAI image generation and editing now use GPT Image 2.5. The existing presets select Flare for quick drafts and everyday work, and Sunburst at max quality for complex scenes and fine detail.

| Preset | Model | Quality |
| --- | --- | --- |
| `fast` | GPT Image 2.5 Flare | `low` |
| `balanced` | GPT Image 2.5 Flare | `high` |
| `quality` | GPT Image 2.5 Sunburst | `max` |

Request overrides and returned model metadata follow the selected preset. The README explains the presets in terms of use cases shared by all three providers. Package and MCP registry versions are updated to 0.14.0.

Validation: `pnpm run check:all` passed (346 tests), and all release version fields match. Live generation comparisons covered text-heavy layouts, complex compositions, and a dense photorealistic scene. Sunburst max was selected after comparing fine detail against xhigh and Gemini Pro Image; it takes longer to generate.
